### PR TITLE
Feat/az button and icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ import com.hereliesaz.aznavrail.AzCycler
 @Composable
 fun MyScreen() {
     var isToggled by remember { mutableStateOf(false) }
-    val cyclerOptions = listOf("A", "B", "C")
-    var selectedCyclerOption by remember { mutableStateOf(cyclerOptions.first()) }
 
     Column {
         AzButton(
@@ -79,8 +77,9 @@ fun MyScreen() {
         )
 
         AzCycler(
-            options = cyclerOptions.toTypedArray(),
-            onOptionSelected = { selectedCyclerOption = it }
+            "Option A" to { /* Action for A */ },
+            "Option B" to { /* Action for B */ },
+            "Option C" to { /* Action for C */ }
         )
     }
 }

--- a/README.md
+++ b/README.md
@@ -42,13 +42,51 @@ And add the dependency to your app's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.HereLiesAz:AzNavRail:3.2") // Or the latest version
+    implementation("com.github.HereLiesAz:AzNavRail:3.3") // Or the latest version
 }
 ```
 
 ## Usage
 
 Using the new DSL API is incredibly simple. You manage the state in your own composable and pass it to the `AzNavRail`.
+
+### Standalone Buttons
+
+You can also use the `AzButton`, `AzToggle`, and `AzCycler` composables by themselves. They are styled to look just like the buttons in the `AzNavRail`.
+
+```kotlin
+import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.AzToggle
+import com.hereliesaz.aznavrail.AzCycler
+
+@Composable
+fun MyScreen() {
+    var isToggled by remember { mutableStateOf(false) }
+    val cyclerOptions = listOf("A", "B", "C")
+    var selectedCyclerOption by remember { mutableStateOf(cyclerOptions.first()) }
+
+    Column {
+        AzButton(
+            onClick = { /* Do something */ },
+            text = "Click Me"
+        )
+
+        AzToggle(
+            textWhenOn = "On",
+            textWhenOff = "Off",
+            isOn = isToggled,
+            onClick = { isToggled = !isToggled }
+        )
+
+        AzCycler(
+            options = cyclerOptions.toTypedArray(),
+            onOptionSelected = { selectedCyclerOption = it }
+        )
+    }
+}
+```
+
+### `AzNavRail`
 
 ```kotlin
 import com.hereliesaz.aznavrail.AzNavRail

