### PR TITLE
Update AzNavRail dependency version to 3.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ And add the dependency to your app's `build.gradle.kts`:
 ```kotlin
 dependencies {
 
-    implementation("com.github.HereLiesAz:AzNavRail:3.14") // Or the latest version
+    implementation("com.github.HereLiesAz:AzNavRail:3.15") // Or the latest version
 }
 ```
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Bump AzNavRail dependency version from 3.14 to 3.15 in the README