### PR TITLE
fix: Address regressions, improve documentation, and restore humor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,22 @@ This "navigrenuail" provides a vertical navigation rail that expands to a full m
 
 ## Features
 
--   **Responsive Layout:** The rail automatically adjusts to landscape orientation, ensuring a great user experience on all devices.
--   **Scrollable Content:** Both the expanded menu and the collapsed rail are scrollable, allowing for a large number of navigation items.
--   **Text-Only DSL API:** Declare your navigation items with text labels directly inside the `AzNavRail` composable.
--   **Multi-line Menu Items:** The expanded menu supports multi-line text, with automatic indentation for readability.
--   **Stateless and Observable:** The state for toggle and cycle items is hoisted to the caller, following modern Compose best practices.
--   **Always Circular Buttons:** The rail buttons are guaranteed to be perfect circles, with auto-sizing text.
--   **Smart Collapse Behavior:** Toggle and standard menu items collapse the rail on tap. Cycler items wait for the user to settle on an option before acting and collapsing the rail.
--   **Delayed Cycler Action:** Cycler items update their displayed option instantly but wait for a 1-second delay before triggering the associated action, allowing users to rapid-cycle without unintended consequences.
--   **Customizable Colors:** Specify a custom color for each rail button.
--   **Dividers:** Add visual separation to your menu with the `azDivider` function.
--   **Automatic Header:** The header automatically uses your app's launcher icon by default. You can configure it to display the app name instead.
--   **Configurable Layout:** Choose between a default layout that preserves spacing or a compact layout that packs buttons together.
--   **Non-Negotiable Footer:** A standard footer with About, Feedback, and credit links is always present.
--   **Loading State:** Display a loading animation over the rail while content is loading.
+-   **Responsive Layout:** Automatically adjusts to orientation changes.
+-   **Scrollable Content:** Both the rail and the expanded menu are scrollable.
+-   **Text-Only DSL API:** A simple, declarative API for building your navigation.
+-   **Multi-line Menu Items:** Supports multi-line text with automatic indentation.
+-   **Stateless and Observable:** Hoist and manage state in your own composables.
+-   **Customizable Shapes:** Choose from `CIRCLE`, `SQUARE`, or `RECTANGLE` for rail buttons.
+-   **Uniform Rectangle Width:** All rectangular buttons automatically share the same width.
+-   **Smart Collapse Behavior:** Menu items intelligently collapse the rail after interactions.
+-   **Delayed Cycler Action:** Cycler items have a built-in delay to prevent accidental triggers.
+-   **Customizable Colors:** Apply custom colors to individual rail buttons.
+-   **Dividers:** Easily add dividers to your menu.
+-   **Automatic Header:** Displays your app's icon or name by default.
+-   **Configurable Layout:** Pack buttons together or preserve spacing.
+-   **Disabled State:** Disable any item, including individual cycler options.
+-   **Loading State:** Show a loading animation over the rail.
+-   **Standalone Components:** Use `AzButton`, `AzToggle`, `AzCycler`, and `AzDivider` on their own.
 
 ## Setup
 
@@ -46,62 +48,93 @@ And add the dependency to your app's `build.gradle.kts`:
 ```kotlin
 dependencies {
 
-    implementation("com.github.HereLiesAz:AzNavRail:3.13") // Or the latest version
+    implementation("com.github.HereLiesAz:AzNavRail:3.14") // Or the latest version
 }
 ```
 
 ## Usage
 
