### PR TITLE
Aznavrail scrolling and icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ fun MainScreen() {
 
         azRailToggle(
             id = "online",
+            text = "Online",
             isChecked = isOnline,
-            toggleOnText = "Online",
-            toggleOffText = "Offline",
             onClick = { isOnline = !isOnline }
         )
 
         azMenuCycler(
             id = "cycler",
+            text = "Cycle",
             options = cycleOptions,
             selectedOption = selectedOption,
             onClick = {
@@ -123,10 +123,10 @@ You declare items and configure the rail within the content lambda of `AzNavRail
 -   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean)`: Configures the settings for the `AzNavRail`.
 -   `azMenuItem(id: String, text: String, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu.
 -   `azRailItem(id: String, text: String, color: Color? = null, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu.
--   `azMenuToggle(id: String, toggleOnText: String, toggleOffText: String, isChecked: Boolean, onClick: () -> Unit)`: Adds a toggle switch item that only appears in the expanded menu.
--   `azRailToggle(id: String, toggleOnText: String, toggleOffText: String, color: Color? = null, isChecked: Boolean, onClick: () -> Unit)`: Adds a toggle switch item that appears in both the collapsed rail and the expanded menu.
--   `azMenuCycler(id: String, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that only appears in the expanded menu.
--   `azRailCycler(id: String, color: Color? = null, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that appears in both the collapsed rail and the expanded menu.
+-   `azMenuToggle(id: String, text: String, isChecked: Boolean, onClick: () -> Unit)`: Adds a toggle switch item that only appears in the expanded menu.
+-   `azRailToggle(id: String, text: String, color: Color? = null, isChecked: Boolean, onClick: () -> Unit)`: Adds a toggle switch item that appears in both the collapsed rail and the expanded menu.
+-   `azMenuCycler(id: String, text: String, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that only appears in the expanded menu.
+-   `azRailCycler(id: String, text: String, color: Color? = null, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that appears in both the collapsed rail and the expanded menu.
 
 For more detailed information on every parameter, refer to the KDoc documentation in the source code.
 

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -197,70 +197,65 @@ fun AzNavRail(
                     }
                 }
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    if (isExpanded) {
-                        Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())) {
+                if (isExpanded) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                             scope.navItems.forEach { item ->
                                 val onCyclerClick = if (item.isCycler) {
                                     {
                                         val state = cyclerStates[item.id]
-                                        if (state != null) {
-                                            state.job?.cancel()
-                                            val options = requireNotNull(item.options) { "Cycler item '${item.id}' must have options" }
-                                            val currentIndex = options.indexOf(state.displayedOption)
-                                            val nextIndex = (currentIndex + 1) % options.size
-                                            val nextOption = options[nextIndex]
-                                            val clickCount = state.pendingClickCount + 1
-                                            cyclerStates[item.id] = state.copy(
-                                                displayedOption = nextOption,
-                                                pendingClickCount = clickCount,
-                                                job = coroutineScope.launch {
-                                                    delay(1000L)
-                                                    repeat(clickCount) {
-                                                        item.onClick()
-                                                    }
-                                                    cyclerStates[item.id] = cyclerStates[item.id]!!.copy(pendingClickCount = 0, job = null)
+                                    if (state != null) {
+                                        state.job?.cancel()
+                                        val options = requireNotNull(item.options) { "Cycler item '${item.id}' must have options" }
+                                        val currentIndex = options.indexOf(state.displayedOption)
+                                        val nextIndex = (currentIndex + 1) % options.size
+                                        val nextOption = options[nextIndex]
+                                        val clickCount = state.pendingClickCount + 1
+                                        cyclerStates[item.id] = state.copy(
+                                            displayedOption = nextOption,
+                                            pendingClickCount = clickCount,
+                                            job = coroutineScope.launch {
+                                                delay(1000L)
+                                                repeat(clickCount) {
+                                                    item.onClick()
                                                 }
-                                            )
-                                        }
+                                                cyclerStates[item.id] = cyclerStates[item.id]!!.copy(pendingClickCount = 0, job = null)
+                                            }
+                                        )
                                     }
-                                } else {
-                                    item.onClick
-                                }
-                                val finalItem = if (item.isCycler) {
-                                    item.copy(selectedOption = cyclerStates[item.id]?.displayedOption ?: item.selectedOption)
-                                } else {
-                                    item
-                                }
-                                MenuItem(item = finalItem, onCyclerClick = onCyclerClick)
-                            }
-                            if (scope.showFooter) {
-                                Footer(appName = appName)
-                            }
-                        }
-                    } else {
-                        val railItems = remember(scope) { scope.navItems.filter { it.isRailItem } }
-                        Column(
-                            modifier = Modifier
-                                .padding(horizontal = AzNavRailDefaults.RailContentHorizontalPadding)
-                                .verticalScroll(rememberScrollState()),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = if (scope.packRailButtons) Arrangement.Top else Arrangement.spacedBy(
-                                AzNavRailDefaults.RailContentVerticalArrangement,
-                                Alignment.CenterVertically
-                            )
-                        ) {
-                            if (scope.packRailButtons) {
-                                railItems.forEach { item ->
-                                    RailContent(item = item)
                                 }
                             } else {
-                                scope.navItems.forEach { menuItem ->
-                                    if (menuItem.isRailItem) {
-                                        RailContent(item = menuItem)
-                                    } else {
-                                        Spacer(modifier = Modifier.height(AzNavRailDefaults.RailContentSpacerHeight))
-                                    }
+                                item.onClick
+                            }
+                            val finalItem = if (item.isCycler) {
+                                item.copy(selectedOption = cyclerStates[item.id]?.displayedOption ?: item.selectedOption)
+                            } else {
+                                item
+                            }
+                            MenuItem(item = finalItem, onCyclerClick = onCyclerClick)
+                        }
+                        }
+                    }
+                    if (scope.showFooter) {
+                        Footer(appName = appName)
+                    }
+                } else {
+                    val railItems = remember(scope) { scope.navItems.filter { it.isRailItem } }
+                    Column(
+                        modifier = Modifier.padding(horizontal = AzNavRailDefaults.RailContentHorizontalPadding).verticalScroll(rememberScrollState()),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = if (scope.packRailButtons) Arrangement.Top else Arrangement.spacedBy(AzNavRailDefaults.RailContentVerticalArrangement, Alignment.CenterVertically)
+                    ) {
+                        if (scope.packRailButtons) {
+                            railItems.forEach { item ->
+                                RailContent(item = item)
+                            }
+                        } else {
+                            scope.navItems.forEach { menuItem ->
+                                if (menuItem.isRailItem) {
+                                    RailContent(item = menuItem)
+                                } else {
+                                    Spacer(modifier = Modifier.height(AzNavRailDefaults.RailContentSpacerHeight))
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary by Sourcery

Update AzNavRail to improve scroll behavior in both expanded and collapsed modes and increase the header icon size.

Enhancements:
- Increase header icon size from 56.dp to 64.dp
- Split and relocate scroll modifiers so only nav items scroll in expanded mode and make collapsed rail vertically scrollable