### PR TITLE
feat: Update documentation and enable draggable rail [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This "navigrenuail" provides a vertical navigation rail that expands to a full m
 - **Standalone Components**: Use `AzButton`, `AzToggle`, `AzCycler`, and `AzDivider` on their own.
 - **Jetpack Navigation Integration**: Seamlessly integrate with Jetpack Navigation using the `navController`.
 - **Hierarchical Navigation**: Create nested menus with host and sub-items.
+- **Draggable Rail**: The rail can be detached and moved around the screen.
 
 ## AzNavRail for Android (Jetpack Compose)
 
@@ -88,7 +89,8 @@ fun SampleScreen() {
                 // displayAppNameInHeader = true, // Set to true to display the app name instead of the icon
                 packRailButtons = false,
                 isLoading = isLoading,
-                defaultShape = AzButtonShape.RECTANGLE // Set a default shape for all rail items
+                defaultShape = AzButtonShape.RECTANGLE, // Set a default shape for all rail items
+                enableRailDragging = true // Enable the draggable rail feature
             )
 
             // A standard menu item - only appears in the expanded menu
@@ -174,6 +176,29 @@ fun SampleScreen() {
             azRailHostItem(id = "rail-host", text = "Rail Host", route = "rail-host")
             azRailSubItem(id = "rail-sub-1", hostId = "rail-host", text = "Rail Sub 1", route = "rail-sub-1")
             azMenuSubItem(id = "rail-sub-2", hostId = "rail-host", text = "Menu Sub 2", route = "rail-sub-2")
+
+            azMenuSubToggle(
+                id = "sub-toggle",
+                hostId = "menu-host",
+                isChecked = isDarkMode,
+                toggleOnText = "Sub Toggle On",
+                toggleOffText = "Sub Toggle Off",
+                route = "sub-toggle",
+                onClick = { isDarkMode = !isDarkMode }
+            )
+
+            azRailSubCycler(
+                id = "sub-cycler",
+                hostId = "rail-host",
+                options = menuCycleOptions,
+                selectedOption = menuSelectedOption,
+                route = "sub-cycler",
+                onClick = {
+                    val currentIndex = menuCycleOptions.indexOf(menuSelectedOption)
+                    val nextIndex = (currentIndex + 1) % menuCycleOptions.size
+                    menuSelectedOption = menuCycleOptions[nextIndex]
+                }
+            )
         }
 
         // Your app's main content goes here
@@ -193,6 +218,8 @@ fun SampleScreen() {
             composable("rail-host") { Text("Rail Host Screen") }
             composable("rail-sub-1") { Text("Rail Sub 1 Screen") }
             composable("rail-sub-2") { Text("Rail Sub 2 Screen") }
+            composable("sub-toggle") { Text("Sub Toggle Screen") }
+            composable("sub-cycler") { Text("Sub Cycler Screen") }
         }
     }
 }
