### PR TITLE
Fix build errors by updating Gradle dependencies and plugins.

### DIFF
--- a/SampleApp/build.gradle.kts
+++ b/SampleApp/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -21,9 +22,6 @@ android {
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.2"
-    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("maven-publish")
-
 }
 
 android {
@@ -35,9 +35,6 @@ android {
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.2"
-    }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 org.gradle.jvmargs=-Xmx2048m
+android.suppressUnsupportedCompileSdk=36

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,8 @@ material3 = "1.4.0-beta01"
 coil = "2.6.0"
 
 # Plugins
-kotlinAndroid = "2.0.0"
-kotlinCompose = "2.0.0"
-androidLibrary = "8.4.1"
+kotlin = "2.0.0"
+androidLibrary = "8.6.0"
 activityCompose = "1.9.0"
 junit = "4.13.2"
 androidx-test-ext-junit = "1.1.5"
@@ -38,6 +37,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 
 
 [plugins]
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinAndroid" }
-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlinCompose" }
+android-application = { id = "com.android.application", version.ref = "androidLibrary" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "androidLibrary" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,8 @@ pluginManagement {
     plugins {
         id("com.android.application").version("8.6.0")
         id("com.android.library").version("8.6.0")
-        id("org.jetbrains.kotlin.android").version("1.9.0")
+        id("org.jetbrains.kotlin.android").version("2.0.0")
+        id("org.jetbrains.kotlin.plugin.compose").version("2.0.0")
     }
     repositories {
         google()


### PR DESCRIPTION
- Updated Android Gradle Plugin to 8.6.0 and Kotlin to 2.0.0.
- Added and configured the Compose Compiler Gradle plugin as required by Kotlin 2.0.
- Removed the hardcoded `kotlinCompilerExtensionVersion` from build scripts.
- Suppressed the `compileSdk` version warning in `gradle.properties` to allow the build to pass with `compileSdk = 36`.

## Summary by Sourcery

Update Gradle plugin and dependency versions, configure the Compose compiler plugin, and suppress compileSdk warnings to resolve build errors.

Bug Fixes:
- Upgrade Android Gradle Plugin to 8.6.0 and Kotlin to 2.0.0 to fix compatibility issues
- Suppress unsupported compileSdk warning in gradle.properties to allow building with compileSdk = 36

Enhancements:
- Add and apply the Compose Compiler Gradle plugin in library and application modules
- Remove hardcoded kotlinCompilerExtensionVersion entries from build scripts