### PR TITLE
feat: Add option to prevent nav rail from collapsing on click

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -231,11 +231,11 @@ fun AzNavRail(
                             } else {
                                 item
                             }
-                            MenuItem(item = finalItem, onCyclerClick = onCyclerClick)
+                            MenuItem(item = finalItem, onCyclerClick = onCyclerClick, onToggle = onToggle)
                         }
                     }
                     if (scope.showFooter) {
-                        Footer(appName = appName)
+                        Footer(appName = appName, onToggle = onToggle)
                     }
                     }
                 } else {
@@ -299,11 +299,13 @@ private fun RailContent(item: AzNavItem) {
  * Composable for displaying a single item in the expanded menu. The text is always displayed on a single line.
  * @param item The navigation item to display.
  * @param onCyclerClick The click handler for cycler items.
+ * @param onToggle The click handler for toggling the rail's expanded state.
  */
 @Composable
 private fun MenuItem(
     item: AzNavItem,
-    onCyclerClick: () -> Unit = item.onClick
+    onCyclerClick: () -> Unit = item.onClick,
+    onToggle: () -> Unit = {}
 ) {
     val textToShow = when {
         item.isToggle -> if (item.isChecked == true) item.toggleOnText else item.toggleOffText
@@ -316,7 +318,12 @@ private fun MenuItem(
             onValueChange = { _ -> item.onClick() }
         )
     } else {
-        Modifier.clickable(onClick = onCyclerClick)
+        Modifier.clickable {
+            onCyclerClick()
+            if (item.collapseOnClick && !item.isToggle && !item.isCycler) {
+                onToggle()
+            }
+        }
     }
 
     Row(
@@ -332,9 +339,10 @@ private fun MenuItem(
 /**
  * Composable for displaying the footer in the expanded menu.
  * @param appName The name of the app.
+ * @param onToggle The click handler for toggling the rail's expanded state.
  */
 @Composable
-private fun Footer(appName: String) {
+private fun Footer(appName: String, onToggle: () -> Unit) {
     val context = LocalContext.current
     val onAboutClick: () -> Unit = remember(context, appName) {
         {
@@ -373,15 +381,16 @@ private fun Footer(appName: String) {
 
     Column {
         HorizontalDivider(modifier = Modifier.padding(horizontal = AzNavRailDefaults.FooterDividerHorizontalPadding, vertical = AzNavRailDefaults.FooterDividerVerticalPadding), color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f))
-        MenuItem(item = AzNavItem(id = "about", text = "About", isRailItem = false, onClick = onAboutClick))
-        MenuItem(item = AzNavItem(id = "feedback", text = "Feedback", isRailItem = false, onClick = onFeedbackClick))
+        MenuItem(item = AzNavItem(id = "about", text = "About", isRailItem = false, onClick = onAboutClick), onToggle = onToggle)
+        MenuItem(item = AzNavItem(id = "feedback", text = "Feedback", isRailItem = false, onClick = onFeedbackClick), onToggle = onToggle)
         MenuItem(
             item = AzNavItem(
                 id = "credit",
                 text = "@HereLiesAz",
                 isRailItem = false,
                 onClick = onCreditClick
-            )
+            ),
+            onToggle = onToggle
         )
         Spacer(modifier = Modifier.height(AzNavRailDefaults.FooterSpacerHeight))
     }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Color
  * @param isCycler If `true`, this item behaves like a cycler.
  * @param options The list of options for a cycler.
  * @param selectedOption The currently selected option for a cycler.
+ * @param collapseOnClick If `true`, the navigation rail will collapse after this item is clicked. This only applies to normal items (not toggles or cyclers).
  * @param onClick The lambda to be executed when the item is clicked. For toggles and cyclers, this is where you should update your state.
  */
 data class AzNavItem(
@@ -31,5 +32,6 @@ data class AzNavItem(
     val isCycler: Boolean = false,
     val options: List<String>? = null,
     val selectedOption: String? = null,
+    val collapseOnClick: Boolean = true,
     val onClick: () -> Unit
 )


### PR DESCRIPTION
This change introduces a new boolean property, `collapseOnClick`, to the `AzNavItem` data class.

By default, this property is `true`, which maintains the existing behavior of the navigation rail collapsing when a standard menu item is clicked.

Developers can now set `collapseOnClick` to `false` on an `AzNavItem` to prevent the rail from collapsing when that specific item is clicked. This new behavior does not affect toggle or cycler items.