### PR TITLE
feat(AzNavRail): Add system bar padding and screen title features

### DIFF
--- a/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
+++ b/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
@@ -51,11 +51,13 @@ fun SampleScreen() {
                 displayAppNameInHeader = true,
                 packRailButtons = false,
                 isLoading = isLoading,
-                defaultShape = AzButtonShape.RECTANGLE // Set a default shape for all rail items
+                defaultShape = AzButtonShape.RECTANGLE, // Set a default shape for all rail items
+                systemBarsPadding = true,
+                displayScreenTitle = true
             )
 
             // A standard menu item
-            azMenuItem(id = "home", text = "Home", onClick = { /* ... */ })
+            azMenuItem(id = "home", text = "Home", onClick = { /* ... */ }, screenTitle = "My Home")
 
             // A rail item with the default shape (RECTANGLE)
             azRailItem(id = "favorites", text = "Favorites", onClick = { /* ... */ })

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -19,6 +19,8 @@ interface AzNavRailScope {
      * @param collapsedRailWidth The width of the rail when it is collapsed.
      * @param showFooter Whether to show the footer.
      * @param isLoading Whether to show the loading animation.
+     * @param systemBarsPadding Whether to apply padding for the system bars.
+     * @param displayScreenTitle Whether to display the screen title.
      */
     fun azSettings(
         displayAppNameInHeader: Boolean = false,
@@ -27,7 +29,9 @@ interface AzNavRailScope {
         collapsedRailWidth: Dp = 80.dp,
         showFooter: Boolean = true,
         isLoading: Boolean = false,
-        defaultShape: AzButtonShape = AzButtonShape.CIRCLE
+        defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
+        systemBarsPadding: Boolean = true,
+        displayScreenTitle: Boolean = true
     )
 
     /**
@@ -36,8 +40,9 @@ interface AzNavRailScope {
      * @param text The text to display for the item.
      * @param disabled Whether the item is disabled.
      * @param onClick The callback to be invoked when the item is clicked.
+     * @param screenTitle The title to display on the screen when this item is selected.
      */
-    fun azMenuItem(id: String, text: String, disabled: Boolean = false, onClick: () -> Unit)
+    fun azMenuItem(id: String, text: String, disabled: Boolean = false, onClick: () -> Unit, screenTitle: String? = null)
 
     /**
      * Adds a rail item that appears in both the collapsed rail and the expanded menu.
@@ -47,8 +52,9 @@ interface AzNavRailScope {
      * @param shape The shape of the button.
      * @param disabled Whether the item is disabled.
      * @param onClick The callback to be invoked when the item is clicked.
+     * @param screenTitle The title to display on the screen when this item is selected.
      */
-    fun azRailItem(id: String, text: String, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, onClick: () -> Unit)
+    fun azRailItem(id: String, text: String, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, onClick: () -> Unit, screenTitle: String? = null)
 
     /**
      * Adds a toggle item that only appears in the expanded menu. The text of the item changes to reflect the state.
@@ -123,6 +129,8 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     var showFooter: Boolean = true
     var isLoading: Boolean = false
     var defaultShape: AzButtonShape = AzButtonShape.CIRCLE
+    var systemBarsPadding: Boolean = true
+    var displayScreenTitle: Boolean = true
 
     override fun azSettings(
         displayAppNameInHeader: Boolean,
@@ -131,7 +139,9 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         collapsedRailWidth: Dp,
         showFooter: Boolean,
         isLoading: Boolean,
-        defaultShape: AzButtonShape
+        defaultShape: AzButtonShape,
+        systemBarsPadding: Boolean,
+        displayScreenTitle: Boolean
     ) {
         require(expandedRailWidth > collapsedRailWidth) {
             """
@@ -151,9 +161,11 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         this.showFooter = showFooter
         this.isLoading = isLoading
         this.defaultShape = defaultShape
+        this.systemBarsPadding = systemBarsPadding
+        this.displayScreenTitle = displayScreenTitle
     }
 
-    override fun azMenuItem(id: String, text: String, disabled: Boolean, onClick: () -> Unit) {
+    override fun azMenuItem(id: String, text: String, disabled: Boolean, onClick: () -> Unit, screenTitle: String?) {
         require(text.isNotEmpty()) {
             """
             `text` must not be empty.
@@ -166,10 +178,10 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
             )
             """.trimIndent()
         }
-        navItems.add(AzNavItem(id = id, text = text, isRailItem = false, disabled = disabled, onClick = onClick))
+        navItems.add(AzNavItem(id = id, text = text, isRailItem = false, disabled = disabled, onClick = onClick, screenTitle = screenTitle))
     }
 
-    override fun azRailItem(id: String, text: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, onClick: () -> Unit) {
+    override fun azRailItem(id: String, text: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, onClick: () -> Unit, screenTitle: String?) {
         require(text.isNotEmpty()) {
             """
             `text` must not be empty.
@@ -182,7 +194,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
             )
             """.trimIndent()
         }
-        navItems.add(AzNavItem(id = id, text = text, isRailItem = true, color = color, shape = shape ?: defaultShape, disabled = disabled, onClick = onClick))
+        navItems.add(AzNavItem(id = id, text = text, isRailItem = true, color = color, shape = shape ?: defaultShape, disabled = disabled, onClick = onClick, screenTitle = screenTitle))
     }
 
     override fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, disabled: Boolean, onClick: () -> Unit) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
@@ -38,5 +38,6 @@ data class AzNavItem(
     val shape: AzButtonShape = AzButtonShape.CIRCLE,
     val disabled: Boolean = false,
     val disabledOptions: List<String>? = null,
+    val screenTitle: String? = null,
     val onClick: () -> Unit
 )

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
@@ -36,7 +36,7 @@ class AzNavRailTest {
     @Test
     fun `azMenuItem should add a menu item`() {
         val scope = AzNavRailScopeImpl()
-        scope.azMenuItem("home", "Home") {}
+        scope.azMenuItem("home", "Home", onClick = {})
         val expectedItem = AzNavItem("home", "Home", isRailItem = false, onClick = {})
         assertEquals(expectedItem.id, scope.navItems[0].id)
         assertEquals(expectedItem.text, scope.navItems[0].text)
@@ -46,13 +46,13 @@ class AzNavRailTest {
     @Test(expected = IllegalArgumentException::class)
     fun `azMenuItem with empty text should throw exception`() {
         val scope = AzNavRailScopeImpl()
-        scope.azMenuItem("home", "") {}
+        scope.azMenuItem("home", "", onClick = {})
     }
 
     @Test
     fun `azRailItem should add a rail item`() {
         val scope = AzNavRailScopeImpl()
-        scope.azRailItem("home", "Home", Color.Red) {}
+        scope.azRailItem("home", "Home", Color.Red, onClick = {})
         val expectedItem = AzNavItem("home", "Home", isRailItem = true, color = Color.Red, onClick = {})
         assertEquals(expectedItem.id, scope.navItems[0].id)
         assertEquals(expectedItem.text, scope.navItems[0].text)
@@ -63,7 +63,7 @@ class AzNavRailTest {
     @Test(expected = IllegalArgumentException::class)
     fun `azRailItem with empty text should throw exception`() {
         val scope = AzNavRailScopeImpl()
-        scope.azRailItem("home", "") {}
+        scope.azRailItem("home", "", onClick = {})
     }
 
     @Test


### PR DESCRIPTION
Adds two new optional features to the AzNavRail component:

- System bar padding: Automatically adds padding to avoid overlapping with the system status and navigation bars. This can be controlled with the `systemBarsPadding` option in `azSettings`.
- Screen title: Displays a screen title at the top-right of the screen, derived from the selected navigation item's text. This can be controlled with the `displayScreenTitle` option in `azSettings`, and a custom title can be provided using the `screenTitle` parameter on `azMenuItem` and `azRailItem`.