### PR TITLE
Feat/add validation to components

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ fun MyScreen() {
 }
 ```
 
+### Standalone Buttons API
+
+-   **`AzButton`**: A simple button.
+    -   `content: AzButtonScope.() -> Unit`: The DSL for the button content.
+        -   `text(text: String)`: Sets the text of the button. Throws an `IllegalArgumentException` if `text` is empty.
+        -   `onClick(action: () -> Unit)`: Sets the click action.
+        -   `color(color: Color)`: Sets the color of the button.
+
+-   **`AzToggle`**: A toggle button.
+    -   `isOn: Boolean`: The state of the toggle.
+    -   `onToggle: () -> Unit`: The callback for when the toggle is clicked.
+    -   `content: AzToggleScope.() -> Unit`: The DSL for the toggle content.
+        -   `default(text: String, color: Color? = null)`: The text and color for the "off" state. Throws an `IllegalArgumentException` if `text` is empty.
+        -   `alt(text: String, color: Color? = null)`: The text and color for the "on" state. Throws an `IllegalArgumentException` if `text` is empty.
+
+-   **`AzCycler`**: A button that cycles through a list of states.
+    -   `content: AzCyclerScope.() -> Unit`: The DSL for the cycler content.
+        -   `state(text: String, onClick: () -> Unit, color: Color? = null)`: Defines a state for the cycler. Throws an `IllegalArgumentException` if `text` is empty.
+    -   Throws an `IllegalArgumentException` if no states are defined.
+
 ## API Reference
 
 The main entry point is the `AzNavRail` composable.
@@ -157,13 +177,13 @@ You declare items and configure the rail within the content lambda of `AzNavRail
 
 **Note:** Functions prefixed with `azMenu` will only appear in the expanded menu view. Functions prefixed with `azRail` will appear on the collapsed rail, and their text will be used as the label in the expanded menu.
 
