### PR TITLE
feat: Import library from Jitpack in sample app

### DIFF
--- a/SampleApp/build.gradle.kts
+++ b/SampleApp/build.gradle.kts
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":"))
+    implementation(libs.aznavrail)
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+aznavrail = "2.3"
 # Android & Jetpack
 composeBom = "2024.04.01"
 coreKtx = "1.16.0"
@@ -14,6 +15,7 @@ androidx-test-ext-junit = "1.1.5"
 espresso-core = "3.5.1"
 
 [libraries]
+aznavrail = { group = "com.github.HereLiesAz", name = "AzNavRail", version.ref = "aznavrail" }
 # AndroidX Core & UI
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,4 +23,4 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "AzNavRail"
-include(":", ":SampleApp")
+include(":SampleApp")


### PR DESCRIPTION
Modified the sample app to import the AzNavRail library from Jitpack instead of using a local project dependency.

- Added the Jitpack repository to `settings.gradle.kts`.
- Added the `aznavrail` dependency to the version catalog in `gradle/libs.versions.toml`.
- Updated the `SampleApp/build.gradle.kts` to use the new Jitpack dependency.
- Removed the local project inclusion from `settings.gradle.kts`.