### PR TITLE
feat(AzNavRail): Implement FAB mode with drag-and-drop and haptic feedback

This commit introduces a new "Floating Action Button (FAB) mode" for the AzNavRail component.

Key features:
- Long-pressing the header now activates a draggable FAB mode.
- Haptic feedback is provided when starting and stopping the drag.
- When the app name is displayed, it transforms into an icon for dragging and reverts back when docked.
- Implemented a "snap-to-home" feature that returns the FAB to its original position when released nearby.
- Tapping the FAB in floating mode toggles the visibility of the rail items.
- All new functionality is opt-in via the `enableRailDragging` setting to ensure backward compatibility.

Fixes:
- Resolved a bug where rail items would not render due to a duplicate, empty `AzNavRailButton` composable.
- Corrected a compilation error by adding the `enableRailDragging` property to `AzNavRailScopeImpl`.

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -434,6 +434,8 @@ fun AzNavRail(
                                             }
                                         }
                                     )
+                                } else {
+                                    detectTapGestures(onTap = { onToggle() })
                                 }
                             },
                         contentAlignment = Alignment.Center
@@ -593,7 +595,7 @@ fun AzNavRail(
                         }
                     }
                 } else {
-                    AnimatedVisibility(visible = showFloatingButtons && !isDragging) {
+                    AnimatedVisibility(visible = !isFloating || (showFloatingButtons && !isDragging)) {
                         Column(
                             modifier = Modifier
                                 .padding(horizontal = AzNavRailDefaults.RailContentHorizontalPadding)


### PR DESCRIPTION
## Summary by Sourcery

Introduce an opt-in floating action button mode to AzNavRail that adds draggable FAB behavior with haptic feedback, snap-to-home positioning, and tap-to-toggle visibility, while preserving backward compatibility via the enableRailDragging flag.

New Features:
- Add opt-in FAB mode for AzNavRail with long-press activation
- Provide haptic feedback on drag start and stop
- Transform app name into a draggable icon and revert on docking
- Implement snap-to-home behavior when releasing the FAB near its origin
- Allow tapping the floating FAB to toggle rail item visibility

Bug Fixes:
- Remove duplicate empty AzNavRailButton composable preventing rail item rendering
- Add missing enableRailDragging property to AzNavRailScopeImpl to fix compilation error

Enhancements:
- Adjust tap gesture detection to handle toggling in floating mode
- Update AnimatedVisibility logic to correctly display floating buttons