### PR TITLE
Refactor AzNavRail to address code review feedback

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,4 +43,6 @@ dependencies {
     implementation(libs.material3)
     implementation(libs.androidx.compose.foundation.layout)
     implementation(libs.androidx.compose.animation.core)
+    implementation(libs.androidx.material.icons.extended)
+    implementation(libs.coil.compose)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 composeBom = "2024.04.01"
 coreKtx = "1.16.0"
 material3 = "1.4.0-beta01"
+coil = "2.6.0"
 
 # Plugins
 kotlinAndroid = "2.2.0"
@@ -21,6 +22,8 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
 androidx-compose-animation-core = { group = "androidx.compose.animation", name = "animation-core" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 
 
 [plugins]

--- a/src/main/java/com/hereliesaz/aznavrail/model/NavRailModels.kt
+++ b/src/main/java/com/hereliesaz/aznavrail/model/NavRailModels.kt
@@ -6,11 +6,9 @@ import androidx.compose.runtime.Composable
  * Represents the header of the navigation rail.
  *
  * @param content A composable lambda for the header content, typically an icon or logo.
- * @param onClick A lambda to be executed when the header is clicked.
  */
 data class NavRailHeader(
-    val content: @Composable () -> Unit,
-    val onClick: () -> Unit
+    val content: @Composable () -> Unit
 )
 
 /**
@@ -43,7 +41,13 @@ data class NavRailCycleButton(
     val options: List<String>,
     val initialOption: String,
     val onStateChange: (String) -> Unit
-) : NavRailItem
+) : NavRailItem {
+    init {
+        require(initialOption in options) {
+            "initialOption ('$initialOption') must be one of the provided options: $options"
+        }
+    }
+}
 
 
 /**

--- a/src/main/java/com/hereliesaz/aznavrail/ui/AzNavRail.kt
+++ b/src/main/java/com/hereliesaz/aznavrail/ui/AzNavRail.kt
@@ -118,11 +118,11 @@ fun AzNavRail(
                         Box(modifier = Modifier.size(headerIconSize)) {
                             if (useAppIconAsHeader) {
                                 val context = LocalContext.current
-                                val iconDrawable = try {
-                                    context.packageManager.getApplicationIcon(context.packageName)
-                                } catch (e: Exception) {
-                                    null
-                                }
+val iconDrawable = try {
+    context.packageManager.getApplicationIcon(context.packageName)
+} catch (e: android.content.pm.PackageManager.NameNotFoundException) {
+    null
+}
 
                                 if (iconDrawable != null) {
                                     Image(

--- a/src/main/java/com/hereliesaz/aznavrail/ui/AzNavRail.kt
+++ b/src/main/java/com/hereliesaz/aznavrail/ui/AzNavRail.kt
@@ -1,52 +1,61 @@
 package com.hereliesaz.aznavrail.ui
 
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
 import com.hereliesaz.aznavrail.model.NavRailActionButton
 import com.hereliesaz.aznavrail.model.NavRailCycleButton
 import com.hereliesaz.aznavrail.model.NavRailHeader
 import com.hereliesaz.aznavrail.model.NavRailItem
 import com.hereliesaz.aznavrail.model.NavRailMenuSection
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 /**
  * An expressive and highly configurable navigation rail component for Jetpack Compose.
  *
  * This component provides a vertical navigation rail that can be expanded to a full menu drawer.
  * It includes built-in support for simple action buttons, stateful cycle buttons with cooldown
- * logic, a configurable footer, and swipe-to-collapse gestures.
+ * logic, and a configurable footer. It uses [ModalNavigationDrawer] to provide a material-compliant
+ * drawer experience.
  *
- * @param header The configuration for the header of the navigation rail, containing the content
- * (e.g., an icon) and a click handler to toggle the expanded state. See [NavRailHeader].
+ * @param header The configuration for the header of the navigation rail. See [NavRailHeader].
+ * If `useAppIconAsHeader` is true, this is ignored.
  * @param buttons The list of items to display in the collapsed state of the rail. This can be a
  * mix of [NavRailActionButton] and [NavRailCycleButton] items. See [NavRailItem].
  * @param menuSections The list of sections and their items to display in the expanded menu view.
  * See [NavRailMenuSection].
  * @param isExpanded Whether the navigation rail is currently in its expanded (menu) state.
+ * @param onExpandedChange A callback invoked when the rail's expansion state should change.
  * @param modifier The modifier to be applied to the navigation rail container.
+ * @param useAppIconAsHeader If true, the rail will attempt to display the app's launcher icon
+ * in the header. If it fails, it will display a fallback menu icon.
  * @param headerIconSize The size of the header icon. Defaults to 80.dp.
  * @param onAboutClicked A lambda to be executed when the 'About' button in the footer is clicked.
  * If null, the button is not shown.
@@ -55,6 +64,7 @@ import kotlinx.coroutines.launch
  * @param creditText The text for the credit/signature line in the footer. Defaults to "@HereLiesAz".
  * If null, the item is not shown.
  * @param onCreditClicked A lambda to be executed when the credit line is clicked.
+ * @param content The main screen content to be displayed next to the navigation rail.
  */
 @Composable
 fun AzNavRail(
@@ -62,104 +72,124 @@ fun AzNavRail(
     buttons: List<NavRailItem>,
     menuSections: List<NavRailMenuSection>,
     isExpanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    useAppIconAsHeader: Boolean = false,
     headerIconSize: Dp = 80.dp,
     onAboutClicked: (() -> Unit)? = null,
     onFeedbackClicked: (() -> Unit)? = null,
     creditText: String? = "@HereLiesAz",
-    onCreditClicked: (() -> Unit)? = null
-
+    onCreditClicked: (() -> Unit)? = null,
+    content: @Composable () -> Unit
 ) {
-    val railWidth by animateDpAsState(
-        targetValue = if (isExpanded) 260.dp else 80.dp,
-        label = "railWidth"
-    )
+    val drawerState = rememberDrawerState(if (isExpanded) DrawerValue.Open else DrawerValue.Closed)
 
-    NavigationRail(
-        modifier = modifier
-            .width(railWidth)
-            .pointerInput(isExpanded) {
-                if (isExpanded) {
-                    detectDragGestures { change, dragAmount ->
-                        change.consume()
-                        val (x, _) = dragAmount
-                        if (x < -20) { // Threshold for a left swipe
-                            header.onClick()
-                        }
-                    }
-                }
-            },
-        containerColor = Color.Transparent,
+    LaunchedEffect(isExpanded) {
+        if (isExpanded) drawerState.open() else drawerState.close()
+    }
 
-        header = {
-            IconButton(
-                onClick = header.onClick,
-                modifier = Modifier.padding(top = 16.dp, bottom = 16.dp)
-            ) {
-                Box(modifier = Modifier.size(headerIconSize)) {
-                    header.content()
-                }
-
-            }
+    LaunchedEffect(drawerState.isOpen) {
+        if (drawerState.isOpen != isExpanded) {
+            onExpandedChange(drawerState.isOpen)
         }
-    ) {
-        if (isExpanded) {
+    }
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
             NavRailMenu(
                 sections = menuSections,
-                onCloseDrawer = header.onClick,
+                onCloseDrawer = { onExpandedChange(false) },
                 onAboutClicked = onAboutClicked,
                 onFeedbackClicked = onFeedbackClicked,
                 creditText = creditText,
                 onCreditClicked = onCreditClicked
-
             )
-        } else {
-            Column(
-                modifier = Modifier.padding(horizontal = 4.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
-            ) {
-                buttons.forEach { item ->
-                    when (item) {
-                        is NavRailActionButton -> {
-                            NavRailButton(
-                                onClick = item.onClick,
-                                text = item.text
-                            )
+        }
+    ) {
+        Row {
+            NavigationRail(
+                modifier = modifier.width(80.dp),
+                containerColor = Color.Transparent,
+                header = {
+                    IconButton(
+                        onClick = { onExpandedChange(!isExpanded) },
+                        modifier = Modifier.padding(top = 16.dp, bottom = 16.dp)
+                    ) {
+                        Box(modifier = Modifier.size(headerIconSize)) {
+                            if (useAppIconAsHeader) {
+                                val context = LocalContext.current
+                                val iconDrawable = try {
+                                    context.packageManager.getApplicationIcon(context.packageName)
+                                } catch (e: Exception) {
+                                    null
+                                }
+
+                                if (iconDrawable != null) {
+                                    Image(
+                                        painter = rememberAsyncImagePainter(model = iconDrawable),
+                                        contentDescription = "App Icon"
+                                    )
+                                } else {
+                                    Icon(
+                                        imageVector = Icons.Default.Menu,
+                                        contentDescription = "Menu"
+                                    )
+                                }
+                            } else {
+                                header.content()
+                            }
                         }
-                        is NavRailCycleButton -> {
-                            NavRailCycleButtonInternal(item = item)
+                    }
+                }
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 4.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
+                ) {
+                    buttons.forEach { item ->
+                        when (item) {
+                            is NavRailActionButton -> {
+                                NavRailButton(
+                                    onClick = item.onClick,
+                                    text = item.text
+                                )
+                            }
+                            is NavRailCycleButton -> {
+                                NavRailCycleButtonInternal(item = item)
+                            }
                         }
                     }
                 }
             }
+            content()
         }
     }
 }
 
 @Composable
 private fun NavRailCycleButtonInternal(item: NavRailCycleButton) {
-    var currentIndex by remember { mutableStateOf(item.options.indexOf(item.initialOption).coerceAtLeast(0)) }
+    var currentIndex by remember { mutableStateOf(item.options.indexOf(item.initialOption)) }
     var isEnabled by remember { mutableStateOf(true) }
-    val coroutineScope = rememberCoroutineScope()
-    var cooldownJob: Job? by remember { mutableStateOf(null) }
+
+    LaunchedEffect(currentIndex) {
+        if (!isEnabled) {
+            delay(1000)
+            isEnabled = true
+        }
+    }
 
     val currentText = item.options.getOrNull(currentIndex) ?: ""
 
     NavRailButton(
         text = currentText,
         onClick = {
-            cooldownJob?.cancel()
+            isEnabled = false
 
             val nextIndex = (currentIndex + 1) % item.options.size
             currentIndex = nextIndex
             item.onStateChange(item.options[nextIndex])
-
-            isEnabled = false
-            cooldownJob = coroutineScope.launch {
-                delay(1000)
-                isEnabled = true
-            }
         },
         color = if (isEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
     )

--- a/src/main/java/com/hereliesaz/aznavrail/ui/NavRailMenu.kt
+++ b/src/main/java/com/hereliesaz/aznavrail/ui/NavRailMenu.kt
@@ -52,7 +52,7 @@ internal fun NavRailMenu(
                     .weight(1f)
                     .verticalScroll(rememberScrollState())
             ) {
-                sections.forEach { section ->
+                sections.forEachIndexed { index, section ->
                     if (section.title.isNotEmpty()) {
                         Text(
                             text = section.title,
@@ -68,7 +68,9 @@ internal fun NavRailMenu(
                             enabled = item.enabled
                         )
                     }
-                    MenuDivider()
+                    if (index < sections.lastIndex) {
+                        MenuDivider()
+                    }
                 }
             }
 
@@ -82,7 +84,22 @@ internal fun NavRailMenu(
                     MenuItem(text = "Feedback", onClick = { onFeedbackClicked(); onCloseDrawer() }, enabled = true)
                 }
                 if (creditText != null) {
-                    MenuItem(text = creditText, onClick = { onCreditClicked?.invoke(); onCloseDrawer() }, enabled = onCreditClicked != null)
+                    if (onCreditClicked != null) {
+                        MenuItem(text = creditText, onClick = { onCreditClicked(); onCloseDrawer() }, enabled = true)
+                    } else {
+                        // Display as plain text if no click handler
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp, vertical = 12.dp)
+                        ) {
+                            Text(
+                                text = creditText,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
                 }
                 Spacer(modifier = Modifier.height(12.dp))
 


### PR DESCRIPTION
This commit incorporates a number of significant improvements and fixes based on code review feedback.

The main architectural change is the refactoring of `AzNavRail` to use `ModalNavigationDrawer`. This provides a more robust and material-compliant user experience, with a proper modal drawer that includes a scrim and handles back-to-close gestures correctly.

Other changes include:
- Added validation to `NavRailCycleButton` to ensure the `initialOption` is valid.
- Simplified the cooldown logic in `NavRailCycleButtonInternal` by using `LaunchedEffect`.
- Added a new feature to allow using the app's icon as the header, with a fallback to a menu icon.
- Omitted the trailing divider after the last section in the `NavRailMenu`.
- Changed the static credit text to be non-clickable when no click handler is provided.
- Added Coil and Material Icons Extended dependencies to support the new features.

## Summary by Sourcery

Refactor navigation rail to leverage Material3's ModalNavigationDrawer and enhance header icon support, input validation, cooldown logic, menu styling, and dependency management.

New Features:
- Allow displaying the app's launcher icon as the navigation rail header with fallback to a menu icon

Bug Fixes:
- Enforce valid initialOption in NavRailCycleButton to prevent invalid state initialization

Enhancements:
- Refactor AzNavRail to use ModalNavigationDrawer with a scrim and proper back-to-close gestures
- Simplify NavRailCycleButtonInternal cooldown mechanism using a LaunchedEffect
- Omit trailing divider after the last section in NavRailMenu and render credit text as plain text when no click handler is provided

Build:
- Add Coil and Material Icons Extended as dependencies to support dynamic icons