### PR TITLE
feat: Add AzButton, AzToggle, AzCycler and fix AzNavRail appIcon size

### DIFF
--- a/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
+++ b/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
@@ -1,0 +1,65 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+
+class AzButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun azButton_displaysCorrectText() {
+        val text = "Click me"
+        composeTestRule.setContent {
+            AzButton(onClick = {}, text = text)
+        }
+        composeTestRule.onNodeWithText(text).assertIsDisplayed()
+    }
+
+    @Test
+    fun azToggle_switchesTextOnClick() {
+        val textOn = "On"
+        val textOff = "Off"
+        composeTestRule.setContent {
+            val (isOn, setIsOn) = remember { mutableStateOf(false) }
+            AzToggle(
+                textWhenOn = textOn,
+                textWhenOff = textOff,
+                isOn = isOn,
+                onClick = { setIsOn(!isOn) }
+            )
+        }
+
+        composeTestRule.onNodeWithText(textOff).assertIsDisplayed()
+        composeTestRule.onNodeWithText(textOff).performClick()
+        composeTestRule.onNodeWithText(textOn).assertIsDisplayed()
+    }
+
+    @Test
+    fun azCycler_cyclesThroughOptions() {
+        val option1 = "Option 1"
+        val option2 = "Option 2"
+        val option3 = "Option 3"
+        composeTestRule.setContent {
+            AzCycler(
+                options = arrayOf(option1, option2, option3),
+                onOptionSelected = {}
+            )
+        }
+
+        composeTestRule.onNodeWithText(option1).assertIsDisplayed()
+        composeTestRule.onNodeWithText(option1).performClick()
+        composeTestRule.onNodeWithText(option2).assertIsDisplayed()
+        composeTestRule.onNodeWithText(option2).performClick()
+        composeTestRule.onNodeWithText(option3).assertIsDisplayed()
+        composeTestRule.onNodeWithText(option3).performClick()
+        composeTestRule.onNodeWithText(option1).assertIsDisplayed()
+    }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
@@ -1,0 +1,87 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.util.text.AutoSizeText
+
+@Composable
+fun AzButton(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.size(72.dp).aspectRatio(1f),
+        shape = CircleShape,
+        border = BorderStroke(3.dp, color),
+        colors = ButtonDefaults.outlinedButtonColors(
+            containerColor = Color.Transparent,
+            contentColor = color
+        ),
+        contentPadding = PaddingValues(8.dp)
+    ) {
+        AutoSizeText(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                textAlign = TextAlign.Center,
+                color = color
+            ),
+            modifier = Modifier.fillMaxSize(),
+            maxLines = if (text.contains("\n")) Int.MAX_VALUE else 1,
+            softWrap = false,
+            alignment = Alignment.Center,
+            lineSpaceRatio = 0.9f
+        )
+    }
+}
+
+@Composable
+fun AzToggle(
+    textWhenOn: String,
+    textWhenOff: String,
+    isOn: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary
+) {
+    AzButton(
+        onClick = onClick,
+        text = if (isOn) textWhenOn else textWhenOff,
+        modifier = modifier,
+        color = color
+    )
+}
+
+@Composable
+fun AzCycler(
+    vararg options: String,
+    onOptionSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary
+) {
+    var currentIndex by remember { mutableStateOf(0) }
+    AzButton(
+        onClick = {
+            currentIndex = (currentIndex + 1) % options.size
+            onOptionSelected(options[currentIndex])
+        },
+        text = options[currentIndex],
+        modifier = modifier,
+        color = color
+    )
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -178,7 +178,8 @@ fun AzNavRail(
                                 if (appIcon != null) {
                                     Image(
                                         painter = rememberAsyncImagePainter(model = appIcon),
-                                        contentDescription = "Toggle menu, showing $appName icon"
+                                        contentDescription = "Toggle menu, showing $appName icon",
+                                        modifier = Modifier.size(AzNavRailDefaults.HeaderIconSize)
                                     )
                                 } else {
                                     Icon(


### PR DESCRIPTION
This commit introduces three new composables: `AzButton`, `AzToggle`, and `AzCycler`. These buttons are designed to be used outside of the `AzNavRail` but with the same look and feel as the `AzRailItem` buttons.

- `AzButton`: A circular button with auto-resizing text, fixed at 72.dp.
- `AzToggle`: A toggle button that displays different text for on and off states.
- `AzCycler`: A button that cycles through a list of text options on click.

Additionally, this commit fixes the size of the `appIcon` in the `AzNavRail` to be the same as the `AzRailItem` buttons (72.dp), as requested.