### PR TITLE
feat(AzNavRail): Integrate AzLoad as default loading animation

### DIFF
--- a/AzLoad/build.gradle.kts
+++ b/AzLoad/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "com.hereliesaz.azload"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 26
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.core.ktx)
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.runtime)
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.material3)
+}
+
+kotlin {
+    jvmToolchain(17)
+}

--- a/AzLoad/consumer-rules.pro
+++ b/AzLoad/consumer-rules.pro
@@ -1,0 +1,9 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are applied to applicatio...
+# and library modules consuming this library.
+#
+# Add custom rules here, for example:
+# -keep class com.example.my_library.MyClass {
+#   public <fields>;
+#   public <methods>;
+# }

--- a/AzLoad/src/main/java/com/hereliesaz/azload/AzLoad.kt
+++ b/AzLoad/src/main/java/com/hereliesaz/azload/AzLoad.kt
@@ -1,0 +1,54 @@
+package com.hereliesaz.azload
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun AzLoad(modifier: Modifier = Modifier) {
+    val infiniteTransition = rememberInfiniteTransition()
+    val rotationY by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        )
+    )
+
+    Box(
+        modifier = modifier
+            .size(120.dp)
+            .graphicsLayer {
+                this.rotationY = rotationY
+            }
+            .border(
+                width = 2.dp,
+                color = MaterialTheme.colorScheme.primary,
+                shape = CircleShape
+            )
+            .clip(CircleShape),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "loading...",
+            style = TextStyle(
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 16.sp
+            )
+        )
+    }
+}

--- a/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
+++ b/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
@@ -37,6 +37,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun SampleScreen() {
     var isOnline by remember { mutableStateOf(true) }
+    var isLoading by remember { mutableStateOf(false) }
     val cycleOptions = remember { listOf("A", "B", "C") }
     var selectedOption by remember { mutableStateOf(cycleOptions.first()) }
     val context = LocalContext.current
@@ -45,13 +46,16 @@ fun SampleScreen() {
         AzNavRail {
             azSettings(
                 displayAppNameInHeader = false,
-                packRailButtons = false
+                packRailButtons = false,
+                isLoading = isLoading
             )
 
             azMenuItem(id = "home", text = "Home", onClick = { /* ... */ })
             azRailItem(id = "favorites", text = "Favs", onClick = { /* ... */ })
             azRailItem(id = "long_text", text = "This is a very long text", onClick = { /* ... */ })
             azRailItem(id = "multi_line", text = "Multi\nLine", onClick = { /* ... */ })
+
+            azRailItem(id = "loading", text = "Load", onClick = { isLoading = !isLoading })
 
             azRailToggle(
                 id = "online",

--- a/aznavrail/build.gradle.kts
+++ b/aznavrail/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.compose.animation.core)
     implementation(libs.androidx.material.icons.extended)
     api(libs.coil.compose)
+    implementation(project(":AzLoad"))
 
     testImplementation(libs.junit)
     testImplementation(libs.androidx.test.ext.junit)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
+import com.hereliesaz.azload.AzLoad
 import com.hereliesaz.aznavrail.model.AzNavItem
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -238,7 +239,15 @@ fun AzNavRail(
                     }
                 }
             ) {
-                if (isExpanded) {
+                if (scope.isLoading) {
+                    Box(
+                        modifier = Modifier.fillMaxHeight(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        AzLoad()
+                    }
+                }
+                else if (isExpanded) {
                     Column(modifier = Modifier.fillMaxHeight()) {
                         Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())) {
                             scope.navItems.forEach { item ->

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -17,13 +17,15 @@ interface AzNavRailScope {
      * @param expandedRailWidth The width of the rail when it is expanded.
      * @param collapsedRailWidth The width of the rail when it is collapsed.
      * @param showFooter Whether to show the footer.
+     * @param isLoading Whether to show the loading animation.
      */
     fun azSettings(
         displayAppNameInHeader: Boolean = false,
         packRailButtons: Boolean = false,
         expandedRailWidth: Dp = 260.dp,
         collapsedRailWidth: Dp = 80.dp,
-        showFooter: Boolean = true
+        showFooter: Boolean = true,
+        isLoading: Boolean = false
     )
 
     /**
@@ -93,13 +95,15 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     var expandedRailWidth: Dp = 260.dp
     var collapsedRailWidth: Dp = 80.dp
     var showFooter: Boolean = true
+    var isLoading: Boolean = false
 
     override fun azSettings(
         displayAppNameInHeader: Boolean,
         packRailButtons: Boolean,
         expandedRailWidth: Dp,
         collapsedRailWidth: Dp,
-        showFooter: Boolean
+        showFooter: Boolean,
+        isLoading: Boolean
     ) {
         require(expandedRailWidth > collapsedRailWidth) {
             """
@@ -117,6 +121,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         this.expandedRailWidth = expandedRailWidth
         this.collapsedRailWidth = collapsedRailWidth
         this.showFooter = showFooter
+        this.isLoading = isLoading
     }
 
     override fun azMenuItem(id: String, text: String, onClick: () -> Unit) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
 androidx-compose-animation-core = { group = "androidx.compose.animation", name = "animation-core" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,3 +25,4 @@ dependencyResolutionManagement {
 rootProject.name = "AzNavRail"
 include(":SampleApp")
 include(":aznavrail")
+include(":AzLoad")


### PR DESCRIPTION
Integrates the `AzLoad` module from `TheLexorcist` project into `AzNavRail` to serve as the default loading animation.

Key changes:
- A new `AzLoad` module has been added to the project.
- `AzNavRail` now includes an `isLoading` parameter in its `azSettings` function. When `true`, the `AzLoad` animation is displayed, overlaying the navigation rail content.
- The `SampleApp` has been updated with a new rail button to demonstrate how to toggle the loading state.

This change makes it easy for developers using `AzNavRail` to display a consistent, built-in loading indicator for asynchronous operations.

## Summary by Sourcery

Integrate the AzLoad module into AzNavRail as the built-in loading indicator, expose an isLoading flag in the azSettings API, and update the SampleApp and build configuration to support and demonstrate the new loader.

New Features:
- Add AzLoad composable module as default loading animation.
- Expose isLoading parameter in AzNavRail azSettings to overlay AzLoad when true.
- Add a SampleApp rail button to toggle and demonstrate the loading state.

Enhancements:
- Include the AzLoad library as a project module and dependency in AzNavRail.
- Update libs.versions.toml, settings.gradle.kts, and build.gradle.kts to integrate new AzLoad dependencies.

Build:
- Introduce a new AzLoad Android library module with Compose configuration and ProGuard rules.