### PR TITLE
feat: Add HostItem and SubItem types

### DIFF
--- a/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
+++ b/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
@@ -143,12 +143,30 @@ fun SampleScreen() {
 
             // A button to demonstrate the loading state
             azRailItem(id = "loading", text = "Load", route = "loading", onClick = { isLoading = !isLoading })
+
+            azDivider()
+
+            azMenuHostItem(id = "menu-host", text = "Menu Host") {
+                // TODO: Handle host click
+            }
+            azMenuSubItem(id = "menu-sub-1", hostId = "menu-host", text = "Menu Sub 1", route = "menu-sub-1")
+            azMenuSubItem(id = "menu-sub-2", hostId = "menu-host", text = "Menu Sub 2", route = "menu-sub-2")
+
+            azRailHostItem(id = "rail-host", text = "Rail Host") {
+                // TODO: Handle host click
+            }
+            azRailSubItem(id = "rail-sub-1", hostId = "rail-host", text = "Rail Sub 1", route = "rail-sub-1")
+            azMenuSubItem(id = "rail-sub-2", hostId = "rail-host", text = "Rail Sub 2", route = "rail-sub-2")
         }
 
         // Your app's main content goes here
         NavHost(navController = navController, startDestination = "home") {
             composable("home") { Text("Home Screen") }
             composable("multi-line") { Text("Multi-line Screen") }
+            composable("menu-sub-1") { Text("Menu Sub 1 Screen") }
+            composable("menu-sub-2") { Text("Menu Sub 2 Screen") }
+            composable("rail-sub-1") { Text("Rail Sub 1 Screen") }
+            composable("rail-sub-2") { Text("Rail Sub 2 Screen") }
             composable("favorites") { Text("Favorites Screen") }
             composable("profile") { Text("Profile Screen") }
             composable("online") { Text("Online Screen") }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -3,6 +3,7 @@ package com.hereliesaz.aznavrail
 import android.annotation.SuppressLint
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -44,7 +45,8 @@ fun AzNavRailButton(
     color: Color = MaterialTheme.colorScheme.primary,
     shape: AzButtonShape = AzButtonShape.CIRCLE,
     disabled: Boolean = false,
-    isSelected: Boolean = false
+    isSelected: Boolean = false,
+    content: @Composable () -> Unit = {}
 ) {
     val buttonShape = when (shape) {
         AzButtonShape.CIRCLE -> CircleShape
@@ -76,17 +78,20 @@ fun AzNavRailButton(
         contentPadding = PaddingValues(8.dp),
         enabled = !disabled
     ) {
-        AutoSizeText(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium.copy(
-                textAlign = TextAlign.Center,
-                color = if (disabled) disabledColor else finalColor
-            ),
-            modifier = Modifier.fillMaxSize(),
-            maxLines = if (text.contains("\n")) Int.MAX_VALUE else 1,
-            softWrap = false,
-            alignment = Alignment.Center,
-            lineSpaceRatio = 0.9f
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            AutoSizeText(
+                text = text,
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    textAlign = TextAlign.Center,
+                    color = if (disabled) disabledColor else finalColor
+                ),
+                modifier = Modifier.weight(1f),
+                maxLines = if (text.contains("\n")) Int.MAX_VALUE else 1,
+                softWrap = false,
+                alignment = Alignment.Center,
+                lineSpaceRatio = 0.9f
+            )
+            content()
+        }
     }
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -134,6 +134,65 @@ interface AzNavRailScope {
      * Adds a divider to the expanded menu.
      */
     fun azDivider()
+
+    /**
+     * Adds a host item that only appears in the expanded menu.
+     * @param id The unique identifier for the item.
+     * @param text The text to display for the item.
+     * @param disabled Whether the item is disabled.
+     * @param onClick The callback to be invoked when the item is clicked.
+     * @param screenTitle The text to display as the screen title when this item is selected.
+     * @param route The route to navigate to when the item is clicked.
+     */
+    fun azMenuHostItem(id: String, text: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+    fun azMenuHostItem(id: String, text: String, route: String, disabled: Boolean = false, screenTitle: String? = null)
+    fun azMenuHostItem(id: String, text: String, route: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+
+
+    /**
+     * Adds a host item that appears in both the collapsed rail and the expanded menu.
+     * @param id The unique identifier for the item.
+     * @param text The text to display for the item.
+     * @param color The color of the item.
+     * @param shape The shape of the button.
+     * @param disabled Whether the item is disabled.
+     * @param onClick The callback to be invoked when the item is clicked.
+     * @param screenTitle The text to display as the screen title when this item is selected.
+     * @param route The route to navigate to when the item is clicked.
+     */
+    fun azRailHostItem(id: String, text: String, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+    fun azRailHostItem(id: String, text: String, route: String, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null)
+    fun azRailHostItem(id: String, text: String, route: String, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+
+
+    /**
+     * Adds a sub item that only appears in the expanded menu.
+     * @param id The unique identifier for the item.
+     * @param hostId The unique identifier of the host item.
+     * @param text The text to display for the item.
+     * @param disabled Whether the item is disabled.
+     * @param onClick The callback to be invoked when the item is clicked.
+     * @param screenTitle The text to display as the screen title when this item is selected.
+     * @param route The route to navigate to when the item is clicked.
+     */
+    fun azMenuSubItem(id: String, hostId: String, text: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+    fun azMenuSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean = false, screenTitle: String? = null)
+    fun azMenuSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+
+
+    /**
+     * Adds a sub item that appears in both the collapsed rail and the expanded menu.
+     * @param id The unique identifier for the item.
+     * @param hostId The unique identifier of the host item.
+     * @param text The text to display for the item.
+     * @param disabled Whether the item is disabled.
+     * @param onClick The callback to be invoked when the item is clicked.
+     * @param screenTitle The text to display as the screen title when this item is selected.
+     * @param route The route to navigate to when the item is clicked.
+     */
+    fun azRailSubItem(id: String, hostId: String, text: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+    fun azRailSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean = false, screenTitle: String? = null)
+    fun azRailSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
 }
 
 internal class AzNavRailScopeImpl : AzNavRailScope {
@@ -366,5 +425,107 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
 
     override fun azDivider() {
         navItems.add(AzNavItem(id = "divider_${navItems.size}", text = "", isRailItem = false, isDivider = true))
+    }
+
+    override fun azMenuHostItem(id: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addMenuHostItem(id, text, null, disabled, screenTitle, onClick)
+    }
+
+    override fun azMenuHostItem(id: String, text: String, route: String, disabled: Boolean, screenTitle: String?) {
+        addMenuHostItem(id, text, route, disabled, screenTitle) {}
+    }
+
+    override fun azMenuHostItem(id: String, text: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addMenuHostItem(id, text, route, disabled, screenTitle, onClick)
+    }
+
+    private fun addMenuHostItem(id: String, text: String, route: String?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addItem(id = id, text = text, route = route, screenTitle = screenTitle, isRailItem = false, disabled = disabled, isHost = true, onClick = onClick)
+    }
+
+    override fun azRailHostItem(id: String, text: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addRailHostItem(id, text, null, color, shape, disabled, screenTitle, onClick)
+    }
+
+    override fun azRailHostItem(id: String, text: String, route: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?) {
+        addRailHostItem(id, text, route, color, shape, disabled, screenTitle) {}
+    }
+
+    override fun azRailHostItem(id: String, text: String, route: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addRailHostItem(id, text, route, color, shape, disabled, screenTitle, onClick)
+    }
+
+    private fun addRailHostItem(id: String, text: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addItem(id = id, text = text, route = route, screenTitle = screenTitle, isRailItem = true, color = color, shape = shape, disabled = disabled, isHost = true, onClick = onClick)
+    }
+
+    override fun azMenuSubItem(id: String, hostId: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addMenuSubItem(id, hostId, text, null, disabled, screenTitle, onClick)
+    }
+
+    override fun azMenuSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean, screenTitle: String?) {
+        addMenuSubItem(id, hostId, text, route, disabled, screenTitle) {}
+    }
+
+    override fun azMenuSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addMenuSubItem(id, hostId, text, route, disabled, screenTitle, onClick)
+    }
+
+    private fun addMenuSubItem(id: String, hostId: String, text: String, route: String?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addItem(id = id, text = text, route = route, screenTitle = screenTitle, isRailItem = false, disabled = disabled, isSubItem = true, hostId = hostId, shape = AzButtonShape.NONE, onClick = onClick)
+    }
+
+    override fun azRailSubItem(id: String, hostId: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addRailSubItem(id, hostId, text, null, disabled, screenTitle, onClick)
+    }
+
+    override fun azRailSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean, screenTitle: String?) {
+        addRailSubItem(id, hostId, text, route, disabled, screenTitle) {}
+    }
+
+    override fun azRailSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addRailSubItem(id, hostId, text, route, disabled, screenTitle, onClick)
+    }
+
+    private fun addRailSubItem(id: String, hostId: String, text: String, route: String?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addItem(id = id, text = text, route = route, screenTitle = screenTitle, isRailItem = true, disabled = disabled, isSubItem = true, hostId = hostId, shape = AzButtonShape.NONE, onClick = onClick)
+    }
+
+    private fun addItem(
+        id: String,
+        text: String,
+        route: String?,
+        screenTitle: String?,
+        isRailItem: Boolean,
+        color: Color? = null,
+        shape: AzButtonShape? = null,
+        disabled: Boolean = false,
+        isHost: Boolean = false,
+        isSubItem: Boolean = false,
+        hostId: String? = null,
+        onClick: () -> Unit
+    ) {
+        require(text.isNotEmpty()) {
+            """
+            `text` must not be empty for item with id `$id`.
+            """.trimIndent()
+        }
+        val finalScreenTitle = if (screenTitle == AzNavRail.noTitle) null else screenTitle ?: text
+        onClickMap[id] = onClick
+        navItems.add(
+            AzNavItem(
+                id = id,
+                text = text,
+                route = route,
+                screenTitle = finalScreenTitle,
+                isRailItem = isRailItem,
+                color = color,
+                shape = shape ?: defaultShape,
+                disabled = disabled,
+                isHost = isHost,
+                isSubItem = isSubItem,
+                hostId = hostId
+            )
+        )
     }
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
@@ -43,5 +43,9 @@ data class AzNavItem(
     val collapseOnClick: Boolean = true,
     val shape: AzButtonShape = AzButtonShape.CIRCLE,
     val disabled: Boolean = false,
-    val disabledOptions: List<String>? = null
+    val disabledOptions: List<String>? = null,
+    val isHost: Boolean = false,
+    val isSubItem: Boolean = false,
+    val hostId: String? = null,
+    val isExpanded: Boolean = false
 ) : Parcelable


### PR DESCRIPTION
Adds `HostItem` and `SubItem` types to the navigation rail.

A `HostItem` can be clicked to reveal its `SubItem`s.

`SubItem`s are forced to have a "none" shape.

The expansion of the host to reveal its subs is animated.