### PR TITLE
feat(navrail): Add AzDivider support and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This "navigrenuail" provides a vertical navigation rail that expands to a full m
 -   **Smart Collapse Behavior:** Toggle and standard menu items collapse the rail on tap. Cycler items wait for the user to settle on an option before acting and collapsing the rail.
 -   **Delayed Cycler Action:** Cycler items update their displayed option instantly but wait for a 1-second delay before triggering the associated action, allowing users to rapid-cycle without unintended consequences.
 -   **Customizable Colors:** Specify a custom color for each rail button.
+-   **Dividers:** Add visual separation to your menu with the `azDivider` function.
 -   **Automatic Header:** The header automatically uses your app's launcher icon by default. You can configure it to display the app name instead.
 -   **Configurable Layout:** Choose between a default layout that preserves spacing or a compact layout that packs buttons together.
 -   **Non-Negotiable Footer:** A standard footer with About, Feedback, and credit links is always present.
@@ -45,7 +46,7 @@ And add the dependency to your app's `build.gradle.kts`:
 ```kotlin
 dependencies {
 
-    implementation("com.github.HereLiesAz:AzNavRail:3.12") // Or the latest version
+    implementation("com.github.HereLiesAz:AzNavRail:3.13") // Or the latest version
 }
 ```
 