--   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean)`: Configures the settings for the `AzNavRail`.
--   `azMenuItem(id: String, text: String, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu.
--   `azRailItem(id: String, text: String, color: Color? = null, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu.
--   `azMenuToggle(id: String, text: String, isChecked: Boolean, onClick: () -> Unit)`: Adds a toggle switch item that only appears in the expanded menu.
--   `azRailToggle(id: String, text: String, color: Color? = null, isChecked: Boolean, onClick: () -> Unit)`: Adds a toggle switch item that appears in both the collapsed rail and the expanded menu.
--   `azMenuCycler(id: String, text: String, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that only appears in the expanded menu.
--   `azRailCycler(id: String, text: String, color: Color? = null, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that appears in both the collapsed rail and the expanded menu.
+-   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean)`: Configures the settings for the `AzNavRail`. Throws an `IllegalArgumentException` if `expandedRailWidth` is not greater than `collapsedRailWidth`.
+-   `azMenuItem(id: String, text: String, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Throws an `IllegalArgumentException` if `text` is empty.
+-   `azRailItem(id: String, text: String, color: Color? = null, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu. Throws an `IllegalArgumentException` if `text` is empty.
+-   `azMenuToggle(id: String, text: String, isChecked: Boolean, onClick: () -> Unit)`: Adds a toggle switch item that only appears in the expanded menu. Throws an `IllegalArgumentException` if `toggleOnText` or `toggleOffText` are empty.
+-   `azRailToggle(id: String, text: String, color: Color? = null, isChecked: Boolean, onClick: () -> Unit)`: Adds a toggle switch item that appears in both the collapsed rail and the expanded menu. Throws an `IllegalArgumentException` if `toggleOnText` or `toggleOffText` are empty.
+-   `azMenuCycler(id: String, text: String, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that only appears in the expanded menu. Throws an `IllegalArgumentException` if `selectedOption` is not in `options`.
+-   `azRailCycler(id: String, text: String, color: Color? = null, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that appears in both the collapsed rail and the expanded menu. Throws an `IllegalArgumentException` if `selectedOption` is not in `options`.
 
 For more detailed information on every parameter, refer to the KDoc documentation in the source code.
 

--- a/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
+++ b/aznavrail/src/androidTest/java/com/hereliesaz/aznavrail/AzButtonTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,6 +27,35 @@ class AzButtonTest {
             }
         }
         composeTestRule.onNodeWithText(text).assertIsDisplayed()
+    }
+
+    @Test
+    fun azButton_withEmptyText_throwsException() {
+        try {
+            composeTestRule.setContent {
+                AzButton {
+                    text("")
+                    onClick {}
+                }
+            }
+            fail("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // Success
+        }
+    }
+
+    @Test
+    fun azCycler_withEmptyTextInState_throwsException() {
+        try {
+            composeTestRule.setContent {
+                AzCycler {
+                    state(text = "", onClick = {})
+                }
+            }
+            fail("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // Success
+        }
     }
 
     @Test
@@ -49,6 +79,24 @@ class AzButtonTest {
     }
 
     @Test
+    fun azToggle_withEmptyText_throwsException() {
+        try {
+            composeTestRule.setContent {
+                AzToggle(
+                    isOn = false,
+                    onToggle = {}
+                ) {
+                    default(text = "")
+                    alt(text = "On")
+                }
+            }
+            fail("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // Success
+        }
+    }
+
+    @Test
     fun azCycler_cyclesThroughOptions() {
         val option1 = "Option 1"
         val option2 = "Option 2"
@@ -68,5 +116,19 @@ class AzButtonTest {
         composeTestRule.onNodeWithText(option3).assertIsDisplayed()
         composeTestRule.onNodeWithText(option3).performClick()
         composeTestRule.onNodeWithText(option1).assertIsDisplayed()
+    }
+
+    @Test
+    fun azCycler_withNoStates_throwsException() {
+        try {
+            composeTestRule.setContent {
+                AzCycler {
+                    // No states
+                }
+            }
+            fail("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // Success
+        }
     }
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
@@ -38,6 +38,17 @@ fun AzButton(
     content: AzButtonScope.() -> Unit
 ) {
     val scope = AzButtonScopeImpl().apply(content)
+    require(scope.text.isNotEmpty()) {
+        """
+        The text for an AzButton cannot be empty.
+
+        // AzButton sample
+        AzButton {
+            text("Click Me")
+            onClick { /* ... */ }
+        }
+        """.trimIndent()
+    }
     AzNavRailButton(
         onClick = scope.onClick,
         text = scope.text,
@@ -78,6 +89,20 @@ fun AzToggle(
     content: AzToggleScope.() -> Unit
 ) {
     val scope = AzToggleScopeImpl().apply(content)
+    require(scope.defaultText.isNotEmpty() && scope.altText.isNotEmpty()) {
+        """
+        The default and alt text for an AzToggle cannot be empty.
+
+        // AzToggle sample
+        AzToggle(
+            isOn = true,
+            onToggle = { /* ... */ }
+        ) {
+            default(text = "Off")
+            alt(text = "On")
+        }
+        """.trimIndent()
+    }
 
     val text = if (isOn) scope.altText else scope.defaultText
     val color = if (isOn) scope.altColor else scope.defaultColor
@@ -106,6 +131,17 @@ interface AzCyclerScope {
 private class AzCyclerScopeImpl : AzCyclerScope {
     val states = mutableListOf<CyclerState>()
     override fun state(text: String, onClick: () -> Unit, color: Color?) {
+        require(text.isNotEmpty()) {
+            """
+            The text for a cycler state cannot be empty.
+
+            // AzCycler sample
+            AzCycler {
+                state(text = "Option A", onClick = { /* ... */ })
+                state(text = "Option B", onClick = { /* ... */ })
+            }
+            """.trimIndent()
+        }
         states.add(CyclerState(text, onClick, color))
     }
 }
@@ -117,6 +153,18 @@ fun AzCycler(
 ) {
     val scope = AzCyclerScopeImpl().apply(content)
     var currentIndex by rememberSaveable { mutableStateOf(0) }
+
+    require(scope.states.isNotEmpty()) {
+        """
+        An AzCycler must have at least one state.
+
+        // AzCycler sample
+        AzCycler {
+            state(text = "Option A", onClick = { /* ... */ })
+            state(text = "Option B", onClick = { /* ... */ })
+        }
+        """.trimIndent()
+    }
 
     if (scope.states.isEmpty()) {
         return

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -101,6 +101,17 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         collapsedRailWidth: Dp,
         showFooter: Boolean
     ) {
+        require(expandedRailWidth > collapsedRailWidth) {
+            """
+            `expandedRailWidth` must be greater than `collapsedRailWidth`.
+
+            // azSettings sample
+            azSettings(
+                expandedRailWidth = 260.dp,
+                collapsedRailWidth = 80.dp
+            )
+            """.trimIndent()
+        }
         this.displayAppNameInHeader = displayAppNameInHeader
         this.packRailButtons = packRailButtons
         this.expandedRailWidth = expandedRailWidth
@@ -109,26 +120,104 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     }
 
     override fun azMenuItem(id: String, text: String, onClick: () -> Unit) {
+        require(text.isNotEmpty()) {
+            """
+            `text` must not be empty.
+
+            // azMenuItem sample
+            azMenuItem(
+                id = "item",
+                text = "My Item",
+                onClick = { /* ... */ }
+            )
+            """.trimIndent()
+        }
         navItems.add(AzNavItem(id = id, text = text, isRailItem = false, onClick = onClick))
     }
 
     override fun azRailItem(id: String, text: String, color: Color?, onClick: () -> Unit) {
+        require(text.isNotEmpty()) {
+            """
+            `text` must not be empty.
+
+            // azRailItem sample
+            azRailItem(
+                id = "item",
+                text = "My Item",
+                onClick = { /* ... */ }
+            )
+            """.trimIndent()
+        }
         navItems.add(AzNavItem(id = id, text = text, isRailItem = true, color = color, onClick = onClick))
     }
 
     override fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit) {
+        require(toggleOnText.isNotEmpty() && toggleOffText.isNotEmpty()) {
+            """
+            `toggleOnText` and `toggleOffText` must not be empty.
+
+            // azMenuToggle sample
+            azMenuToggle(
+                id = "toggle",
+                isChecked = true,
+                toggleOnText = "On",
+                toggleOffText = "Off",
+                onClick = { /* ... */ }
+            )
+            """.trimIndent()
+        }
         navItems.add(AzNavItem(id = id, text = "", isRailItem = false, isToggle = true, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, onClick = onClick))
     }
 
     override fun azRailToggle(id: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit) {
+        require(toggleOnText.isNotEmpty() && toggleOffText.isNotEmpty()) {
+            """
+            `toggleOnText` and `toggleOffText` must not be empty.
+
+            // azRailToggle sample
+            azRailToggle(
+                id = "toggle",
+                isChecked = true,
+                toggleOnText = "On",
+                toggleOffText = "Off",
+                onClick = { /* ... */ }
+            )
+            """.trimIndent()
+        }
         navItems.add(AzNavItem(id = id, text = "", isRailItem = true, color = color, isToggle = true, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, onClick = onClick))
     }
 
     override fun azMenuCycler(id: String, options: List<String>, selectedOption: String, onClick: () -> Unit) {
+        require(selectedOption in options) {
+            """
+            `selectedOption` must be one of the provided options.
+
+            // azMenuCycler sample
+            azMenuCycler(
+                id = "cycler",
+                options = listOf("A", "B", "C"),
+                selectedOption = "A",
+                onClick = { /* ... */ }
+            )
+            """.trimIndent()
+        }
         navItems.add(AzNavItem(id = id, text = "", isRailItem = false, isCycler = true, options = options, selectedOption = selectedOption, onClick = onClick))
     }
 
     override fun azRailCycler(id: String, color: Color?, options: List<String>, selectedOption: String, onClick: () -> Unit) {
+        require(selectedOption in options) {
+            """
+            `selectedOption` must be one of the provided options.
+
+            // azRailCycler sample
+            azRailCycler(
+                id = "cycler",
+                options = listOf("A", "B", "C"),
+                selectedOption = "A",
+                onClick = { /* ... */ }
+            )
+            """.trimIndent()
+        }
         navItems.add(AzNavItem(id = id, text = "", isRailItem = true, color = color, isCycler = true, options = options, selectedOption = selectedOption, onClick = onClick))
     }
 }

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
@@ -27,6 +27,12 @@ class AzNavRailTest {
         assertEquals(false, scope.showFooter)
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun `azSettings with invalid widths should throw exception`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azSettings(expandedRailWidth = 100.dp, collapsedRailWidth = 200.dp)
+    }
+
     @Test
     fun `azMenuItem should add a menu item`() {
         val scope = AzNavRailScopeImpl()
@@ -35,6 +41,12 @@ class AzNavRailTest {
         assertEquals(expectedItem.id, scope.navItems[0].id)
         assertEquals(expectedItem.text, scope.navItems[0].text)
         assertEquals(expectedItem.isRailItem, scope.navItems[0].isRailItem)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `azMenuItem with empty text should throw exception`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azMenuItem("home", "") {}
     }
 
     @Test
@@ -46,6 +58,12 @@ class AzNavRailTest {
         assertEquals(expectedItem.text, scope.navItems[0].text)
         assertEquals(expectedItem.isRailItem, scope.navItems[0].isRailItem)
         assertEquals(expectedItem.color, scope.navItems[0].color)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `azRailItem with empty text should throw exception`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azRailItem("home", "") {}
     }
 
     @Test
@@ -60,6 +78,18 @@ class AzNavRailTest {
         assertEquals(expectedItem.isChecked, scope.navItems[0].isChecked)
         assertEquals(expectedItem.toggleOnText, scope.navItems[0].toggleOnText)
         assertEquals(expectedItem.toggleOffText, scope.navItems[0].toggleOffText)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `azRailToggle with empty text should throw exception`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azRailToggle("toggle", Color.Blue, false, "On", "") {}
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `azMenuToggle with empty text should throw exception`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azMenuToggle("toggle", true, "", "Off") {}
     }
 
     @Test
@@ -89,6 +119,20 @@ class AzNavRailTest {
         assertEquals(expectedItem.isCycler, scope.navItems[0].isCycler)
         assertEquals(expectedItem.options, scope.navItems[0].options)
         assertEquals(expectedItem.selectedOption, scope.navItems[0].selectedOption)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `azRailCycler with invalid selectedOption should throw exception`() {
+        val scope = AzNavRailScopeImpl()
+        val options = listOf("A", "B", "C")
+        scope.azRailCycler("cycler", Color.Green, options, "D") {}
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `azMenuCycler with invalid selectedOption should throw exception`() {
+        val scope = AzNavRailScopeImpl()
+        val options = listOf("A", "B", "C")
+        scope.azMenuCycler("cycler", options, "D") {}
     }
 
     @Test


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive input validation to AzNavRail DSL functions and standalone button components, enforce non-empty text, valid width ordering, and require cyclers to have at least one state; update tests to cover invalid input cases and enhance the README with documentation of these validation rules.

Enhancements:
- Enforce expandedRailWidth > collapsedRailWidth in azSettings
- Require non-empty text for azMenuItem, azRailItem, AzButton, AzToggle states, and AzCycler states
- Require non-empty toggleOnText and toggleOffText for menu and rail toggles
- Require selectedOption to be in options list for menu and rail cyclers
- Require at least one state defined in AzCycler

Documentation:
- Update README to document validation rules for AzButton, AzToggle, AzCycler, and AzNavRail functions

Tests:
- Add unit tests expecting IllegalArgumentException for invalid azSettings parameters
- Add unit tests for empty text in menu and rail items, toggles, and cyclers
- Add Android tests for AzButton, AzToggle, and AzCycler throwing exceptions on invalid input
- Add test for AzCycler with no states throwing exception