@@ -204,6 +231,12 @@ fun SampleScreen() {
 
 -   **Host Items**: These are top-level items that can contain sub-items. They can be placed in the rail or the menu.
 -   **Sub-Items**: These are nested items that are only visible when their host item is expanded. They can also be placed in the rail or the menu.
+
+### Draggable Rail
+
+The rail can be detached and moved around the screen by long-pressing the header icon. To enable this feature, set `enableRailDragging = true` in the `azSettings` block.
+
+When the rail is in its floating state, the rail buttons will be hidden. A single tap on the header icon will toggle their visibility. To snap the rail back to its original position, drag it near the top-left corner of the screen.
 
 ### API Reference
 
@@ -238,7 +271,7 @@ The DSL for configuring the `AzNavRail`.
 
 **Note:** Functions prefixed with `azMenu` will only appear in the expanded menu view. Functions prefixed with `azRail` will appear on the collapsed rail, and their text will be used as the label in the expanded menu.
 
--   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean, defaultShape: AzButtonShape)`: Configures the settings for the `AzNavRail`.
+-   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean, defaultShape: AzButtonShape, enableRailDragging: Boolean)`: Configures the settings for the `AzNavRail`.
 -   `azMenuItem(id: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
 -   `azMenuItem(id: String, text: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
 -   `azRailItem(id: String, text: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text in the expanded menu.
@@ -262,6 +295,14 @@ The DSL for configuring the `AzNavRail`.
 -   `azMenuSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a sub item that only appears in the expanded menu.
 -   `azRailSubItem(id: String, hostId: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a sub item that appears in both the collapsed rail and the expanded menu.
 -   `azRailSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a sub item that appears in both the collapsed rail and the expanded menu.
+-   `azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a toggle sub-item that only appears in the expanded menu.
+-   `azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a toggle sub-item that only appears in the expanded menu.
+-   `azRailSubToggle(id: String, hostId: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a toggle sub-item that appears in both the collapsed rail and the expanded menu.
+-   `azRailSubToggle(id: String, hostId: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, shape: AzButtonShape?, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a toggle sub-item that appears in both the collapsed rail and the expanded menu.
+-   `azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit)`: Adds a cycler sub-item that only appears in the expanded menu.
+-   `azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit)`: Adds a cycler sub-item that only appears in the expanded menu.
+-   `azRailSubCycler(id: String, hostId: String, color: Color?, options: List<String>, selectedOption: String, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit)`: Adds a cycler sub-item that appears in both the collapsed rail and the expanded menu.
+-   `azRailSubCycler(id: String, hostId: String, color: Color?, options: List<String>, selectedOption: String, shape: AzButtonShape?, route: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit)`: Adds a cycler sub-item that appears in both the collapsed rail and the expanded menu.
 
 ## AzNavRail for Web (React)
 

--- a/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
+++ b/SampleApp/src/main/java/com/example/sampleapp/MainActivity.kt
@@ -68,7 +68,8 @@ fun SampleScreen() {
                 // displayAppNameInHeader = true, // Set to true to display the app name instead of the icon
                 packRailButtons = packRailButtons,
                 isLoading = isLoading,
-                defaultShape = AzButtonShape.RECTANGLE // Set a default shape for all rail items
+                defaultShape = AzButtonShape.RECTANGLE, // Set a default shape for all rail items
+                enableRailDragging = true
             )
 
             // A standard menu item - only appears in the expanded menu

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -28,7 +28,8 @@ interface AzNavRailScope {
         collapsedRailWidth: Dp = 80.dp,
         showFooter: Boolean = true,
         isLoading: Boolean = false,
-        defaultShape: AzButtonShape = AzButtonShape.CIRCLE
+        defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
+        enableRailDragging: Boolean = false
     )
 
     /**
@@ -193,6 +194,22 @@ interface AzNavRailScope {
     fun azRailSubItem(id: String, hostId: String, text: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
     fun azRailSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean = false, screenTitle: String? = null)
     fun azRailSubItem(id: String, hostId: String, text: String, route: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+
+    fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+    fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+    fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String, disabled: Boolean = false, screenTitle: String? = null)
+
+    fun azRailSubToggle(id: String, hostId: String, color: Color? = null, isChecked: Boolean, toggleOnText: String, toggleOffText: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+    fun azRailSubToggle(id: String, hostId: String, color: Color? = null, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String, disabled: Boolean = false, screenTitle: String? = null, onClick: () -> Unit)
+    fun azRailSubToggle(id: String, hostId: String, color: Color? = null, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String, disabled: Boolean = false, screenTitle: String? = null)
+
+    fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, onClick: () -> Unit)
+    fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, onClick: () -> Unit)
+    fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null)
+
+    fun azRailSubCycler(id: String, hostId: String, color: Color? = null, options: List<String>, selectedOption: String, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, onClick: () -> Unit)
+    fun azRailSubCycler(id: String, hostId: String, color: Color? = null, options: List<String>, selectedOption: String, route: String, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, onClick: () -> Unit)
+    fun azRailSubCycler(id: String, hostId: String, color: Color? = null, options: List<String>, selectedOption: String, route: String, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null)
 }
 
 internal class AzNavRailScopeImpl : AzNavRailScope {
@@ -206,6 +223,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     var showFooter: Boolean = true
     var isLoading: Boolean = false
     var defaultShape: AzButtonShape = AzButtonShape.CIRCLE
+    var enableRailDragging: Boolean = false
 
     override fun azSettings(
         displayAppNameInHeader: Boolean,
@@ -214,7 +232,8 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         collapsedRailWidth: Dp,
         showFooter: Boolean,
         isLoading: Boolean,
-        defaultShape: AzButtonShape
+        defaultShape: AzButtonShape,
+        enableRailDragging: Boolean
     ) {
         require(expandedRailWidth > collapsedRailWidth) {
             """
@@ -234,6 +253,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         this.showFooter = showFooter
         this.isLoading = isLoading
         this.defaultShape = defaultShape
+        this.enableRailDragging = enableRailDragging
     }
 
     override fun azMenuItem(id: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
@@ -308,24 +328,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     }
 
     private fun addMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
-        require(toggleOnText.isNotEmpty() && toggleOffText.isNotEmpty()) {
-            """
-            `toggleOnText` and `toggleOffText` must not be empty.
-
-            // azMenuToggle sample
-            azMenuToggle(
-                id = "toggle",
-                isChecked = true,
-                toggleOnText = "On",
-                toggleOffText = "Off",
-                onClick = { /* ... */ }
-            )
-            """.trimIndent()
-        }
-        val text = if (isChecked) toggleOnText else toggleOffText
-        val finalScreenTitle = if (screenTitle == AzNavRail.noTitle) null else screenTitle ?: text
-        onClickMap[id] = onClick
-        navItems.add(AzNavItem(id = id, text = "", route = route, screenTitle = finalScreenTitle, isRailItem = false, isToggle = true, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, disabled = disabled))
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, route = route, disabled = disabled, screenTitle = screenTitle, isRailItem = false, isSubItem = false, shape = AzButtonShape.NONE, onClick = onClick)
     }
 
     override fun azRailToggle(id: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
@@ -341,24 +344,20 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     }
 
     private fun addRailToggle(id: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, shape: AzButtonShape?, route: String?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
-        require(toggleOnText.isNotEmpty() && toggleOffText.isNotEmpty()) {
-            """
-            `toggleOnText` and `toggleOffText` must not be empty.
-
-            // azRailToggle sample
-            azRailToggle(
-                id = "toggle",
-                isChecked = true,
-                toggleOnText = "On",
-                toggleOffText = "Off",
-                onClick = { /* ... */ }
-            )
-            """.trimIndent()
-        }
-        val text = if (isChecked) toggleOnText else toggleOffText
-        val finalScreenTitle = if (screenTitle == AzNavRail.noTitle) null else screenTitle ?: text
-        onClickMap[id] = onClick
-        navItems.add(AzNavItem(id = id, text = "", route = route, screenTitle = finalScreenTitle, isRailItem = true, color = color, isToggle = true, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, shape = shape ?: defaultShape, disabled = disabled))
+        addToggle(
+            id = id,
+            color = color,
+            isChecked = isChecked,
+            toggleOnText = toggleOnText,
+            toggleOffText = toggleOffText,
+            shape = shape ?: defaultShape,
+            route = route,
+            disabled = disabled,
+            screenTitle = screenTitle,
+            isRailItem = true,
+            isSubItem = false,
+            onClick = onClick
+        )
     }
 
     override fun azMenuCycler(id: String, options: List<String>, selectedOption: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
@@ -374,22 +373,19 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     }
 
     private fun addMenuCycler(id: String, options: List<String>, selectedOption: String, route: String?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
-        require(selectedOption in options) {
-            """
-            `selectedOption` must be one of the provided options.
-
-            // azMenuCycler sample
-            azMenuCycler(
-                id = "cycler",
-                options = listOf("A", "B", "C"),
-                selectedOption = "A",
-                onClick = { /* ... */ }
-            )
-            """.trimIndent()
-        }
-        val finalScreenTitle = if (screenTitle == AzNavRail.noTitle) null else screenTitle ?: selectedOption
-        onClickMap[id] = onClick
-        navItems.add(AzNavItem(id = id, text = "", route = route, screenTitle = finalScreenTitle, isRailItem = false, isCycler = true, options = options, selectedOption = selectedOption, disabled = disabled, disabledOptions = disabledOptions))
+        addCycler(
+            id = id,
+            options = options,
+            selectedOption = selectedOption,
+            route = route,
+            disabled = disabled,
+            disabledOptions = disabledOptions,
+            screenTitle = screenTitle,
+            isRailItem = false,
+            isSubItem = false,
+            shape = AzButtonShape.NONE,
+            onClick = onClick
+        )
     }
 
     override fun azRailCycler(id: String, color: Color?, options: List<String>, selectedOption: String, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
@@ -405,22 +401,20 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     }
 
     private fun addRailCycler(id: String, color: Color?, options: List<String>, selectedOption: String, shape: AzButtonShape?, route: String?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
-        require(selectedOption in options) {
-            """
-            `selectedOption` must be one of the provided options.
-
-            // azRailCycler sample
-            azRailCycler(
-                id = "cycler",
-                options = listOf("A", "B", "C"),
-                selectedOption = "A",
-                onClick = { /* ... */ }
-            )
-            """.trimIndent()
-        }
-        val finalScreenTitle = if (screenTitle == AzNavRail.noTitle) null else screenTitle ?: selectedOption
-        onClickMap[id] = onClick
-        navItems.add(AzNavItem(id = id, text = "", route = route, screenTitle = finalScreenTitle, isRailItem = true, color = color, isCycler = true, options = options, selectedOption = selectedOption, shape = shape ?: defaultShape, disabled = disabled, disabledOptions = disabledOptions))
+        addCycler(
+            id = id,
+            color = color,
+            options = options,
+            selectedOption = selectedOption,
+            shape = shape ?: defaultShape,
+            route = route,
+            disabled = disabled,
+            disabledOptions = disabledOptions,
+            screenTitle = screenTitle,
+            isRailItem = true,
+            isSubItem = false,
+            onClick = onClick
+        )
     }
 
     override fun azDivider() {
@@ -489,6 +483,155 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
 
     private fun addRailSubItem(id: String, hostId: String, text: String, route: String?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
         addItem(id = id, text = text, route = route, screenTitle = screenTitle, isRailItem = true, disabled = disabled, isSubItem = true, hostId = hostId, shape = AzButtonShape.NONE, onClick = onClick)
+    }
+
+    override fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
+        addMenuSubCycler(id, hostId, options, selectedOption, null, disabled, disabledOptions, screenTitle, onClick)
+    }
+
+    override fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
+        addMenuSubCycler(id, hostId, options, selectedOption, route, disabled, disabledOptions, screenTitle, onClick)
+    }
+
+    override fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?) {
+        addMenuSubCycler(id, hostId, options, selectedOption, route, disabled, disabledOptions, screenTitle) {}
+    }
+
+    private fun addMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
+        addCycler(id = id, hostId = hostId, options = options, selectedOption = selectedOption, route = route, disabled = disabled, disabledOptions = disabledOptions, screenTitle = screenTitle, isRailItem = false, isSubItem = true, shape = AzButtonShape.NONE, onClick = onClick)
+    }
+
+    override fun azRailSubCycler(id: String, hostId: String, color: Color?, options: List<String>, selectedOption: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
+        addRailSubCycler(id, hostId, color, options, selectedOption, null, disabled, disabledOptions, screenTitle, onClick)
+    }
+
+    override fun azRailSubCycler(id: String, hostId: String, color: Color?, options: List<String>, selectedOption: String, route: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
+        addRailSubCycler(id, hostId, color, options, selectedOption, route, disabled, disabledOptions, screenTitle, onClick)
+    }
+
+    override fun azRailSubCycler(id: String, hostId: String, color: Color?, options: List<String>, selectedOption: String, route: String, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?) {
+        addRailSubCycler(id, hostId, color, options, selectedOption, route, disabled, disabledOptions, screenTitle) {}
+    }
+
+    private fun addRailSubCycler(id: String, hostId: String, color: Color?, options: List<String>, selectedOption: String, route: String?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, onClick: () -> Unit) {
+        addCycler(id = id, hostId = hostId, color = color, options = options, selectedOption = selectedOption, route = route, disabled = disabled, disabledOptions = disabledOptions, screenTitle = screenTitle, isRailItem = true, isSubItem = true, shape = AzButtonShape.NONE, onClick = onClick)
+    }
+
+    private fun addCycler(
+        id: String,
+        hostId: String? = null,
+        color: Color? = null,
+        options: List<String>,
+        selectedOption: String,
+        route: String?,
+        disabled: Boolean,
+        disabledOptions: List<String>?,
+        screenTitle: String?,
+        isRailItem: Boolean,
+        isSubItem: Boolean,
+        shape: AzButtonShape,
+        onClick: () -> Unit
+    ) {
+        require(selectedOption in options) {
+            """
+            `selectedOption` must be one of the provided options.
+            """.trimIndent()
+        }
+        val finalScreenTitle = if (screenTitle == AzNavRail.noTitle) null else screenTitle ?: selectedOption
+        onClickMap[id] = onClick
+        navItems.add(
+            AzNavItem(
+                id = id,
+                text = "",
+                route = route,
+                screenTitle = finalScreenTitle,
+                isRailItem = isRailItem,
+                color = color,
+                isCycler = true,
+                options = options,
+                selectedOption = selectedOption,
+                shape = shape,
+                disabled = disabled,
+                disabledOptions = disabledOptions,
+                isSubItem = isSubItem,
+                hostId = hostId
+            )
+        )
+    }
+
+    override fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addMenuSubToggle(id, hostId, isChecked, toggleOnText, toggleOffText, null, disabled, screenTitle, onClick)
+    }
+
+    override fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addMenuSubToggle(id, hostId, isChecked, toggleOnText, toggleOffText, route, disabled, screenTitle, onClick)
+    }
+
+    override fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String, disabled: Boolean, screenTitle: String?) {
+        addMenuSubToggle(id, hostId, isChecked, toggleOnText, toggleOffText, route, disabled, screenTitle) {}
+    }
+
+    private fun addMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addToggle(id = id, hostId = hostId, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, route = route, disabled = disabled, screenTitle = screenTitle, isRailItem = false, isSubItem = true, shape = AzButtonShape.NONE, onClick = onClick)
+    }
+
+    override fun azRailSubToggle(id: String, hostId: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addRailSubToggle(id, hostId, color, isChecked, toggleOnText, toggleOffText, null, disabled, screenTitle, onClick)
+    }
+
+    override fun azRailSubToggle(id: String, hostId: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addRailSubToggle(id, hostId, color, isChecked, toggleOnText, toggleOffText, route, disabled, screenTitle, onClick)
+    }
+
+    override fun azRailSubToggle(id: String, hostId: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String, disabled: Boolean, screenTitle: String?) {
+        addRailSubToggle(id, hostId, color, isChecked, toggleOnText, toggleOffText, route, disabled, screenTitle) {}
+    }
+
+    private fun addRailSubToggle(id: String, hostId: String, color: Color?, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {
+        addToggle(id = id, hostId = hostId, color = color, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, route = route, disabled = disabled, screenTitle = screenTitle, isRailItem = true, isSubItem = true, shape = AzButtonShape.NONE, onClick = onClick)
+    }
+
+    private fun addToggle(
+        id: String,
+        hostId: String? = null,
+        color: Color? = null,
+        isChecked: Boolean,
+        toggleOnText: String,
+        toggleOffText: String,
+        route: String?,
+        disabled: Boolean,
+        screenTitle: String?,
+        isRailItem: Boolean,
+        isSubItem: Boolean,
+        shape: AzButtonShape,
+        onClick: () -> Unit
+    ) {
+        require(toggleOnText.isNotEmpty() && toggleOffText.isNotEmpty()) {
+            """
+            `toggleOnText` and `toggleOffText` must not be empty.
+            """.trimIndent()
+        }
+        val text = if (isChecked) toggleOnText else toggleOffText
+        val finalScreenTitle = if (screenTitle == AzNavRail.noTitle) null else screenTitle ?: text
+        onClickMap[id] = onClick
+        navItems.add(
+            AzNavItem(
+                id = id,
+                text = "",
+                route = route,
+                screenTitle = finalScreenTitle,
+                isRailItem = isRailItem,
+                color = color,
+                isToggle = true,
+                isChecked = isChecked,
+                toggleOnText = toggleOnText,
+                toggleOffText = toggleOffText,
+                shape = shape,
+                disabled = disabled,
+                isSubItem = isSubItem,
+                hostId = hostId
+            )
+        )
     }
 
     private fun addItem(

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
@@ -163,4 +163,52 @@ class AzNavRailTest {
         scope.azRailItem("favorites", "Favorites", onClick = {}, screenTitle = "My Favorites")
         assertEquals("My Favorites", scope.navItems[0].screenTitle)
     }
+
+    @Test
+    fun `azMenuSubToggle should add a menu sub-toggle item`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azMenuHostItem("host", "Host", onClick = {})
+        scope.azMenuSubToggle("sub_toggle", "host", true, "On", "Off") {}
+        val expectedItem = AzNavItem("sub_toggle", "", isRailItem = false, isToggle = true, isChecked = true, toggleOnText = "On", toggleOffText = "Off", isSubItem = true, hostId = "host")
+        assertEquals(expectedItem.id, scope.navItems[1].id)
+        assertEquals(expectedItem.isSubItem, scope.navItems[1].isSubItem)
+        assertEquals(expectedItem.hostId, scope.navItems[1].hostId)
+    }
+
+    @Test
+    fun `azRailSubToggle should add a rail sub-toggle item`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azRailHostItem("host", "Host", onClick = {})
+        scope.azRailSubToggle("sub_toggle", "host", Color.Blue, false, "On", "Off") {}
+        val expectedItem = AzNavItem("sub_toggle", "", isRailItem = true, color = Color.Blue, isToggle = true, isChecked = false, toggleOnText = "On", toggleOffText = "Off", isSubItem = true, hostId = "host")
+        assertEquals(expectedItem.id, scope.navItems[1].id)
+        assertEquals(expectedItem.isRailItem, scope.navItems[1].isRailItem)
+        assertEquals(expectedItem.isSubItem, scope.navItems[1].isSubItem)
+        assertEquals(expectedItem.hostId, scope.navItems[1].hostId)
+    }
+
+    @Test
+    fun `azMenuSubCycler should add a menu sub-cycler item`() {
+        val scope = AzNavRailScopeImpl()
+        val options = listOf("A", "B", "C")
+        scope.azMenuHostItem("host", "Host", onClick = {})
+        scope.azMenuSubCycler("sub_cycler", "host", options, "A") {}
+        val expectedItem = AzNavItem("sub_cycler", "", isRailItem = false, isCycler = true, options = options, selectedOption = "A", isSubItem = true, hostId = "host")
+        assertEquals(expectedItem.id, scope.navItems[1].id)
+        assertEquals(expectedItem.isSubItem, scope.navItems[1].isSubItem)
+        assertEquals(expectedItem.hostId, scope.navItems[1].hostId)
+    }
+
+    @Test
+    fun `azRailSubCycler should add a rail sub-cycler item`() {
+        val scope = AzNavRailScopeImpl()
+        val options = listOf("A", "B", "C")
+        scope.azRailHostItem("host", "Host", onClick = {})
+        scope.azRailSubCycler("sub_cycler", "host", Color.Green, options, "B") {}
+        val expectedItem = AzNavItem("sub_cycler", "", isRailItem = true, color = Color.Green, isCycler = true, options = options, selectedOption = "B", isSubItem = true, hostId = "host")
+        assertEquals(expectedItem.id, scope.navItems[1].id)
+        assertEquals(expectedItem.isRailItem, scope.navItems[1].isRailItem)
+        assertEquals(expectedItem.isSubItem, scope.navItems[1].isSubItem)
+        assertEquals(expectedItem.hostId, scope.navItems[1].hostId)
+    }
 }


### PR DESCRIPTION
This commit updates the README.md to include documentation for the new sub-item and draggable rail features. It also enables the draggable rail feature in the sample app.

Note: This commit is being made at the user's request and the code is in a broken, non-compiling state.

## Summary by Sourcery

Implement draggable rail capability and extend the AzNavRail DSL with nested toggle and cycler sub-items, refactor internal logic to reduce duplication, and update documentation and tests accordingly

New Features:
- Enable draggable nav rail with long-press detach, drag-to-reposition, button visibility toggle, and snap-back behavior
- Add DSL functions for sub-item toggles (azMenuSubToggle/azRailSubToggle) and cyclers (azMenuSubCycler/azRailSubCycler)

Enhancements:
- Refactor internal logic to consolidate toggle and cycler creation into shared helper methods

Documentation:
- Update README and sample app to document the draggable rail feature and new sub-item DSL functions

Tests:
- Add unit tests for sub-item toggle and cycler functions