@@ -73,6 +74,8 @@ fun MainScreen() {
         azMenuItem(id = "home", text = "Home\nSweet Home", onClick = { /* Navigate home */ })
         azRailItem(id = "favorites", text = "Favs", onClick = { /* Show favorites */ })
 
+        azDivider()
+
         azRailToggle(
             id = "online",
             isChecked = isOnline,
@@ -88,65 +91,6 @@ fun MainScreen() {
             onClick = {
                 val currentIndex = cycleOptions.indexOf(selectedOption)
                 selectedOption = cycleOptions[(currentIndex + 1) % cycleOptions.size]
-            }
-        )
-    }
-}
-```
-
-### Loading State
-
-When your app is loading data, you can display an unobtrusive animation over the rail by setting the `isLoading` parameter to `true` in the `azSettings` function. This will disable all buttons and show a loading indicator until the `isLoading` is set back to `false`.
-
-```kotlin
-@Composable
-fun MainScreen(myViewModel: MyViewModel = viewModel()) {
-    val uiState by myViewModel.uiState.collectAsState()
-
-    AzNavRail {
-        azSettings(
-            isLoading = uiState.isLoading
-        )
-
-        // ... your rail and menu items
-    }
-}
-```
-
-### Standalone Buttons
-
-You can also use the `AzButton`, `AzToggle`, and `AzCycler` composables by themselves. They are styled to look just like the buttons in the `AzNavRail`.
-
-```kotlin
-import com.hereliesaz.aznavrail.AzButton
-import com.hereliesaz.aznavrail.AzToggle
-import com.hereliesaz.aznavrail.AzCycler
-
-@Composable
-fun MyScreen() {
-    var isToggled by remember { mutableStateOf(false) }
-    val cyclerOptions = listOf("A", "B", "C")
-    var selectedOption by remember { mutableStateOf(cyclerOptions.first()) }
-
-    Column {
-        AzButton(
-            text = "Click Me",
-            onClick = { /* Do something */ }
-        )
-
-        AzToggle(
-            isChecked = isToggled,
-            onToggle = { isToggled = !isToggled },
-            toggleOnText = "On",
-            toggleOffText = "Off"
-        )
-
-        AzCycler(
-            options = cyclerOptions,
-            selectedOption = selectedOption,
-            onCycle = {
-                val currentIndex = cyclerOptions.indexOf(selectedOption)
-                selectedOption = cyclerOptions[(currentIndex + 1) % cyclerOptions.size]
             }
         )
     }
@@ -183,42 +127,111 @@ You declare items and configure the rail within the content lambda of `AzNavRail
 **Note:** Functions prefixed with `azMenu` will only appear in the expanded menu view. Functions prefixed with `azRail` will appear on the collapsed rail, and their text will be used as the label in the expanded menu.
 
 -   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean)`: Configures the settings for the `AzNavRail`.
-    -   **`isLoading`**: Whether to show the loading animation. Defaults to `false`.
 -   `azMenuItem(id: String, text: String, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
 -   `azRailItem(id: String, text: String, color: Color? = null, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text in the expanded menu.
 -   `azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit)`: Adds a toggle item that only appears in the expanded menu. Tapping it executes the action and collapses the rail.
 -   `azRailToggle(id: String, color: Color? = null, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit)`: Adds a toggle item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail.
 -   `azMenuCycler(id: String, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that only appears in the expanded menu. Tapping it cycles through options and executes the `onClick` action for the final selection after a 1-second delay, then collapses the rail.
 -   `azRailCycler(id: String, color: Color? = null, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that appears in both the collapsed rail and the expanded menu. The behavior is the same as `azMenuCycler`.
+-   `azDivider()`: Adds a horizontal divider to the expanded menu.
 
-### Standalone Buttons API
+## Other Components
 
--   **`AzButton`**: A simple button.
-    -   `onClick: () -> Unit`: The callback to be invoked when the button is clicked.
-    -   `text: String`: The text to display on the button.
-    -   `modifier: Modifier`: The modifier to be applied to the button.
-    -   `color: Color`: The color of the button's border and text.
+### Loading State
 
--   **`AzToggle`**: A toggle button.
-    -   `isChecked: Boolean`: Whether the toggle is in the "on" state.
-    -   `onToggle: () -> Unit`: The callback to be invoked when the button is toggled.
-    -   `toggleOnText: String`: The text to display when the toggle is on.
-    -   `toggleOffText: String`: The text to display when the toggle is off.
-    -   `modifier: Modifier`: The modifier to be applied to the button.
-    -   `color: Color`: The color of the button's border and text.
+When your app is loading data, you can display an unobtrusive animation over the rail by setting the `isLoading` parameter to `true` in the `azSettings` function. This will disable all buttons and show a loading indicator until `isLoading` is set back to `false`.
 
--   **`AzCycler`**: A button that cycles through a list of options when clicked.
-    -   `options: List<String>`: The list of options to cycle through.
-    -   `selectedOption: String`: The currently selected option.
-    -   `onCycle: () -> Unit`: The callback to be invoked after a 1-second delay on the final selected option.
-    -   `modifier: Modifier`: The modifier to be applied to the button.
-    -   `color: Color`: The color of the button's border and text.
+This feature is powered by the `AzLoad` composable, which is integrated directly into the `AzNavRail` and does not require any separate setup.
+
+```kotlin
+@Composable
+fun MainScreen(myViewModel: MyViewModel = viewModel()) {
+    val uiState by myViewModel.uiState.collectAsState()
+
+    AzNavRail {
+        azSettings(
+            isLoading = uiState.isLoading
+        )
+
+        // ... your rail and menu items
+    }
+}
+```
 
 ### Standalone Components
 
--   `AzButton(onClick: () -> Unit, text: String, color: Color? = null)`: A standalone circular button.
--   `AzToggle(isChecked: Boolean, onToggle: () -> Unit, toggleOnText: String, toggleOffText: String, color: Color? = null)`: A standalone toggle button.
--   `AzCycler(options: List<String>, selectedOption: String, onCycle: () -> Unit, color: Color? = null)`: A standalone cycler button with delayed action.
+You can also use the `AzButton`, `AzToggle`, `AzCycler`, and `AzDivider` composables by themselves. They are styled to look just like the components in the `AzNavRail`.
+
+```kotlin
+import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.AzToggle
+import com.hereliesaz.aznavrail.AzCycler
+import com.hereliesaz.aznavrail.AzDivider
+
+@Composable
+fun MyScreen() {
+    var isToggled by remember { mutableStateOf(false) }
+    val cyclerOptions = listOf("A", "B", "C")
+    var selectedOption by remember { mutableStateOf(cyclerOptions.first()) }
+
+    Column {
+        AzButton(
+            text = "Click Me",
+            onClick = { /* Do something */ }
+        )
+
+        AzDivider()
+
+        AzToggle(
+            isChecked = isToggled,
+            onToggle = { isToggled = !isToggled },
+            toggleOnText = "On",
+            toggleOffText = "Off"
+        )
+
+        AzCycler(
+            options = cyclerOptions,
+            selectedOption = selectedOption,
+            onCycle = {
+                val currentIndex = cyclerOptions.indexOf(selectedOption)
+                selectedOption = cyclerOptions[(currentIndex + 1) % cyclerOptions.size]
+            }
+        )
+    }
+}
+```
+
+#### `AzButton`
+A simple, circular button.
+-   `onClick: () -> Unit`: The callback to be invoked when the button is clicked.
+-   `text: String`: The text to display on the button.
+-   `modifier: Modifier`: The modifier to be applied to the button.
+-   `color: Color`: The color of the button's border and text.
+
+#### `AzToggle`
+A toggle button.
+-   `isChecked: Boolean`: Whether the toggle is in the "on" state.
+-   `onToggle: () -> Unit`: The callback to be invoked when the button is toggled.
+-   `toggleOnText: String`: The text to display when the toggle is on.
+-   `toggleOffText: String`: The text to display when the toggle is off.
+-   `modifier: Modifier`: The modifier to be applied to the button.
+-   `color: Color`: The color of the button's border and text.
+
+#### `AzCycler`
+A button that cycles through a list of options when clicked.
+-   `options: List<String>`: The list of options to cycle through.
+-   `selectedOption: String`: The currently selected option.
+-   `onCycle: () -> Unit`: The callback to be invoked after a 1-second delay on the final selected option.
+-   `modifier: Modifier`: The modifier to be applied to the button.
+-   `color: Color`: The color of the button's border and text.
+
+#### `AzDivider`
+A divider that automatically adjusts its orientation based on the available space.
+-   `modifier: Modifier`: The modifier to be applied to the divider.
+-   `thickness: Dp`: The thickness of the divider line.
+-   `color: Color`: The color of the divider line.
+-   `horizontalPadding: Dp`: The padding applied to the left and right of the divider.
+-   `verticalPadding: Dp`: The padding applied to the top and bottom of the divider.
 
 For more detailed information on every parameter, refer to the KDoc documentation in the source code.
 

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -263,50 +263,54 @@ fun AzNavRail(
                     Column(modifier = Modifier.fillMaxHeight()) {
                         Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())) {
                             scope.navItems.forEach { item ->
-                                val onCyclerClick = if (item.isCycler) {
-                                    {
-                                        val state = cyclerStates[item.id]
-                                        if (state != null) {
-                                            state.job?.cancel()
-                                            val options = requireNotNull(item.options) { "Cycler item '${item.id}' must have options" }
-                                            val currentIndex = options.indexOf(state.displayedOption)
-                                            val nextIndex = (currentIndex + 1) % options.size
-                                            val nextOption = options[nextIndex]
+                                if (item.isDivider) {
+                                    AzDivider()
+                                } else {
+                                    val onCyclerClick = if (item.isCycler) {
+                                        {
+                                            val state = cyclerStates[item.id]
+                                            if (state != null) {
+                                                state.job?.cancel()
+                                                val options = requireNotNull(item.options) { "Cycler item '${item.id}' must have options" }
+                                                val currentIndex = options.indexOf(state.displayedOption)
+                                                val nextIndex = (currentIndex + 1) % options.size
+                                                val nextOption = options[nextIndex]
 
-                                            cyclerStates[item.id] = state.copy(
-                                                displayedOption = nextOption,
-                                                job = coroutineScope.launch {
-                                                    delay(1000L)
+                                                cyclerStates[item.id] = state.copy(
+                                                    displayedOption = nextOption,
+                                                    job = coroutineScope.launch {
+                                                        delay(1000L)
 
-                                                    val finalItemState = scope.navItems.find { it.id == item.id } ?: item
-                                                    val currentStateInVm = finalItemState.selectedOption
-                                                    val targetState = nextOption
+                                                        val finalItemState = scope.navItems.find { it.id == item.id } ?: item
+                                                        val currentStateInVm = finalItemState.selectedOption
+                                                        val targetState = nextOption
 
-                                                    val currentIndexInVm = options.indexOf(currentStateInVm)
-                                                    val targetIndex = options.indexOf(targetState)
+                                                        val currentIndexInVm = options.indexOf(currentStateInVm)
+                                                        val targetIndex = options.indexOf(targetState)
 
-                                                    if (currentIndexInVm != -1 && targetIndex != -1) {
-                                                        val clicksToCatchUp = (targetIndex - currentIndexInVm + options.size) % options.size
-                                                        repeat(clicksToCatchUp) {
-                                                            item.onClick()
+                                                        if (currentIndexInVm != -1 && targetIndex != -1) {
+                                                            val clicksToCatchUp = (targetIndex - currentIndexInVm + options.size) % options.size
+                                                            repeat(clicksToCatchUp) {
+                                                                item.onClick()
+                                                            }
                                                         }
-                                                    }
 
-                                                    onToggle()
-                                                    cyclerStates[item.id] = cyclerStates[item.id]!!.copy(job = null)
-                                                }
-                                            )
+                                                        onToggle()
+                                                        cyclerStates[item.id] = cyclerStates[item.id]!!.copy(job = null)
+                                                    }
+                                                )
+                                            }
                                         }
+                                    } else {
+                                        item.onClick
                                     }
-                                } else {
-                                    item.onClick
+                                    val finalItem = if (item.isCycler) {
+                                        item.copy(selectedOption = cyclerStates[item.id]?.displayedOption ?: item.selectedOption)
+                                    } else {
+                                        item
+                                    }
+                                    MenuItem(item = finalItem, onCyclerClick = onCyclerClick, onToggle = onToggle)
                                 }
-                                val finalItem = if (item.isCycler) {
-                                    item.copy(selectedOption = cyclerStates[item.id]?.displayedOption ?: item.selectedOption)
-                                } else {
-                                    item
-                                }
-                                MenuItem(item = finalItem, onCyclerClick = onCyclerClick, onToggle = onToggle)
                             }
                         }
                         if (scope.showFooter) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -94,6 +94,11 @@ interface AzNavRailScope {
      * @param onClick The callback to be invoked for the final selected option after the delay.
      */
     fun azRailCycler(id: String, color: Color? = null, options: List<String>, selectedOption: String, onClick: () -> Unit)
+
+    /**
+     * Adds a divider to the expanded menu.
+     */
+    fun azDivider()
 }
 
 internal class AzNavRailScopeImpl : AzNavRailScope {
@@ -232,5 +237,9 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
             """.trimIndent()
         }
         navItems.add(AzNavItem(id = id, text = "", isRailItem = true, color = color, isCycler = true, options = options, selectedOption = selectedOption, onClick = onClick))
+    }
+
+    override fun azDivider() {
+        navItems.add(AzNavItem(id = "divider_${navItems.size}", text = "", isRailItem = false, isDivider = true, onClick = {}))
     }
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Color
  * @param isCycler If `true`, this item behaves like a cycler.
  * @param options The list of options for a cycler.
  * @param selectedOption The currently selected option for a cycler.
+ * @param isDivider If `true`, this item is a divider.
  * @param collapseOnClick If `true`, the navigation rail will collapse after this item is clicked. This only applies to normal items (not toggles or cyclers).
  * @param onClick The lambda to be executed when the item is clicked. For toggles and cyclers, this is where you should update your state.
  */
@@ -32,6 +33,7 @@ data class AzNavItem(
     val isCycler: Boolean = false,
     val options: List<String>? = null,
     val selectedOption: String? = null,
+    val isDivider: Boolean = false,
     val collapseOnClick: Boolean = true,
     val onClick: () -> Unit
 )


### PR DESCRIPTION
This commit introduces two main changes:

1.  **AzDivider in AzNavRail:** The `AzNavRail` component now supports adding dividers to the expanded menu using the `azDivider()` function in the DSL. This allows for better visual separation of menu items.

2.  **README Updates:** The `README.md` file has been significantly updated to:
    *   Document the new `azDivider` feature.
    *   Clarify the usage of the `AzLoad` component for displaying a loading state.
    *   Reorganize and improve the documentation for all standalone components (`AzButton`, `AzToggle`, `AzCycler`, `AzDivider`) for better clarity and consistency.

## Summary by Sourcery

Add divider support to AzNavRail via a new azDivider DSL function and standalone composable, and update documentation and version reference to cover the new feature and clarify usage.

New Features:
- Add azDivider() DSL function to insert horizontal dividers in the expanded AzNavRail menu
- Add standalone AzDivider composable for use outside of AzNavRail

Build:
- Bump library dependency version to 3.13 in README

Documentation:
- Update README to document the azDivider feature, clarify AzLoad loading-state usage, and reorganize the standalone component API reference