### PR TITLE
feat: Make app icon size match rail buttons

### DIFF
--- a/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzNavRailUITest.kt
+++ b/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzNavRailUITest.kt
@@ -4,8 +4,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,7 +22,7 @@ class AzNavRailUITest {
         composeTestRule.setContent {
             AzNavRail {}
         }
-        composeTestRule.onNodeWithText("App").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Toggle menu, showing App icon").assertIsDisplayed()
     }
 
     @Test
@@ -30,10 +33,28 @@ class AzNavRailUITest {
             }
         }
 
-        composeTestRule.onNodeWithText("App").performClick()
+        composeTestRule.onNodeWithContentDescription("Toggle menu, showing App icon").performClick()
         composeTestRule.onNodeWithText("Home").assertIsDisplayed()
 
-        composeTestRule.onNodeWithText("App").performClick()
+        composeTestRule.onNodeWithContentDescription("Toggle menu, showing App icon").performClick()
         composeTestRule.onNodeWithText("Home").assertDoesNotExist()
+    }
+
+    @Test
+    fun appIcon_hasCorrectSize() {
+        composeTestRule.setContent {
+            AzNavRail {}
+        }
+
+        val iconNode = composeTestRule.onNodeWithContentDescription("Toggle menu, showing App icon", useUnmergedTree = true)
+        iconNode.assertExists()
+
+        val density = composeTestRule.density
+        val expectedSize = with(density) { 72.dp.toPx() }
+
+        val bounds = iconNode.fetchSemanticsNode().size
+
+        assertEquals(expectedSize.toInt(), bounds.width)
+        assertEquals(expectedSize.toInt(), bounds.height)
     }
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -44,7 +44,7 @@ private object AzNavRailLogger {
 private object AzNavRailDefaults {
     const val SWIPE_THRESHOLD_PX = 20f
     val HeaderPadding = 16.dp
-    val HeaderIconSize = 64.dp
+    val HeaderIconSize = 72.dp
     val HeaderTextSpacer = 8.dp
     val RailContentHorizontalPadding = 4.dp
     val RailContentVerticalArrangement = 8.dp


### PR DESCRIPTION
The app icon at the top of the navigation rail is now the same size as the circular rail buttons (72.dp).

A UI test has been added to verify the icon's size. Note: The test could not be run in the current environment due to the lack of a connected device.

## Summary by Sourcery

Resize the navigation rail header icon to match the circular rail buttons and update UI tests accordingly

New Features:
- Resize nav rail header icon from 64.dp to 72.dp to match rail button size

Enhancements:
- Refactor existing UI tests to select the header icon by content description instead of text

Tests:
- Add a UI test to assert the header icon’s width and height are 72.dp