### PR TITLE
fix: Stabilize build and add dependency list to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,18 @@ AzNavRail(
 | `onFeedbackClicked` | `(() -> Unit)?`                    | (Optional) A click handler for the 'Feedback' button in the footer. If `null`, the button is hidden.                                     |
 | `creditText`        | `String?`                          | (Optional) The text for the credit line in the footer. If `null`, the item is hidden.                                                    |
 | `onCreditClicked`   | `(() -> Unit)?`                    | (Optional) A click handler for the credit line.                                                                                          |
+
+## Dependencies
+
+This library depends on the following third-party libraries:
+
+*   **AndroidX Core**: `androidx.core:core-ktx:1.16.0`
+*   **Jetpack Compose BOM**: `androidx.compose:compose-bom:2024.04.01`
+*   **Jetpack Compose UI**: `androidx.compose.ui:ui`
+*   **Jetpack Compose UI Graphics**: `androidx.compose.ui:ui-graphics`
+*   **Jetpack Compose UI Tooling Preview**: `androidx.compose.ui:ui-tooling-preview`
+*   **Material 3**: `androidx.compose.material3:material3:1.4.0-beta01`
+*   **Jetpack Compose Foundation Layout**: `androidx.compose.foundation:foundation-layout`
+*   **Jetpack Compose Animation Core**: `androidx.compose.animation:animation-core`
+*   **Jetpack Compose Material Icons Extended**: `androidx.compose.material:material-icons-extended`
+*   **Coil Compose**: `io.coil-kt:coil-compose:2.6.0`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "com.hereliesaz.aznavrail"
-    compileSdk = 36
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,9 @@ material3 = "1.4.0-beta01"
 coil = "2.6.0"
 
 # Plugins
-kotlinAndroid = "2.2.0"
-kotlinCompose = "2.2.0"
-androidLibrary = "8.13.0-alpha03"
+kotlinAndroid = "2.0.0"
+kotlinCompose = "2.0.0"
+androidLibrary = "8.4.1"
 
 [libraries]
 # AndroidX Core & UI


### PR DESCRIPTION
This commit addresses two issues:
1.  The project was failing to build due to unstable dependency versions and unaccepted SDK licenses.
2.  The README.md file was missing a list of the project's dependencies.

The build has been stabilized by:
- Downgrading the `compileSdk` from 36 to 34.
- Downgrading the Android Gradle Plugin from `8.13.0-alpha03` to `8.4.1`.
- Downgrading the Kotlin plugins from `2.2.0` to `2.0.0` to resolve incompatibility warnings.
- Accepting the Android SDK licenses.

A new 'Dependencies' section has been added to the `README.md` to list the libraries this project uses.