### PR TITLE
Update build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("maven-publish")
+
 }
 
 android {
@@ -50,3 +52,19 @@ dependencies {
     implementation(libs.androidx.material.icons.extended)
     api(libs.coil.compose)
 }
+publishing {
+        publications {
+            create<MavenPublication>("mavenJava") {
+                from(components["java"]) // For a standard JVM library
+                // artifact(tasks.jar) // If you need a specific JAR
+                // artifact(tasks.sourcesJar) // If you want to publish sources
+            }
+        }
+        repositories {
+            maven {
+                // For Maven Central, you'll configure Sonatype OSSRH
+                // For a local Maven repository:
+                // url = uri("${layout.buildDirectory.get()}/repo")
+            }
+        }
+    }


### PR DESCRIPTION
## Summary by Sourcery

Enable Maven publishing by applying the maven-publish plugin and setting up a basic publications and repositories block in build.gradle.kts

Enhancements:
- Apply the maven-publish plugin and configure a MavenPublication for the library’s Java component
- Add a publishing block with a placeholder Maven repository for future deployment