### PR TITLE
feat: Add test app module and configure as library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.testapp"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.example.testapp"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.2"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(project(":")) // Depend on the root library project
+
+    // Standard Compose dependencies for the test app
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.material3)
+    implementation(libs.androidx.activityCompose)
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.testapp">
+
+    <application
+        android:allowBackup="true"
+        android:label="Test App"
+        android:theme="@android:style/Theme.Material.Light">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/testapp/MainActivity.kt
+++ b/app/src/main/java/com/example/testapp/MainActivity.kt
@@ -1,0 +1,58 @@
+package com.example.testapp
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.hereliesaz.aznavrail.model.NavItem
+import com.hereliesaz.aznavrail.model.NavItemData
+import com.hereliesaz.aznavrail.model.NavRailHeader
+import com.hereliesaz.aznavrail.model.NavRailMenuSection
+import com.hereliesaz.aznavrail.model.PredefinedAction
+import com.hereliesaz.aznavrail.ui.AzNavRail
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            TestAppScreen()
+        }
+    }
+}
+
+@Composable
+fun TestAppScreen() {
+    // 1. Define dummy data for the NavRail
+    val header = NavRailHeader(
+        content = { Text("Menu") }
+    )
+
+    val menuSections = listOf(
+        NavRailMenuSection(
+            title = "Main",
+            items = listOf(
+                NavItem(
+                    text = "Home",
+                    data = NavItemData.Action(onClick = {})
+                ),
+                NavItem(
+                    text = "Settings",
+                    data = NavItemData.Action(predefinedAction = PredefinedAction.SETTINGS)
+                )
+            )
+        )
+    )
+
+    // 2. Define a dummy action handler
+    val onPredefinedAction: (PredefinedAction) -> Unit = { action ->
+        println("Action clicked: $action")
+    }
+
+    // 3. Instantiate the AzNavRail component
+    AzNavRail(
+        header = header,
+        menuSections = menuSections,
+        onPredefinedAction = onPredefinedAction
+    )
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,17 +1,17 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
 }
 
 android {
     namespace = "com.hereliesaz.aznavrail"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
+        consumerProguardFiles("proguard-rules.pro")
     }
 
     buildTypes {
@@ -31,6 +31,10 @@ android {
 
     buildFeatures {
         compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+org.gradle.jvmargs=-Xmx2048m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,10 +9,12 @@ coil = "2.6.0"
 kotlinAndroid = "2.0.0"
 kotlinCompose = "2.0.0"
 androidLibrary = "8.4.1"
+activityCompose = "1.9.0"
 
 [libraries]
 # AndroidX Core & UI
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 
 # Jetpack Compose
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 15 16:57:08 CDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,14 @@
 pluginManagement {
-  repositories {
-    google()
-    mavenCentral()
-    gradlePluginPortal()
-  }
+    plugins {
+        id("com.android.application").version("8.6.0")
+        id("com.android.library").version("8.6.0")
+        id("org.jetbrains.kotlin.android").version("1.9.0")
+    }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
@@ -14,3 +19,4 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "AzNavRail"
+include(":", ":app")


### PR DESCRIPTION
Converts the project from a single module into a root library (':') and a new test application (':app').

- Creates the directory structure, build script, manifest, and a basic MainActivity for the ':app' module.
- Refactors the root build script to be a library.
- Updates Gradle, AGP, and SDK versions to resolve dozens of build and configuration errors encountered during the process.

The project is not in a compilable state. The build currently fails trying to resolve the `androidx.activity:activity-compose` dependency.