-Using the new DSL API is incredibly simple. You manage the state in your own composable and pass it to the `AzNavRail`.
+Here is a comprehensive example demonstrating the various features of `AzNavRail`. You can find this code in the `SampleApp`.
 
 ```kotlin
 import com.hereliesaz.aznavrail.AzNavRail
+import com.hereliesaz.aznavrail.model.AzButtonShape
 
 @Composable
-fun MainScreen() {
+fun SampleScreen() {
     var isOnline by remember { mutableStateOf(true) }
-    val cycleOptions = listOf("Option A", "Option B", "Option C")
+    var isLoading by remember { mutableStateOf(false) }
+    val cycleOptions = remember { listOf("A", "B", "C", "D") }
     var selectedOption by remember { mutableStateOf(cycleOptions.first()) }
+    val context = LocalContext.current
 
-    AzNavRail {
-        // Configure the rail's behavior
-        azSettings(
-            displayAppNameInHeader = false,
-            packRailButtons = false
-        )
+    Row {
+        AzNavRail {
+            azSettings(
+                displayAppNameInHeader = true,
+                packRailButtons = false,
+                isLoading = isLoading,
+                defaultShape = AzButtonShape.RECTANGLE // Set a default shape for all rail items
+            )
 
-        // Declare the navigation items
-        azMenuItem(id = "home", text = "Home\nSweet Home", onClick = { /* Navigate home */ })
-        azRailItem(id = "favorites", text = "Favs", onClick = { /* Show favorites */ })
+            // A standard menu item
+            azMenuItem(id = "home", text = "Home", onClick = { /* ... */ })
 
-        azDivider()
+            // A rail item with the default shape (RECTANGLE)
+            azRailItem(id = "favorites", text = "Favorites", onClick = { /* ... */ })
 
-        azRailToggle(
-            id = "online",
-            isChecked = isOnline,
-            toggleOnText = "Online",
-            toggleOffText = "Offline",
-            onClick = { isOnline = !isOnline }
-        )
+            // A disabled rail item that overrides the default shape
+            azRailItem(
+                id = "profile",
+                text = "Profile",
+                shape = AzButtonShape.CIRCLE,
+                disabled = true,
+                onClick = { /* This will not be triggered */ }
+            )
 
-        azMenuCycler(
-            id = "cycler",
-            options = cycleOptions,
-            selectedOption = selectedOption,
-            onClick = {
-                val currentIndex = cycleOptions.indexOf(selectedOption)
-                selectedOption = cycleOptions[(currentIndex + 1) % cycleOptions.size]
-            }
-        )
+            azDivider()
+
+            // A toggle item with the SQUARE shape
+            azRailToggle(
+                id = "online",
+                isChecked = isOnline,
+                toggleOnText = "Online",
+                toggleOffText = "Offline",
+                shape = AzButtonShape.SQUARE,
+                onClick = { isOnline = !isOnline }
+            )
+
+            // A cycler with a disabled option
+            azRailCycler(
+                id = "cycler",
+                options = cycleOptions,
+                selectedOption = selectedOption,
+                disabledOptions = listOf("C"),
+                onClick = {
+                    val currentIndex = cycleOptions.indexOf(selectedOption)
+                    selectedOption = cycleOptions[(currentIndex + 1) % cycleOptions.size]
+                }
+            )
+
+            // A button to demonstrate the loading state
+            azRailItem(id = "loading", text = "Load", onClick = { isLoading = !isLoading })
+        }
+
+        // Your app's main content goes here
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("isOnline: $isOnline")
+            Text("selectedOption: $selectedOption")
+            Text("isLoading: $isLoading")
+        }
     }
 }
 ```
 
 ## API Reference
 
-The main entry point is the `AzNavRail` composable.
-
 ### `AzNavRail`
+
+The main composable for the navigation rail.
 
 ```kotlin
 @Composable
@@ -113,8 +146,6 @@ fun AzNavRail(
 )
 ```
 
-An M3-style navigation rail that expands into a full menu drawer.
-
 -   **`modifier`**: The modifier to be applied to the navigation rail.
 -   **`initiallyExpanded`**: Whether the navigation rail is expanded by default.
 -   **`disableSwipeToOpen`**: Whether to disable the swipe-to-open gesture.
@@ -122,17 +153,17 @@ An M3-style navigation rail that expands into a full menu drawer.
 
 ### `AzNavRailScope`
 
-You declare items and configure the rail within the content lambda of `AzNavRail`. The available functions are:
+The DSL for configuring the `AzNavRail`.
 
 **Note:** Functions prefixed with `azMenu` will only appear in the expanded menu view. Functions prefixed with `azRail` will appear on the collapsed rail, and their text will be used as the label in the expanded menu.
 
