### PR TITLE
Fix Gradle build and generate SampleApp APK

### DIFF
--- a/SampleApp/src/main/AndroidManifest.xml
+++ b/SampleApp/src/main/AndroidManifest.xml
@@ -3,9 +3,7 @@
 
     <application
         android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SampleApp">
         <activity

--- a/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
+++ b/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
@@ -40,22 +40,22 @@ fun SampleScreen() {
 
     Row {
         AzNavRail {
-            settings(
+            azSettings(
                 displayAppNameInHeader = false,
                 packRailButtons = false
             )
 
-            MenuItem(id = "home", text = "Home", onClick = { /* ... */ })
-            RailItem(id = "favorites", text = "Favs", onClick = { /* ... */ })
+            azMenuItem(id = "home", text = "Home", onClick = { /* ... */ })
+            azRailItem(id = "favorites", text = "Favs", onClick = { /* ... */ })
 
-            RailToggle(
+            azRailToggle(
                 id = "online",
                 text = "Online",
                 isChecked = isOnline,
                 onClick = { isOnline = !isOnline }
             )
 
-            MenuCycler(
+            azMenuCycler(
                 id = "cycler",
                 text = "Cycle",
                 options = cycleOptions,

--- a/SampleApp/src/main/res/values/styles.xml
+++ b/SampleApp/src/main/res/values/styles.xml
@@ -2,4 +2,4 @@
 <resources>
 
     <style name="Theme.SampleApp" parent="android:Theme.Material.Light.NoActionBar" />
-
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,19 +52,3 @@ dependencies {
     implementation(libs.androidx.material.icons.extended)
     api(libs.coil.compose)
 }
-publishing {
-        publications {
-            create<MavenPublication>("mavenJava") {
-                from(components["java"]) // For a standard JVM library
-                // artifact(tasks.jar) // If you need a specific JAR
-                // artifact(tasks.sourcesJar) // If you want to publish sources
-            }
-        }
-        repositories {
-            maven {
-                // For Maven Central, you'll configure Sonatype OSSRH
-                // For a local Maven repository:
-                // url = uri("${layout.buildDirectory.get()}/repo")
-            }
-        }
-    }

--- a/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -40,7 +41,7 @@ import com.hereliesaz.aznavrail.model.AzNavItem
 
 @Composable
 fun AzNavRail(
-    content: @Composable AzNavRailScope.() -> Unit
+    content: AzNavRailScope.() -> Unit
 ) {
     val scope = remember(content) { AzNavRailScopeImpl().apply(content) }
     val navItems = scope.navItems

--- a/src/main/java/com/hereliesaz/aznavrail/ui/AzNavRail.kt
+++ b/src/main/java/com/hereliesaz/aznavrail/ui/AzNavRail.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/src/main/java/com/hereliesaz/aznavrail/ui/NavRailMenu.kt
+++ b/src/main/java/com/hereliesaz/aznavrail/ui/NavRailMenu.kt
@@ -127,8 +127,9 @@ private fun MenuItem(
             .padding(horizontal = 24.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        if (item.icon != null) {
-            Icon(imageVector = item.icon, contentDescription = item.text)
+        val icon = item.icon
+        if (icon != null) {
+            Icon(imageVector = icon, contentDescription = item.text)
             Spacer(modifier = Modifier.width(16.dp))
         }
         Text(


### PR DESCRIPTION
This commit resolves a persistent Gradle build issue and generates the debug APK for the SampleApp.

The build was failing due to a chain of issues that were fixed in sequence:
- Removed a misconfigured `maven-publish` block from the root build.gradle.kts.
- Fixed several Kotlin compilation errors in the AzNavRail library source code (missing imports, incorrect API usage).
- Corrected a malformed XML file (styles.xml) in the SampleApp.
- Removed references to missing launcher icons from the AndroidManifest.xml.
- Updated the SampleApp's MainActivity to use the new, correct DSL for the AzNavRail library.

After fixing the build, the SampleApp-debug.apk was generated and has been committed to the `prebuilt_apk/` directory as requested.