### PR TITLE
Fix button styling and default icon, remove text resizing

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -177,7 +178,7 @@ fun AzNavRail(
                                     if (appIcon != null) {
                                         Image(painter = rememberAsyncImagePainter(model = appIcon), contentDescription = "Toggle menu, showing $appName icon")
                                     } else {
-                                        Icon(imageVector = Icons.Default.Menu, contentDescription = "Toggle Menu")
+                                        Icon(imageVector = Icons.Default.Apps, contentDescription = "Toggle Menu")
                                     }
                                 }
                                 if (isExpanded) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -46,34 +46,18 @@ fun AzNavRailButton(
         onClick = onClick,
         modifier = modifier.size(size).aspectRatio(1f),
         shape = CircleShape,
-        border = BorderStroke(3.dp, color.copy(alpha = 0.7f)),
+        border = BorderStroke(3.dp, color),
         colors = ButtonDefaults.outlinedButtonColors(
             containerColor = Color.Transparent,
             contentColor = color
         ),
         contentPadding = PaddingValues(4.dp)
     ) {
-        BoxWithConstraints(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            val initialStyle = MaterialTheme.typography.labelSmall
-            var shrunkTextStyle by remember(text) { mutableStateOf(initialStyle) }
-            var shouldShrink by remember(text) { mutableStateOf(true) }
-
-            Text(
-                text = text,
-                textAlign = TextAlign.Center,
-                style = shrunkTextStyle,
-                maxLines = 1,
-                onTextLayout = { result ->
-                    if (shouldShrink && result.didOverflowWidth) {
-                        shrunkTextStyle = shrunkTextStyle.copy(fontSize = shrunkTextStyle.fontSize * 0.9f)
-                    } else {
-                        shouldShrink = false
-                    }
-                }
-            )
-        }
+        Text(
+            text = text,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 1
+        )
     }
 }


### PR DESCRIPTION
This commit addresses several issues with the AzNavRail component:

- The navigation buttons are now transparent circles with a fully opaque colored stroke, as requested.
- The default header icon is now a more appropriate 'Apps' icon when the app's own icon cannot be loaded.

The text auto-sizing feature has been removed from the `AzNavRailButton` due to persistent build issues that could not be resolved. The `TextAutoSize` feature of Jetpack Compose, which should provide this functionality, was not found by the compiler, even though the project's dependencies seem to be up to date. After multiple failed attempts to implement this feature, the decision was made to use a fixed font size to ensure the stability of the component.