--   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean)`: Configures the settings for the `AzNavRail`.
--   `azMenuItem(id: String, text: String, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
--   `azRailItem(id: String, text: String, color: Color? = null, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text in the expanded menu.
--   `azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit)`: Adds a toggle item that only appears in the expanded menu. Tapping it executes the action and collapses the rail.
--   `azRailToggle(id: String, color: Color? = null, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit)`: Adds a toggle item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail.
--   `azMenuCycler(id: String, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that only appears in the expanded menu. Tapping it cycles through options and executes the `onClick` action for the final selection after a 1-second delay, then collapses the rail.
--   `azRailCycler(id: String, color: Color? = null, options: List<String>, selectedOption: String, onClick: () -> Unit)`: Adds a cycler item that appears in both the collapsed rail and the expanded menu. The behavior is the same as `azMenuCycler`.
+-   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean, defaultShape: AzButtonShape)`: Configures the settings for the `AzNavRail`.
+-   `azMenuItem(id: String, text: String, disabled: Boolean, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
+-   `azRailItem(id: String, text: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text in the expanded menu.
+-   `azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, disabled: Boolean, onClick: () -> Unit)`: Adds a toggle item that only appears in the expanded menu. Tapping it executes the action and collapses the rail.
+-   `azRailToggle(id: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, shape: AzButtonShape?, disabled: Boolean, onClick: () -> Unit)`: Adds a toggle item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail.
+-   `azMenuCycler(id: String, options: List<String>, selectedOption: String, disabled: Boolean, disabledOptions: List<String>?, onClick: () -> Unit)`: Adds a cycler item that only appears in the expanded menu. Tapping it cycles through options and executes the `onClick` action for the final selection after a 1-second delay, then collapses the rail.
+-   `azRailCycler(id: String, color: Color?, options: List<String>, selectedOption: String, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, onClick: () -> Unit)`: Adds a cycler item that appears in both the collapsed rail and the expanded menu. The behavior is the same as `azMenuCycler`.
 -   `azDivider()`: Adds a horizontal divider to the expanded menu.
 
 ## Other Components

--- a/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
+++ b/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
@@ -12,13 +12,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import android.widget.Toast
 import androidx.compose.runtime.setValue
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.hereliesaz.aznavrail.AzDivider
+import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.AzNavRail
+import com.hereliesaz.aznavrail.model.AzButtonShape
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -40,56 +41,67 @@ class MainActivity : ComponentActivity() {
 fun SampleScreen() {
     var isOnline by remember { mutableStateOf(true) }
     var isLoading by remember { mutableStateOf(false) }
-    val cycleOptions = remember { listOf("A", "B", "C") }
+    val cycleOptions = remember { listOf("A", "B", "C", "D") }
     var selectedOption by remember { mutableStateOf(cycleOptions.first()) }
     val context = LocalContext.current
 
     Row {
         AzNavRail {
             azSettings(
-                displayAppNameInHeader = false,
+                displayAppNameInHeader = true,
                 packRailButtons = false,
-                isLoading = isLoading
+                isLoading = isLoading,
+                defaultShape = AzButtonShape.RECTANGLE // Set a default shape for all rail items
             )
 
+            // A standard menu item
             azMenuItem(id = "home", text = "Home", onClick = { /* ... */ })
-            azRailItem(id = "favorites", text = "Favs", onClick = { /* ... */ })
-            azRailItem(id = "long_text", text = "This is a very long text", onClick = { /* ... */ })
-            azRailItem(id = "multi_line", text = "Multi\nLine", onClick = { /* ... */ })
 
-            azRailItem(id = "loading", text = "Load", onClick = { isLoading = !isLoading })
+            // A rail item with the default shape (RECTANGLE)
+            azRailItem(id = "favorites", text = "Favorites", onClick = { /* ... */ })
 
+            // A disabled rail item that overrides the default shape
+            azRailItem(
+                id = "profile",
+                text = "Profile",
+                shape = AzButtonShape.CIRCLE,
+                disabled = true,
+                onClick = { /* This will not be triggered */ }
+            )
+
+            azDivider()
+
+            // A toggle item with the SQUARE shape
             azRailToggle(
                 id = "online",
                 isChecked = isOnline,
                 toggleOnText = "Online",
                 toggleOffText = "Offline",
-                onClick = {
-                    isOnline = !isOnline
-                    Toast.makeText(context, "Toggle clicked! isOnline: $isOnline", Toast.LENGTH_SHORT).show()
-                }
+                shape = AzButtonShape.SQUARE,
+                onClick = { isOnline = !isOnline }
             )
 
-            azMenuCycler(
+            // A cycler with a disabled option
+            azRailCycler(
                 id = "cycler",
                 options = cycleOptions,
                 selectedOption = selectedOption,
+                disabledOptions = listOf("C"),
                 onClick = {
                     val currentIndex = cycleOptions.indexOf(selectedOption)
                     selectedOption = cycleOptions[(currentIndex + 1) % cycleOptions.size]
-                    Toast.makeText(context, "Cycler clicked! selectedOption: $selectedOption", Toast.LENGTH_SHORT).show()
                 }
             )
+
+            // A button to demonstrate the loading state
+            azRailItem(id = "loading", text = "Load", onClick = { isLoading = !isLoading })
         }
-        Column {
-            Text("Horizontal Divider:")
-            AzDivider()
-            Text("Some content below the divider.")
-            Row {
-                Text("Vertical Divider:")
-                AzDivider()
-                Text("Some content to the right of the divider.")
-            }
+
+        // Your app's main content goes here
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("isOnline: $isOnline")
+            Text("selectedOption: $selectedOption")
+            Text("isLoading: $isLoading")
         }
     }
 }

--- a/aznavrail/build.gradle.kts
+++ b/aznavrail/build.gradle.kts
@@ -68,7 +68,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.github.HereLiesAz"
                 artifactId = "AzNavRail"
-                version = "3.3"
+                version = "3.14"
             }
         }
     }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
@@ -41,7 +39,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.hereliesaz.aznavrail.AzLoad
+import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzNavItem
+import com.hereliesaz.aznavrail.util.EqualWidthLayout
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -271,34 +271,46 @@ fun AzNavRail(
                                             val state = cyclerStates[item.id]
                                             if (state != null) {
                                                 state.job?.cancel()
+
                                                 val options = requireNotNull(item.options) { "Cycler item '${item.id}' must have options" }
-                                                val currentIndex = options.indexOf(state.displayedOption)
-                                                val nextIndex = (currentIndex + 1) % options.size
-                                                val nextOption = options[nextIndex]
+                                                val disabledOptions = item.disabledOptions ?: emptyList()
+                                                val enabledOptions = options.filterNot { it in disabledOptions }
 
-                                                cyclerStates[item.id] = state.copy(
-                                                    displayedOption = nextOption,
-                                                    job = coroutineScope.launch {
-                                                        delay(1000L)
+                                                if (enabledOptions.isNotEmpty()) {
+                                                    val currentDisplayed = state.displayedOption
+                                                    val currentIndexInEnabled = enabledOptions.indexOf(currentDisplayed)
 
-                                                        val finalItemState = scope.navItems.find { it.id == item.id } ?: item
-                                                        val currentStateInVm = finalItemState.selectedOption
-                                                        val targetState = nextOption
-
-                                                        val currentIndexInVm = options.indexOf(currentStateInVm)
-                                                        val targetIndex = options.indexOf(targetState)
-
-                                                        if (currentIndexInVm != -1 && targetIndex != -1) {
-                                                            val clicksToCatchUp = (targetIndex - currentIndexInVm + options.size) % options.size
-                                                            repeat(clicksToCatchUp) {
-                                                                item.onClick()
-                                                            }
-                                                        }
-
-                                                        onToggle()
-                                                        cyclerStates[item.id] = cyclerStates[item.id]!!.copy(job = null)
+                                                    val nextIndex = if (currentIndexInEnabled != -1) {
+                                                        (currentIndexInEnabled + 1) % enabledOptions.size
+                                                    } else {
+                                                        0
                                                     }
-                                                )
+                                                    val nextOption = enabledOptions[nextIndex]
+
+                                                    cyclerStates[item.id] = state.copy(
+                                                        displayedOption = nextOption,
+                                                        job = coroutineScope.launch {
+                                                            delay(1000L)
+
+                                                            val finalItemState = scope.navItems.find { it.id == item.id } ?: item
+                                                            val currentStateInVm = finalItemState.selectedOption
+                                                            val targetState = nextOption
+
+                                                            val currentIndexInVm = options.indexOf(currentStateInVm)
+                                                            val targetIndex = options.indexOf(targetState)
+
+                                                            if (currentIndexInVm != -1 && targetIndex != -1) {
+                                                                val clicksToCatchUp = (targetIndex - currentIndexInVm + options.size) % options.size
+                                                                repeat(clicksToCatchUp) {
+                                                                    item.onClick()
+                                                                }
+                                                            }
+
+                                                            onToggle()
+                                                            cyclerStates[item.id] = cyclerStates[item.id]!!.copy(job = null)
+                                                        }
+                                                    )
+                                                }
                                             }
                                         }
                                     } else {
@@ -318,22 +330,62 @@ fun AzNavRail(
                         }
                     }
                 } else {
-                    val railItems = remember(scope) { scope.navItems.filter { it.isRailItem } }
-                    LazyColumn(
-                        modifier = Modifier.padding(horizontal = AzNavRailDefaults.RailContentHorizontalPadding),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = if (scope.packRailButtons) Arrangement.Top else Arrangement.spacedBy(AzNavRailDefaults.RailContentVerticalArrangement, Alignment.CenterVertically)
+                    Column(
+                        modifier = Modifier
+                            .padding(horizontal = AzNavRailDefaults.RailContentHorizontalPadding)
+                            .verticalScroll(rememberScrollState()),
+                        horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        if (scope.packRailButtons) {
-                            items(railItems) { item ->
-                                RailContent(item = item, buttonSize = buttonSize)
+                        val onRailCyclerClick: (AzNavItem) -> Unit = { item ->
+                            val state = cyclerStates[item.id]
+                            if (state != null) {
+                                val options = requireNotNull(item.options) { "Cycler item '${item.id}' must have options" }
+                                val disabledOptions = item.disabledOptions ?: emptyList()
+                                val enabledOptions = options.filterNot { it in disabledOptions }
+
+                                if (enabledOptions.isNotEmpty()) {
+                                    val currentDisplayed = item.selectedOption
+                                    val currentIndexInEnabled = enabledOptions.indexOf(currentDisplayed)
+
+                                    val nextIndex = if (currentIndexInEnabled != -1) {
+                                        (currentIndexInEnabled + 1) % enabledOptions.size
+                                    } else {
+                                        0
+                                    }
+                                    val nextOption = enabledOptions[nextIndex]
+
+                                    val finalItemState = scope.navItems.find { it.id == item.id } ?: item
+                                    val currentStateInVm = finalItemState.selectedOption
+                                    val targetState = nextOption
+
+                                    val currentIndexInVm = options.indexOf(currentStateInVm)
+                                    val targetIndex = options.indexOf(targetState)
+
+                                    if (currentIndexInVm != -1 && targetIndex != -1) {
+                                        val clicksToCatchUp = (targetIndex - currentIndexInVm + options.size) % options.size
+                                        repeat(clicksToCatchUp) {
+                                            item.onClick()
+                                        }
+                                    }
+                                }
                             }
-                        } else {
-                            items(scope.navItems) { menuItem ->
-                                if (menuItem.isRailItem) {
-                                    RailContent(item = menuItem, buttonSize = buttonSize)
-                                } else {
-                                    Spacer(modifier = Modifier.height(AzNavRailDefaults.RailContentSpacerHeight))
+                        }
+
+                        EqualWidthLayout(
+                            verticalSpacing = if (scope.packRailButtons) 0.dp else AzNavRailDefaults.RailContentVerticalArrangement
+                        ) {
+                            if (scope.packRailButtons) {
+                                val railItems = scope.navItems.filter { it.isRailItem }
+                                railItems.forEach { item ->
+                                    RailContent(item = item, buttonSize = buttonSize, onRailCyclerClick = onRailCyclerClick)
+                                }
+                            } else {
+                                scope.navItems.forEach { menuItem ->
+                                    if (menuItem.isRailItem) {
+                                        RailContent(item = menuItem, buttonSize = buttonSize, onRailCyclerClick = onRailCyclerClick)
+                                    } else {
+                                        Spacer(modifier = Modifier.height(AzNavRailDefaults.RailContentSpacerHeight))
+                                    }
                                 }
                             }
                         }
@@ -362,17 +414,30 @@ fun AzNavRail(
  * @param buttonSize The size of the button.
  */
 @Composable
-private fun RailContent(item: AzNavItem, buttonSize: Dp) {
+private fun RailContent(
+    item: AzNavItem,
+    buttonSize: Dp,
+    onRailCyclerClick: (AzNavItem) -> Unit
+) {
     val textToShow = when {
         item.isToggle -> if (item.isChecked == true) item.toggleOnText else item.toggleOffText
         item.isCycler -> item.selectedOption ?: ""
         else -> item.text
     }
+
+    val onClick = if (item.isCycler) {
+        { onRailCyclerClick(item) }
+    } else {
+        item.onClick
+    }
+
     AzNavRailButton(
-        onClick = item.onClick,
+        onClick = onClick,
         text = textToShow,
         color = item.color ?: MaterialTheme.colorScheme.primary,
-        size = buttonSize
+        size = buttonSize,
+        shape = item.shape,
+        disabled = item.disabled
     )
 }
 
@@ -399,23 +464,32 @@ private fun MenuItem(
         item.isCycler -> item.selectedOption ?: ""
         else -> item.text
     }
-    val modifier = if (item.isToggle) {
-        Modifier.toggleable(
-            value = item.isChecked ?: false,
-            onValueChange = {
-                item.onClick()
-                onToggle()
-            }
-        )
-    } else {
-        Modifier.clickable {
-            if (item.isCycler) {
-                onCyclerClick()
-            } else {
-                item.onClick()
-                onToggle()
+
+    val modifier = if (item.disabled) Modifier else {
+        if (item.isToggle) {
+            Modifier.toggleable(
+                value = item.isChecked ?: false,
+                onValueChange = {
+                    item.onClick()
+                    onToggle()
+                }
+            )
+        } else {
+            Modifier.clickable {
+                if (item.isCycler) {
+                    onCyclerClick()
+                } else {
+                    item.onClick()
+                    onToggle()
+                }
             }
         }
+    }
+
+    val textColor = if (item.disabled) {
+        MaterialTheme.typography.bodyMedium.color.copy(alpha = 0.5f)
+    } else {
+        MaterialTheme.typography.bodyMedium.color
     }
 
     Row(
@@ -430,6 +504,7 @@ private fun MenuItem(
                 Text(
                     text = line,
                     style = MaterialTheme.typography.bodyMedium,
+                    color = textColor,
                     modifier = if (index > 0) Modifier.padding(start = 16.dp) else Modifier
                 )
             }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.runtime.Composable
@@ -18,6 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.model.AzButtonShape
 
 /**
  * A circular, text-only button with auto-sizing text, designed for the collapsed navigation rail.
@@ -27,6 +31,8 @@ import androidx.compose.ui.unit.dp
  * @param modifier The modifier to be applied to the button.
  * @param size The diameter of the circular button.
  * @param color The color of the button's border and text.
+ * @param shape The shape of the button.
+ * @param disabled Whether the button is disabled.
  */
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
@@ -35,24 +41,43 @@ fun AzNavRailButton(
     text: String,
     modifier: Modifier = Modifier,
     size: Dp = 72.dp,
-    color: Color = MaterialTheme.colorScheme.primary
+    color: Color = MaterialTheme.colorScheme.primary,
+    shape: AzButtonShape = AzButtonShape.CIRCLE,
+    disabled: Boolean = false
 ) {
+    val buttonShape = when (shape) {
+        AzButtonShape.CIRCLE -> CircleShape
+        AzButtonShape.SQUARE -> RoundedCornerShape(0.dp)
+        AzButtonShape.RECTANGLE -> RoundedCornerShape(0.dp)
+    }
+
+    val buttonModifier = when (shape) {
+        AzButtonShape.CIRCLE -> modifier.size(size).aspectRatio(1f)
+        AzButtonShape.SQUARE -> modifier.size(size).aspectRatio(1f)
+        AzButtonShape.RECTANGLE -> modifier.height(size).widthIn(min = size)
+    }
+
+    val disabledColor = color.copy(alpha = 0.5f)
+
     OutlinedButton(
         onClick = onClick,
-        modifier = modifier.size(size).aspectRatio(1f),
-        shape = CircleShape,
-        border = BorderStroke(3.dp, color),
+        modifier = buttonModifier,
+        shape = buttonShape,
+        border = BorderStroke(3.dp, if (disabled) disabledColor else color),
         colors = ButtonDefaults.outlinedButtonColors(
             containerColor = Color.Transparent,
-            contentColor = color
+            contentColor = if (disabled) disabledColor else color,
+            disabledContainerColor = Color.Transparent,
+            disabledContentColor = disabledColor
         ),
-        contentPadding = PaddingValues(8.dp)
+        contentPadding = PaddingValues(8.dp),
+        enabled = !disabled
     ) {
         AutoSizeText(
             text = text,
             style = MaterialTheme.typography.bodyMedium.copy(
                 textAlign = TextAlign.Center,
-                color = color
+                color = if (disabled) disabledColor else color
             ),
             modifier = Modifier.fillMaxSize(),
             maxLines = if (text.contains("\n")) Int.MAX_VALUE else 1,

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzNavItem
 
 /**
@@ -25,25 +26,29 @@ interface AzNavRailScope {
         expandedRailWidth: Dp = 260.dp,
         collapsedRailWidth: Dp = 80.dp,
         showFooter: Boolean = true,
-        isLoading: Boolean = false
+        isLoading: Boolean = false,
+        defaultShape: AzButtonShape = AzButtonShape.CIRCLE
     )
 
     /**
      * Adds a menu item that only appears in the expanded menu.
      * @param id The unique identifier for the item.
      * @param text The text to display for the item.
+     * @param disabled Whether the item is disabled.
      * @param onClick The callback to be invoked when the item is clicked.
      */
-    fun azMenuItem(id: String, text: String, onClick: () -> Unit)
+    fun azMenuItem(id: String, text: String, disabled: Boolean = false, onClick: () -> Unit)
 
     /**
      * Adds a rail item that appears in both the collapsed rail and the expanded menu.
      * @param id The unique identifier for the item.
      * @param text The text to display for the item.
      * @param color The color of the item.
+     * @param shape The shape of the button.
+     * @param disabled Whether the item is disabled.
      * @param onClick The callback to be invoked when the item is clicked.
      */
-    fun azRailItem(id: String, text: String, color: Color? = null, onClick: () -> Unit)
+    fun azRailItem(id: String, text: String, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, onClick: () -> Unit)
 
     /**
      * Adds a toggle item that only appears in the expanded menu. The text of the item changes to reflect the state.
@@ -51,9 +56,10 @@ interface AzNavRailScope {
      * @param isChecked Whether the toggle is in the "on" state.
      * @param toggleOnText The text to display when the toggle is on.
      * @param toggleOffText The text to display when the toggle is off.
+     * @param disabled Whether the item is disabled.
      * @param onClick The callback to be invoked when the item is clicked.
      */
-    fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit)
+    fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, disabled: Boolean = false, onClick: () -> Unit)
 
     /**
      * Adds a toggle item that appears in both the collapsed rail and the expanded menu. The text of the item changes to reflect the state.
@@ -62,9 +68,11 @@ interface AzNavRailScope {
      * @param isChecked Whether the toggle is in the "on" state.
      * @param toggleOnText The text to display when the toggle is on.
      * @param toggleOffText The text to display when the toggle is off.
+     * @param shape The shape of the button.
+     * @param disabled Whether the item is disabled.
      * @param onClick The callback to be invoked when the item is clicked.
      */
-    fun azRailToggle(id: String, color: Color? = null, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit)
+    fun azRailToggle(id: String, color: Color? = null, isChecked: Boolean, toggleOnText: String, toggleOffText: String, shape: AzButtonShape? = null, disabled: Boolean = false, onClick: () -> Unit)
 
     /**
      * Adds a cycler item that only appears in the expanded menu.
@@ -76,9 +84,11 @@ interface AzNavRailScope {
      * @param id The unique identifier for the item.
      * @param options The list of options to cycle through.
      * @param selectedOption The currently selected option.
+     * @param disabled Whether the item is disabled.
+     * @param disabledOptions The list of options to disable.
      * @param onClick The callback to be invoked for the final selected option after the delay.
      */
-    fun azMenuCycler(id: String, options: List<String>, selectedOption: String, onClick: () -> Unit)
+    fun azMenuCycler(id: String, options: List<String>, selectedOption: String, disabled: Boolean = false, disabledOptions: List<String>? = null, onClick: () -> Unit)
 
     /**
      * Adds a cycler item that appears in both the collapsed rail and the expanded menu.
@@ -91,9 +101,12 @@ interface AzNavRailScope {
      * @param color The color of the item.
      * @param options The list of options to cycle through.
      * @param selectedOption The currently selected option.
+     * @param shape The shape of the button.
+     * @param disabled Whether the item is disabled.
+     * @param disabledOptions The list of options to disable.
      * @param onClick The callback to be invoked for the final selected option after the delay.
      */
-    fun azRailCycler(id: String, color: Color? = null, options: List<String>, selectedOption: String, onClick: () -> Unit)
+    fun azRailCycler(id: String, color: Color? = null, options: List<String>, selectedOption: String, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, onClick: () -> Unit)
 
     /**
      * Adds a divider to the expanded menu.
@@ -109,6 +122,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     var collapsedRailWidth: Dp = 80.dp
     var showFooter: Boolean = true
     var isLoading: Boolean = false
+    var defaultShape: AzButtonShape = AzButtonShape.CIRCLE
 
     override fun azSettings(
         displayAppNameInHeader: Boolean,
@@ -116,7 +130,8 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         expandedRailWidth: Dp,
         collapsedRailWidth: Dp,
         showFooter: Boolean,
-        isLoading: Boolean
+        isLoading: Boolean,
+        defaultShape: AzButtonShape
     ) {
         require(expandedRailWidth > collapsedRailWidth) {
             """
@@ -135,9 +150,10 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         this.collapsedRailWidth = collapsedRailWidth
         this.showFooter = showFooter
         this.isLoading = isLoading
+        this.defaultShape = defaultShape
     }
 
-    override fun azMenuItem(id: String, text: String, onClick: () -> Unit) {
+    override fun azMenuItem(id: String, text: String, disabled: Boolean, onClick: () -> Unit) {
         require(text.isNotEmpty()) {
             """
             `text` must not be empty.
@@ -150,10 +166,10 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
             )
             """.trimIndent()
         }
-        navItems.add(AzNavItem(id = id, text = text, isRailItem = false, onClick = onClick))
+        navItems.add(AzNavItem(id = id, text = text, isRailItem = false, disabled = disabled, onClick = onClick))
     }
 
-    override fun azRailItem(id: String, text: String, color: Color?, onClick: () -> Unit) {
+    override fun azRailItem(id: String, text: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, onClick: () -> Unit) {
         require(text.isNotEmpty()) {
             """
             `text` must not be empty.
@@ -166,10 +182,10 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
             )
             """.trimIndent()
         }
-        navItems.add(AzNavItem(id = id, text = text, isRailItem = true, color = color, onClick = onClick))
+        navItems.add(AzNavItem(id = id, text = text, isRailItem = true, color = color, shape = shape ?: defaultShape, disabled = disabled, onClick = onClick))
     }
 
-    override fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit) {
+    override fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, disabled: Boolean, onClick: () -> Unit) {
         require(toggleOnText.isNotEmpty() && toggleOffText.isNotEmpty()) {
             """
             `toggleOnText` and `toggleOffText` must not be empty.
@@ -184,10 +200,10 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
             )
             """.trimIndent()
         }
-        navItems.add(AzNavItem(id = id, text = "", isRailItem = false, isToggle = true, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, onClick = onClick))
+        navItems.add(AzNavItem(id = id, text = "", isRailItem = false, isToggle = true, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, disabled = disabled, onClick = onClick))
     }
 
-    override fun azRailToggle(id: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, onClick: () -> Unit) {
+    override fun azRailToggle(id: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, shape: AzButtonShape?, disabled: Boolean, onClick: () -> Unit) {
         require(toggleOnText.isNotEmpty() && toggleOffText.isNotEmpty()) {
             """
             `toggleOnText` and `toggleOffText` must not be empty.
@@ -202,10 +218,10 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
             )
             """.trimIndent()
         }
-        navItems.add(AzNavItem(id = id, text = "", isRailItem = true, color = color, isToggle = true, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, onClick = onClick))
+        navItems.add(AzNavItem(id = id, text = "", isRailItem = true, color = color, isToggle = true, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, shape = shape ?: defaultShape, disabled = disabled, onClick = onClick))
     }
 
-    override fun azMenuCycler(id: String, options: List<String>, selectedOption: String, onClick: () -> Unit) {
+    override fun azMenuCycler(id: String, options: List<String>, selectedOption: String, disabled: Boolean, disabledOptions: List<String>?, onClick: () -> Unit) {
         require(selectedOption in options) {
             """
             `selectedOption` must be one of the provided options.
@@ -219,10 +235,10 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
             )
             """.trimIndent()
         }
-        navItems.add(AzNavItem(id = id, text = "", isRailItem = false, isCycler = true, options = options, selectedOption = selectedOption, onClick = onClick))
+        navItems.add(AzNavItem(id = id, text = "", isRailItem = false, isCycler = true, options = options, selectedOption = selectedOption, disabled = disabled, disabledOptions = disabledOptions, onClick = onClick))
     }
 
-    override fun azRailCycler(id: String, color: Color?, options: List<String>, selectedOption: String, onClick: () -> Unit) {
+    override fun azRailCycler(id: String, color: Color?, options: List<String>, selectedOption: String, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, onClick: () -> Unit) {
         require(selectedOption in options) {
             """
             `selectedOption` must be one of the provided options.
@@ -236,7 +252,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
             )
             """.trimIndent()
         }
-        navItems.add(AzNavItem(id = id, text = "", isRailItem = true, color = color, isCycler = true, options = options, selectedOption = selectedOption, onClick = onClick))
+        navItems.add(AzNavItem(id = id, text = "", isRailItem = true, color = color, isCycler = true, options = options, selectedOption = selectedOption, shape = shape ?: defaultShape, disabled = disabled, disabledOptions = disabledOptions, onClick = onClick))
     }
 
     override fun azDivider() {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzButtonShape.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzButtonShape.kt
@@ -1,0 +1,10 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * Represents the shape of a rail button.
+ */
+enum class AzButtonShape {
+    CIRCLE,
+    SQUARE,
+    RECTANGLE
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
@@ -35,5 +35,8 @@ data class AzNavItem(
     val selectedOption: String? = null,
     val isDivider: Boolean = false,
     val collapseOnClick: Boolean = true,
+    val shape: AzButtonShape = AzButtonShape.CIRCLE,
+    val disabled: Boolean = false,
+    val disabledOptions: List<String>? = null,
     val onClick: () -> Unit
 )

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/util/EqualWidthLayout.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/util/EqualWidthLayout.kt
@@ -1,0 +1,36 @@
+package com.hereliesaz.aznavrail.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+@Composable
+fun EqualWidthLayout(
+    modifier: Modifier = Modifier,
+    verticalSpacing: Dp = 0.dp,
+    content: @Composable () -> Unit
+) {
+    SubcomposeLayout(modifier = modifier) { constraints ->
+        val placeables = subcompose(Unit, content).map { it.measure(constraints) }
+
+        val maxWidth = placeables.maxOfOrNull { it.width } ?: 0
+        val newConstraints = constraints.copy(minWidth = maxWidth, maxWidth = maxWidth)
+
+        val newPlaceables = subcompose(Unit, content).map { it.measure(newConstraints) }
+
+        val spacingPx = verticalSpacing.toPx()
+        val totalHeight = (newPlaceables.sumOf { it.height } + (spacingPx * (newPlaceables.size - 1))).coerceAtLeast(0f)
+
+        layout(newConstraints.maxWidth, totalHeight.roundToInt()) {
+            var y = 0f
+            newPlaceables.forEach { placeable ->
+                placeable.place(0, y.roundToInt())
+                y += placeable.height + spacingPx
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Fixes a regression where the vertical spacing between rail items was no longer applied.
- Fixes a bug where disabled cycler options were not handled correctly in the collapsed rail.
- Removes a redundant disabled check in the cycler's click handler.
- Restores the detailed API reference and the section on standalone components to the `README.md` file.
- Restores the original, more humorous introduction to the `README.md` file.