### PR TITLE
Fix: App icon size in navigation rail

### DIFF
--- a/SampleApp/build.gradle.kts
+++ b/SampleApp/build.gradle.kts
@@ -33,8 +33,8 @@ android {
 }
 
 dependencies {
-    //implementation(project(":aznavrail"))
-    implementation(libs.aznavrail)
+    implementation(project(":aznavrail"))
+    //implementation(libs.aznavrail)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -178,8 +178,7 @@ fun AzNavRail(
                                 if (appIcon != null) {
                                     Image(
                                         painter = rememberAsyncImagePainter(model = appIcon),
-                                        contentDescription = "Toggle menu, showing $appName icon",
-                                        modifier = Modifier.size(AzNavRailDefaults.HeaderIconSize)
+                                        contentDescription = "Toggle menu, showing $appName icon"
                                     )
                                 } else {
                                     Icon(


### PR DESCRIPTION
The app icon in the navigation rail was being resized to a fixed size, which contradicted the instructions in AGENTS.md. This change removes the explicit sizing of the app icon, allowing it to be displayed at its natural size.

In addition, the build configuration for the SampleApp was updated to use a local project dependency on the aznavrail library, which is necessary for local development and testing.