### PR TITLE
feat: Add usage tests for AzNavRail

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,8 @@ android {
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildFeatures {
@@ -45,4 +47,13 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.material3)
     implementation(libs.androidx.activity.compose)
+
+    // Test dependencies
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.ui.test.junit4)
+    debugImplementation(libs.androidx.ui.tooling)
+    debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/app/src/androidTest/java/com/hereliesaz/testapp/AzNavRailUsageTest.kt
+++ b/app/src/androidTest/java/com/hereliesaz/testapp/AzNavRailUsageTest.kt
@@ -1,0 +1,189 @@
+package com.hereliesaz.testapp
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.hereliesaz.aznavrail.model.NavItem
+import com.hereliesaz.aznavrail.model.NavItemData
+import com.hereliesaz.aznavrail.model.NavRailHeader
+import com.hereliesaz.aznavrail.model.NavRailMenuSection
+import com.hereliesaz.aznavrail.model.PredefinedAction
+import com.hereliesaz.aznavrail.ui.AzNavRail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AzNavRailUsageTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun azNavRail_isDisplayed() {
+        composeTestRule.setContent {
+            AzNavRail(
+                appName = "Test App",
+                header = NavRailHeader { androidx.compose.material3.Text("Menu") },
+                menuSections = listOf(
+                    NavRailMenuSection(
+                        title = "Main",
+                        items = listOf(
+                            NavItem(
+                                text = "Home",
+                                data = NavItemData.Action(predefinedAction = PredefinedAction.HOME),
+                                showOnRail = true
+                            )
+                        )
+                    )
+                ),
+                onPredefinedAction = { }
+            )
+        }
+
+        composeTestRule.onNodeWithText("Home").assertExists()
+    }
+
+    @Test
+    fun azNavRail_expandsAndCollapses() {
+        composeTestRule.setContent {
+            AzNavRail(
+                appName = "Test App",
+                header = NavRailHeader { androidx.compose.material3.Text("Menu") },
+                menuSections = listOf(
+                    NavRailMenuSection(
+                        title = "Main",
+                        items = listOf(
+                            NavItem(
+                                text = "Home",
+                                data = NavItemData.Action(predefinedAction = PredefinedAction.HOME),
+                                showOnRail = true
+                            )
+                        )
+                    )
+                ),
+                onPredefinedAction = { }
+            )
+        }
+
+        // Rail is initially collapsed
+        composeTestRule.onNodeWithText("Main").assertDoesNotExist()
+
+        // Expand the rail by clicking the header
+        composeTestRule.onNodeWithText("Menu").performClick()
+
+        // Rail is expanded
+        composeTestRule.onNodeWithText("Main").assertExists()
+    }
+
+    @Test
+    fun azNavRail_toggleButton_stateChanges() {
+        var isOnline = false
+        composeTestRule.setContent {
+            AzNavRail(
+                appName = "Test App",
+                header = NavRailHeader { androidx.compose.material3.Text("Menu") },
+                menuSections = listOf(
+                    NavRailMenuSection(
+                        title = "Main",
+                        items = listOf(
+                            NavItem(
+                                text = "Online",
+                                data = NavItemData.Toggle(
+                                    initialIsChecked = false,
+                                    onStateChange = { isOnline = it }
+                                ),
+                                showOnRail = true,
+                                railButtonText = "Offline"
+                            )
+                        )
+                    )
+                ),
+                onPredefinedAction = { }
+            )
+        }
+
+        // Initial state
+        composeTestRule.onNodeWithText("Offline").assertExists()
+        assert(!isOnline)
+
+        // Click to toggle
+        composeTestRule.onNodeWithText("Offline").performClick()
+
+        // State updated
+        assert(isOnline)
+    }
+
+    @Test
+    fun azNavRail_cycleButton_stateChanges() {
+        var currentStatus = "Away"
+        val statuses = listOf("Away", "Busy", "Online")
+        composeTestRule.setContent {
+            AzNavRail(
+                appName = "Test App",
+                header = NavRailHeader { androidx.compose.material3.Text("Menu") },
+                menuSections = listOf(
+                    NavRailMenuSection(
+                        title = "Main",
+                        items = listOf(
+                            NavItem(
+                                text = "Status",
+                                data = NavItemData.Cycle(
+                                    options = statuses,
+                                    initialOption = "Away",
+                                    onStateChange = { currentStatus = it }
+                                ),
+                                showOnRail = true
+                            )
+                        )
+                    )
+                ),
+                onPredefinedAction = { },
+                allowCyclersOnRail = true
+            )
+        }
+
+        // Initial state
+        composeTestRule.onNodeWithText("Away").assertExists()
+        assert(currentStatus == "Away")
+
+        // Click to cycle
+        composeTestRule.onNodeWithText("Away").performClick()
+        composeTestRule.onNodeWithText("Busy").assertExists()
+        assert(currentStatus == "Busy")
+
+        // Click to cycle again
+        composeTestRule.onNodeWithText("Busy").performClick()
+        composeTestRule.onNodeWithText("Online").assertExists()
+        assert(currentStatus == "Online")
+    }
+
+    @Test
+    fun azNavRail_customButtonContent_isDisplayed() {
+        composeTestRule.setContent {
+            AzNavRail(
+                appName = "Test App",
+                header = NavRailHeader { androidx.compose.material3.Text("Menu") },
+                menuSections = listOf(
+                    NavRailMenuSection(
+                        title = "Main",
+                        items = listOf(
+                            NavItem(
+                                text = "Custom",
+                                data = NavItemData.Action(),
+                                showOnRail = true
+                            )
+                        )
+                    )
+                ),
+                onPredefinedAction = { },
+                buttonContent = { item, _ ->
+                    androidx.compose.material3.Text("Custom ${item.text}")
+                }
+            )
+        }
+
+        composeTestRule.onNodeWithText("Custom Custom").assertExists()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,9 @@ kotlinAndroid = "2.0.0"
 kotlinCompose = "2.0.0"
 androidLibrary = "8.4.1"
 activityCompose = "1.9.0"
+junit = "4.13.2"
+androidx-test-ext-junit = "1.1.5"
+espresso-core = "3.5.1"
 
 [libraries]
 # AndroidX Core & UI
@@ -26,6 +29,12 @@ androidx-compose-foundation-layout = { group = "androidx.compose.foundation", na
 androidx-compose-animation-core = { group = "androidx.compose.animation", name = "animation-core" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
+espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
+androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
 
 [plugins]


### PR DESCRIPTION
This commit introduces a suite of UI tests for the `AzNavRail` library. These tests are designed to help developers understand how to use the library correctly and to prevent common misconfigurations.

The new tests cover the following scenarios:
- Verifying that the `AzNavRail` composable is displayed correctly.
- Testing the expand and collapse functionality of the rail.
- Verifying the state changes of `Toggle` and `Cycle` buttons.
- Demonstrating how to provide a custom `buttonContent` and verifying that it is rendered.

The necessary testing dependencies have been added to the `app/build.gradle.kts` and `gradle/libs.versions.toml` files.