### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ And add the dependency to your app's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.HereLiesAz:AzNavRail:2.5.0") // Or the latest version
+    implementation("com.github.HereLiesAz:AzNavRail:2.6") // Or the latest version
 }
 ```
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Bump the AzNavRail implementation dependency from version 2.5.0 to 2.6 in the README