### PR TITLE
Fix: Correct AzRailItem button sizing in landscape mode

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -178,8 +178,7 @@ fun AzNavRail(
     }
 
     BoxWithConstraints(modifier = modifier) {
-        val isLandscape = maxWidth > maxHeight
-        val buttonSize = if (isLandscape) (maxHeight - AzNavRailDefaults.HeaderPadding * 2) / 8 else AzNavRailDefaults.HeaderIconSize
+        val buttonSize = scope.collapsedRailWidth - AzNavRailDefaults.RailContentHorizontalPadding * 2
 
         Row(
             modifier = Modifier.pointerInput(isExpanded, disableSwipeToOpen) {


### PR DESCRIPTION
The AzRailItem buttons were incorrectly sized in landscape mode because their size was calculated based on the screen's height. This resulted in the buttons appearing squashed.

This commit fixes the issue by calculating the button size based on the width of the collapsed navigation rail. This ensures the buttons are always proportioned correctly, regardless of the device's orientation.

## Summary by Sourcery

Bug Fixes:
- Use collapsedRailWidth minus horizontal padding for button size calculation instead of screen height to ensure proper proportions in all orientations