### PR TITLE
Fix AzNavRail button styling, text resizing, and header

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -168,17 +169,19 @@ fun AzNavRail(
                 modifier = Modifier.width(railWidth),
                 containerColor = Color.Transparent,
                 header = {
-                    IconButton(onClick = onToggle, modifier = Modifier.padding(top = AzNavRailDefaults.HeaderPadding, bottom = AzNavRailDefaults.HeaderPadding)) {
+                    Box(
+                        modifier = Modifier
+                            .padding(top = AzNavRailDefaults.HeaderPadding, bottom = AzNavRailDefaults.HeaderPadding)
+                            .clickable(onClick = onToggle)
+                    ) {
                         if (scope.displayAppNameInHeader) {
                             Text(text = if (isExpanded) appName else appName.firstOrNull()?.toString() ?: "", style = MaterialTheme.typography.titleMedium)
                         } else {
                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                Box(modifier = Modifier.size(AzNavRailDefaults.HeaderIconSize)) {
-                                    if (appIcon != null) {
-                                        Image(painter = rememberAsyncImagePainter(model = appIcon), contentDescription = "Toggle menu, showing $appName icon")
-                                    } else {
-                                        Icon(imageVector = Icons.Default.Menu, contentDescription = "Toggle Menu")
-                                    }
+                                if (appIcon != null) {
+                                    Image(painter = rememberAsyncImagePainter(model = appIcon), contentDescription = "Toggle menu, showing $appName icon")
+                                } else {
+                                    Icon(imageVector = Icons.Default.Apps, contentDescription = "Toggle Menu")
                                 }
                                 if (isExpanded) {
                                     Spacer(modifier = Modifier.width(AzNavRailDefaults.HeaderTextSpacer))

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -20,9 +20,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /**
  * A circular, text-only button with auto-sizing text, designed for the collapsed navigation rail.
@@ -42,38 +45,39 @@ fun AzNavRailButton(
     size: Dp = 72.dp,
     color: Color = MaterialTheme.colorScheme.primary
 ) {
+    var fontSize by remember { mutableStateOf(50.sp) }
+    var readyToDraw by remember { mutableStateOf(false) }
+
     OutlinedButton(
         onClick = onClick,
         modifier = modifier.size(size).aspectRatio(1f),
         shape = CircleShape,
-        border = BorderStroke(3.dp, color.copy(alpha = 0.7f)),
+        border = BorderStroke(3.dp, color),
         colors = ButtonDefaults.outlinedButtonColors(
             containerColor = Color.Transparent,
             contentColor = color
         ),
         contentPadding = PaddingValues(4.dp)
     ) {
-        BoxWithConstraints(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            val initialStyle = MaterialTheme.typography.labelSmall
-            var shrunkTextStyle by remember(text) { mutableStateOf(initialStyle) }
-            var shouldShrink by remember(text) { mutableStateOf(true) }
-
-            Text(
-                text = text,
-                textAlign = TextAlign.Center,
-                style = shrunkTextStyle,
-                maxLines = 1,
-                onTextLayout = { result ->
-                    if (shouldShrink && result.didOverflowWidth) {
-                        shrunkTextStyle = shrunkTextStyle.copy(fontSize = shrunkTextStyle.fontSize * 0.9f)
-                    } else {
-                        shouldShrink = false
-                    }
+        Text(
+            text = text,
+            modifier = Modifier.drawWithContent {
+                if (readyToDraw) {
+                    drawContent()
                 }
-            )
-        }
+            },
+            style = TextStyle(
+                fontSize = fontSize,
+                textAlign = TextAlign.Center
+            ),
+            maxLines = 1,
+            onTextLayout = { textLayoutResult ->
+                if (textLayoutResult.didOverflowWidth) {
+                    fontSize *= 0.9f
+                } else {
+                    readyToDraw = true
+                }
+            }
+        )
     }
 }


### PR DESCRIPTION
This commit addresses several issues with the AzNavRail component to align with the user's requirements.

The `AzNavRailButton` has been updated to ensure it is always a transparent circle with a fully opaque colored stroke.

A robust text auto-sizing mechanism has been implemented in `AzNavRailButton`. The text now dynamically resizes to fit within the circular button without wrapping, using a manual approach with `onTextLayout` to ensure compatibility and avoid build issues.

The header of the `AzNavRail` has been modified to no longer constrain the app icon or app name within a circular shape. The `IconButton` has been replaced with a `Box` with a `clickable` modifier, and the explicit sizing of the icon has been removed, allowing the header content to be displayed at its natural size. Additionally, a more appropriate fallback icon is now used when the application's icon cannot be loaded.