### PR TITLE
feat(AzNavRail): Center AzLoad animation and add padding to rectangul…

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzLoad.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzLoad.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 @Composable
-fun AzLoad(modifier: Modifier = Modifier) {
+fun AzLoad() {
     val infiniteTransition = rememberInfiniteTransition()
     val rotationY by infiniteTransition.animateFloat(
         initialValue = 0f,
@@ -30,7 +30,7 @@ fun AzLoad(modifier: Modifier = Modifier) {
     )
 
     Box(
-        modifier = modifier
+        modifier = Modifier
             .size(120.dp)
             .graphicsLayer {
                 this.rotationY = rotationY

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -38,10 +38,15 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
@@ -96,6 +101,19 @@ private data class CyclerTransientState(
     val displayedOption: String,
     val job: Job? = null
 )
+
+private object CenteredPopupPositionProvider : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize
+    ): IntOffset {
+        val x = (windowSize.width - popupContentSize.width) / 2
+        val y = (windowSize.height - popupContentSize.height) / 2
+        return IntOffset(x, y)
+    }
+}
 
 /**
  * An M3-style navigation rail that expands into a menu drawer.
@@ -242,10 +260,12 @@ fun AzNavRail(
         }
         if (scope.isLoading) {
             Popup(
-                alignment = Alignment.Center,
+                popupPositionProvider = CenteredPopupPositionProvider,
                 properties = PopupProperties(focusable = false)
             ) {
-                AzLoad(modifier = Modifier.fillMaxSize())
+                Box(contentAlignment = Alignment.Center) {
+                    AzLoad()
+                }
             }
         }
         Row(
@@ -508,15 +528,19 @@ private fun RailContent(
         }
     }
 
-    AzNavRailButton(
-        onClick = onClick,
-        text = textToShow,
-        color = item.color ?: MaterialTheme.colorScheme.primary,
-        size = buttonSize,
-        shape = item.shape,
-        disabled = item.disabled,
-        isSelected = isSelected
-    )
+    Box(
+        modifier = if (item.shape == AzButtonShape.RECTANGLE) Modifier.padding(vertical = 2.dp) else Modifier
+    ) {
+        AzNavRailButton(
+            onClick = onClick,
+            text = textToShow,
+            color = item.color ?: MaterialTheme.colorScheme.primary,
+            size = buttonSize,
+            shape = item.shape,
+            disabled = item.disabled,
+            isSelected = isSelected
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
…ar buttons

This commit addresses two separate UI issues:

1.  **AzLoad Animation:** The `AzLoad` loading animation was previously displayed full-screen, causing the circular progress indicator to become distorted. This has been fixed by:
    *   Implementing a custom `PopupPositionProvider` to ensure the `Popup` is always centered on the screen.
    *   Giving the `AzLoad` composable a fixed size of `120.dp` to ensure it is always rendered as a square.
    *   Removing the `modifier` parameter from `AzLoad` to prevent the size from being overridden.

2.  **Rectangular Button Padding:** Rectangular buttons in the navigation rail were lacking vertical spacing. This has been addressed by adding `2.dp` of vertical padding to all rectangular rail items.

These changes ensure the loading animation is always displayed correctly and that the rectangular rail items have proper spacing, improving the overall visual presentation of the UI.