--- a/README.md
+++ b/README.md
@@ -50,43 +50,6 @@ dependencies {
 
 Using the new DSL API is incredibly simple. You manage the state in your own composable and pass it to the `AzNavRail`.
 
-### Standalone Buttons
-
-You can also use the `AzButton`, `AzToggle`, and `AzCycler` composables by themselves. They are styled to look just like the buttons in the `AzNavRail`.
-
-```kotlin
-import com.hereliesaz.aznavrail.AzButton
-import com.hereliesaz.aznavrail.AzToggle
-import com.hereliesaz.aznavrail.AzCycler
-
-@Composable
-fun MyScreen() {
-    var isToggled by remember { mutableStateOf(false) }
-
-    Column {
-        AzButton(
-            onClick = { /* Do something */ },
-            text = "Click Me"
-        )
-
-        AzToggle(
-            textWhenOn = "On",
-            textWhenOff = "Off",
-            isOn = isToggled,
-            onClick = { isToggled = !isToggled }
-        )
-
-        AzCycler(
-            "Option A" to { /* Action for A */ },
-            "Option B" to { /* Action for B */ },
-            "Option C" to { /* Action for C */ }
-        )
-    }
-}
-```
-
-### `AzNavRail`
-
 ```kotlin
 import com.hereliesaz.aznavrail.AzNavRail
 
@@ -128,6 +91,42 @@ fun MainScreen() {
 }
 ```
 
+### Standalone Buttons
+
+You can also use the `AzButton`, `AzToggle`, and `AzCycler` composables by themselves. They are styled to look just like the buttons in the `AzNavRail`.
+
+```kotlin
+import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.AzToggle
+import com.hereliesaz.aznavrail.AzCycler
+
+@Composable
+fun MyScreen() {
+    var isToggled by remember { mutableStateOf(false) }
+
+    Column {
+        AzButton {
+            text("Click Me")
+            onClick { /* Do something */ }
+        }
+
+        AzToggle(
+            isOn = isToggled,
+            onToggle = { isToggled = !isToggled }
+        ) {
+            default(text = "Off")
+            alt(text = "On")
+        }
+
+        AzCycler {
+            state(text = "Option A", onClick = { /* Action for A */ })
+            state(text = "Option B", onClick = { /* Action for B */ })
+            state(text = "Option C", onClick = { /* Action for C */ })
+        }
+    }
+}
+```
+
 ## API Reference
 
 The main entry point is the `AzNavRail` composable.
@@ -144,7 +143,7 @@ fun AzNavRail(
 )
 ```
 
-An M3-style navigation rail that expands into a menu drawer.
+An M3-style navigation rail that expands into a full menu drawer.
 
 -   **`modifier`**: The modifier to be applied to the navigation rail.
 -   **`initiallyExpanded`**: Whether the navigation rail is expanded by default.

--- a/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
+++ b/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
@@ -1,7 +1,9 @@
 package com.hereliesaz.aznavrail
 
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -18,7 +20,10 @@ class AzButtonTest {
     fun azButton_displaysCorrectText() {
         val text = "Click me"
         composeTestRule.setContent {
-            AzButton(onClick = {}, text = text)
+            AzButton {
+                text(text)
+                onClick {}
+            }
         }
         composeTestRule.onNodeWithText(text).assertIsDisplayed()
     }
@@ -28,13 +33,14 @@ class AzButtonTest {
         val textOn = "On"
         val textOff = "Off"
         composeTestRule.setContent {
-            val (isOn, setIsOn) = remember { mutableStateOf(false) }
+            var isOn by remember { mutableStateOf(false) }
             AzToggle(
-                textWhenOn = textOn,
-                textWhenOff = textOff,
                 isOn = isOn,
-                onClick = { setIsOn(!isOn) }
-            )
+                onToggle = { isOn = !isOn }
+            ) {
+                default(text = textOff)
+                alt(text = textOn)
+            }
         }
 
         composeTestRule.onNodeWithText(textOff).assertIsDisplayed()
@@ -48,11 +54,11 @@ class AzButtonTest {
         val option2 = "Option 2"
         val option3 = "Option 3"
         composeTestRule.setContent {
-            AzCycler(
-                option1 to {},
-                option2 to {},
-                option3 to {}
-            )
+            AzCycler {
+                state(text = option1, onClick = {})
+                state(text = option2, onClick = {})
+                state(text = option3, onClick = {})
+            }
         }
 
         composeTestRule.onNodeWithText(option1).assertIsDisplayed()

--- a/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
+++ b/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
@@ -1,0 +1,65 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+
+class AzButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun azButton_displaysCorrectText() {
+        val text = "Click me"
+        composeTestRule.setContent {
+            AzButton(onClick = {}, text = text)
+        }
+        composeTestRule.onNodeWithText(text).assertIsDisplayed()
+    }
+
+    @Test
+    fun azToggle_switchesTextOnClick() {
+        val textOn = "On"
+        val textOff = "Off"
+        composeTestRule.setContent {
+            val (isOn, setIsOn) = remember { mutableStateOf(false) }
+            AzToggle(
+                textWhenOn = textOn,
+                textWhenOff = textOff,
+                isOn = isOn,
+                onClick = { setIsOn(!isOn) }
+            )
+        }
+
+        composeTestRule.onNodeWithText(textOff).assertIsDisplayed()
+        composeTestRule.onNodeWithText(textOff).performClick()
+        composeTestRule.onNodeWithText(textOn).assertIsDisplayed()
+    }
+
+    @Test
+    fun azCycler_cyclesThroughOptions() {
+        val option1 = "Option 1"
+        val option2 = "Option 2"
+        val option3 = "Option 3"
+        composeTestRule.setContent {
+            AzCycler(
+                options = arrayOf(option1, option2, option3),
+                onOptionSelected = {}
+            )
+        }
+
+        composeTestRule.onNodeWithText(option1).assertIsDisplayed()
+        composeTestRule.onNodeWithText(option1).performClick()
+        composeTestRule.onNodeWithText(option2).assertIsDisplayed()
+        composeTestRule.onNodeWithText(option2).performClick()
+        composeTestRule.onNodeWithText(option3).assertIsDisplayed()
+        composeTestRule.onNodeWithText(option3).performClick()
+        composeTestRule.onNodeWithText(option1).assertIsDisplayed()
+    }
+}

--- a/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
+++ b/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
@@ -49,8 +49,9 @@ class AzButtonTest {
         val option3 = "Option 3"
         composeTestRule.setContent {
             AzCycler(
-                options = arrayOf(option1, option2, option3),
-                onOptionSelected = {}
+                option1 to {},
+                option2 to {},
+                option3 to {}
             )
         }
 

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
@@ -9,9 +9,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
- * What's so hard to understand about a button? It's a circle, it has text, and you click it.
- * This one is special, though, because it's the same size as the buttons in the `AzNavRail`.
- * The text will also shrink to fit, so you don't have to worry about it looking ugly.
+ * A circular, text-only button with auto-sizing text.
+ * This button is styled to be consistent with the buttons used in the `AzNavRail` component.
  *
  * @param onClick What happens when you click the button. You have to tell it what to do.
  * @param text The text that shows up on the button.
@@ -34,9 +33,8 @@ fun AzButton(
 }
 
 /**
- * This is a button that can be on or off. It's like a light switch.
- * You give it two pieces of text, one for when it's on and one for when it's off.
- * It will show the right text all by itself.
+ * A toggle button that displays different text based on its on/off state.
+ * This button is styled to be consistent with the buttons used in the `AzNavRail` component.
  *
  * @param textWhenOn The text to show when the button is on.
  * @param textWhenOff The text to show when the button is off.
@@ -63,10 +61,9 @@ fun AzToggle(
 }
 
 /**
- * This button is like a rolodex. You give it a list of things, and it will show them one by one.
- * Every time you click it, it shows the next thing in the list.
- * When it gets to the end, it starts over from the beginning.
- * The action for the selected option is executed after a 1-second delay.
+ * A button that cycles through a list of options. Each option consists of a text label and an associated action.
+ * When the button is clicked, it displays the next option in the list.
+ * The action for an option is executed one second after it is displayed.
  *
  * @param options The list of things to show, as pairs of (text, action). You can give it as many as you want.
  * @param modifier If you want to change how the button looks, you can use this.

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
@@ -115,7 +115,7 @@ fun AzCycler(
     modifier: Modifier = Modifier,
     content: AzCyclerScope.() -> Unit
 ) {
-    val scope = remember { AzCyclerScopeImpl() }.apply(content)
+    val scope = AzCyclerScopeImpl().apply(content)
     var currentIndex by rememberSaveable { mutableStateOf(0) }
 
     if (scope.states.isEmpty()) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
@@ -1,0 +1,119 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.util.text.AutoSizeText
+
+/**
+ * What's so hard to understand about a button? It's a circle, it has text, and you click it.
+ * This one is special, though, because it's the same size as the buttons in the `AzNavRail`.
+ * The text will also shrink to fit, so you don't have to worry about it looking ugly.
+ *
+ * @param onClick What happens when you click the button. You have to tell it what to do.
+ * @param text The text that shows up on the button.
+ * @param modifier If you want to change how the button looks, you can use this.
+ * @param color The color of the button's border and text.
+ */
+@Composable
+fun AzButton(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.size(72.dp).aspectRatio(1f),
+        shape = CircleShape,
+        border = BorderStroke(3.dp, color),
+        colors = ButtonDefaults.outlinedButtonColors(
+            containerColor = Color.Transparent,
+            contentColor = color
+        ),
+        contentPadding = PaddingValues(8.dp)
+    ) {
+        AutoSizeText(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                textAlign = TextAlign.Center,
+                color = color
+            ),
+            modifier = Modifier.fillMaxSize(),
+            maxLines = if (text.contains("\n")) Int.MAX_VALUE else 1,
+            softWrap = false,
+            alignment = Alignment.Center,
+            lineSpaceRatio = 0.9f
+        )
+    }
+}
+
+/**
+ * This is a button that can be on or off. It's like a light switch.
+ * You give it two pieces of text, one for when it's on and one for when it's off.
+ * It will show the right text all by itself.
+ *
+ * @param textWhenOn The text to show when the button is on.
+ * @param textWhenOff The text to show when the button is off.
+ * @param isOn A boolean that tells the button if it's on or off.
+ * @param onClick What happens when you click the button.
+ * @param modifier If you want to change how the button looks, you can use this.
+ * @param color The color of the button's border and text.
+ */
+@Composable
+fun AzToggle(
+    textWhenOn: String,
+    textWhenOff: String,
+    isOn: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary
+) {
+    AzButton(
+        onClick = onClick,
+        text = if (isOn) textWhenOn else textWhenOff,
+        modifier = modifier,
+        color = color
+    )
+}
+
+/**
+ * This button is like a rolodex. You give it a list of things, and it will show them one by one.
+ * Every time you click it, it shows the next thing in the list.
+ * When it gets to the end, it starts over from the beginning.
+ *
+ * @param options The list of things to show. You can give it as many as you want.
+ * @param onOptionSelected This is how you know which option is showing. It will give you the text of the current option.
+ * @param modifier If you want to change how the button looks, you can use this.
+ * @param color The color of the button's border and text.
+ */
+@Composable
+fun AzCycler(
+    vararg options: String,
+    onOptionSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary
+) {
+    var currentIndex by remember { mutableStateOf(0) }
+    AzButton(
+        onClick = {
+            currentIndex = (currentIndex + 1) % options.size
+            onOptionSelected(options[currentIndex])
+        },
+        text = options[currentIndex],
+        modifier = modifier,
+        color = color
+    )
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
@@ -37,7 +37,7 @@ fun AzButton(
     modifier: Modifier = Modifier,
     content: AzButtonScope.() -> Unit
 ) {
-    val scope = remember { AzButtonScopeImpl() }.apply(content)
+    val scope = AzButtonScopeImpl().apply(content)
     AzNavRailButton(
         onClick = scope.onClick,
         text = scope.text,

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
@@ -2,97 +2,135 @@ package com.hereliesaz.aznavrail
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
-/**
- * A circular, text-only button with auto-sizing text.
- * This button is styled to be consistent with the buttons used in the `AzNavRail` component.
- *
- * @param onClick What happens when you click the button. You have to tell it what to do.
- * @param text The text that shows up on the button.
- * @param modifier If you want to change how the button looks, you can use this.
- * @param color The color of the button's border and text.
- */
-@Composable
-fun AzButton(
-    onClick: () -> Unit,
-    text: String,
-    modifier: Modifier = Modifier,
-    color: Color = MaterialTheme.colorScheme.primary
-) {
-    AzNavRailButton(
-        onClick = onClick,
-        text = text,
-        modifier = modifier,
-        color = color
-    )
+// --- AzButton ---
+
+interface AzButtonScope {
+    fun text(text: String)
+    fun onClick(action: () -> Unit)
+    fun color(color: Color)
 }
 
-/**
- * A toggle button that displays different text based on its on/off state.
- * This button is styled to be consistent with the buttons used in the `AzNavRail` component.
- *
- * @param textWhenOn The text to show when the button is on.
- * @param textWhenOff The text to show when the button is off.
- * @param isOn A boolean that tells the button if it's on or off.
- * @param onClick What happens when you click the button.
- * @param modifier If you want to change how the button looks, you can use this.
- * @param color The color of the button's border and text.
- */
-@Composable
-fun AzToggle(
-    textWhenOn: String,
-    textWhenOff: String,
-    isOn: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    color: Color = MaterialTheme.colorScheme.primary
-) {
-    AzButton(
-        onClick = onClick,
-        text = if (isOn) textWhenOn else textWhenOff,
-        modifier = modifier,
-        color = color
-    )
-}
+private class AzButtonScopeImpl : AzButtonScope {
+    var text: String = ""
+    var onClick: () -> Unit = {}
+    var color: Color? = null
 
-/**
- * A button that cycles through a list of options. Each option consists of a text label and an associated action.
- * When the button is clicked, it displays the next option in the list.
- * The action for an option is executed one second after it is displayed.
- *
- * @param options The list of things to show, as pairs of (text, action). You can give it as many as you want.
- * @param modifier If you want to change how the button looks, you can use this.
- * @param color The color of the button's border and text.
- */
-@Composable
-fun AzCycler(
-    vararg options: Pair<String, () -> Unit>,
-    modifier: Modifier = Modifier,
-    color: Color = MaterialTheme.colorScheme.primary
-) {
-    val coroutineScope = rememberCoroutineScope()
-    var currentIndex by remember { mutableStateOf(0) }
-    var job by remember { mutableStateOf<Job?>(null) }
-
-    LaunchedEffect(currentIndex) {
-        job?.cancel()
-        job = coroutineScope.launch {
-            delay(1000L)
-            options[currentIndex].second()
-        }
+    override fun text(text: String) {
+        this.text = text
     }
 
-    AzButton(
-        onClick = {
-            currentIndex = (currentIndex + 1) % options.size
-        },
-        text = options[currentIndex].first,
+    override fun onClick(action: () -> Unit) {
+        this.onClick = action
+    }
+
+    override fun color(color: Color) {
+        this.color = color
+    }
+}
+
+@Composable
+fun AzButton(
+    modifier: Modifier = Modifier,
+    content: AzButtonScope.() -> Unit
+) {
+    val scope = remember { AzButtonScopeImpl() }.apply(content)
+    AzNavRailButton(
+        onClick = scope.onClick,
+        text = scope.text,
         modifier = modifier,
-        color = color
+        color = scope.color ?: MaterialTheme.colorScheme.primary
+    )
+}
+
+// --- AzToggle ---
+
+interface AzToggleScope {
+    fun default(text: String, color: Color? = null)
+    fun alt(text: String, color: Color? = null)
+}
+
+private class AzToggleScopeImpl : AzToggleScope {
+    var defaultText: String = ""
+    var defaultColor: Color? = null
+    var altText: String = ""
+    var altColor: Color? = null
+
+    override fun default(text: String, color: Color?) {
+        this.defaultText = text
+        this.defaultColor = color
+    }
+
+    override fun alt(text: String, color: Color?) {
+        this.altText = text
+        this.altColor = color
+    }
+}
+
+@Composable
+fun AzToggle(
+    isOn: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: AzToggleScope.() -> Unit
+) {
+    val scope = remember { AzToggleScopeImpl() }.apply(content)
+
+    val text = if (isOn) scope.altText else scope.defaultText
+    val color = if (isOn) scope.altColor else scope.defaultColor
+
+    AzNavRailButton(
+        onClick = onToggle,
+        text = text,
+        modifier = modifier,
+        color = color ?: MaterialTheme.colorScheme.primary
+    )
+}
+
+
+// --- AzCycler ---
+
+data class CyclerState(
+    val text: String,
+    val onClick: () -> Unit,
+    val color: Color?
+)
+
+interface AzCyclerScope {
+    fun state(text: String, onClick: () -> Unit, color: Color? = null)
+}
+
+private class AzCyclerScopeImpl : AzCyclerScope {
+    val states = mutableListOf<CyclerState>()
+    override fun state(text: String, onClick: () -> Unit, color: Color?) {
+        states.add(CyclerState(text, onClick, color))
+    }
+}
+
+@Composable
+fun AzCycler(
+    modifier: Modifier = Modifier,
+    content: AzCyclerScope.() -> Unit
+) {
+    val scope = remember { AzCyclerScopeImpl() }.apply(content)
+    var currentIndex by rememberSaveable { mutableStateOf(0) }
+
+    if (scope.states.isEmpty()) {
+        return
+    }
+
+    val currentState = scope.states[currentIndex]
+
+    AzNavRailButton(
+        onClick = {
+            currentState.onClick()
+            currentIndex = (currentIndex + 1) % scope.states.size
+        },
+        text = currentState.text,
+        modifier = modifier,
+        color = currentState.color ?: MaterialTheme.colorScheme.primary
     )
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
@@ -77,7 +77,7 @@ fun AzToggle(
     modifier: Modifier = Modifier,
     content: AzToggleScope.() -> Unit
 ) {
-    val scope = remember { AzToggleScopeImpl() }.apply(content)
+    val scope = AzToggleScopeImpl().apply(content)
 
     val text = if (isOn) scope.altText else scope.defaultText
     val color = if (isOn) scope.altColor else scope.defaultColor

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -186,11 +186,7 @@ fun AzNavRail(
                         contentAlignment = Alignment.Center
                     ) {
                         if (scope.displayAppNameInHeader) {
-                            val textModifier = if (isExpanded) {
-                                Modifier.width(scope.expandedRailWidth)
-                            } else {
-                                Modifier
-                            }
+                            val textModifier = Modifier.width(scope.expandedRailWidth)
                             Text(
                                 text = if (isExpanded) appName else appName.firstOrNull()?.toString() ?: "",
                                 style = MaterialTheme.typography.titleMedium,

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -76,6 +76,9 @@ private data class CyclerTransientState(
  *
  * The content of the rail and menu is defined using a DSL within the `content` lambda.
  *
+ * The header of the rail will automatically display your app's icon. This icon is not a button,
+ * but it is the same size as the rail items. Clicking it will expand or collapse the rail.
+ *
  * @param modifier The modifier to be applied to the navigation rail.
  * @param initiallyExpanded Whether the navigation rail is expanded by default.
  * @param disableSwipeToOpen Whether to disable the swipe-to-open gesture.
@@ -178,7 +181,8 @@ fun AzNavRail(
                                 if (appIcon != null) {
                                     Image(
                                         painter = rememberAsyncImagePainter(model = appIcon),
-                                        contentDescription = "Toggle menu, showing $appName icon"
+                                        contentDescription = "Toggle menu, showing $appName icon",
+                                        modifier = Modifier.size(AzNavRailDefaults.HeaderIconSize)
                                     )
                                 } else {
                                     Icon(

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -21,7 +21,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.hereliesaz.aznavrail.model.AzNavItem
@@ -173,16 +175,38 @@ fun AzNavRail(
                 modifier = Modifier.width(railWidth),
                 containerColor = Color.Transparent,
                 header = {
-                    IconButton(onClick = onToggle, modifier = Modifier.padding(top = AzNavRailDefaults.HeaderPadding, bottom = AzNavRailDefaults.HeaderPadding)) {
+                    Box(
+                        modifier = Modifier
+                            .padding(top = AzNavRailDefaults.HeaderPadding, bottom = AzNavRailDefaults.HeaderPadding)
+                            .clickable(
+                                onClick = onToggle,
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
                         if (scope.displayAppNameInHeader) {
-                            Text(text = if (isExpanded) appName else appName.firstOrNull()?.toString() ?: "", style = MaterialTheme.typography.titleMedium)
+                            val textModifier = if (isExpanded) {
+                                Modifier.width(scope.expandedRailWidth)
+                            } else {
+                                Modifier
+                            }
+                            Text(
+                                text = if (isExpanded) appName else appName.firstOrNull()?.toString() ?: "",
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = textModifier,
+                                softWrap = false,
+                                maxLines = if (isExpanded && appName.contains("\n")) Int.MAX_VALUE else 1,
+                                textAlign = TextAlign.Center
+                            )
                         } else {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 if (appIcon != null) {
                                     Image(
                                         painter = rememberAsyncImagePainter(model = appIcon),
                                         contentDescription = "Toggle menu, showing $appName icon",
-                                        modifier = Modifier.size(AzNavRailDefaults.HeaderIconSize)
+                                        modifier = Modifier.size(AzNavRailDefaults.HeaderIconSize),
+                                        contentScale = ContentScale.Crop
                                     )
                                 } else {
                                     Icon(

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -197,7 +197,7 @@ fun AzNavRail(
                                 modifier = textModifier,
                                 softWrap = false,
                                 maxLines = if (isExpanded && appName.contains("\n")) Int.MAX_VALUE else 1,
-                                textAlign = TextAlign.Center
+                                textAlign = if (isExpanded) TextAlign.Center else TextAlign.Start
                             )
                         } else {
                             Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
## Summary by Sourcery

Introduce standalone button composables (AzButton, AzToggle, AzCycler), enhance AzNavRail header behavior and styling, update documentation, and add corresponding UI tests.

New Features:
- Add standalone AzButton, AzToggle, and AzCycler composables for independent use.
- Make the AzNavRail header icon clickable to toggle expansion and adjust its display behavior.

Enhancements:
- Refine header text layout with alignment, soft wrap, and max lines, and enforce consistent icon sizing using ContentScale.
- Update AzNavRail description to reference a full menu drawer.

Documentation:
- Bump library version to 3.3 in README and add a section demonstrating standalone button usage.

Tests:
- Add Android UI tests for AzButton, AzToggle toggle behavior, and AzCycler state cycling.