### PR TITLE
Fix: Implement custom saver for AzForm state

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzForm.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzForm.kt
@@ -15,6 +15,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.toMutableStateMap
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -56,7 +59,12 @@ fun AzForm(
     content: AzFormScope.() -> Unit
 ) {
     val scope = remember(formName, content) { AzFormScope().apply(content) }
-    val formData = rememberSaveable {
+    val formData = rememberSaveable(
+        saver = listSaver<SnapshotStateMap<String, String>, Pair<String, String>>(
+            save = { it.toList() },
+            restore = { it.toMutableStateMap() }
+        )
+    ) {
         mutableStateMapOf<String, String>().apply {
             scope.entries.forEach { entry ->
                 this[entry.entryName] = ""


### PR DESCRIPTION
The AzForm component was crashing on configuration changes (e.g., screen rotation) because its `SnapshotStateMap` could not be automatically saved.

This commit fixes the issue by providing a custom `listSaver` to the `rememberSaveable` call that manages the form's state. The saver converts the map to a `List` of `Pair`s for saving and restores it on recreation, making the form's state persist correctly.

## Summary by Sourcery

Implement a custom saver for AzForm's state map using listSaver to serialize and restore the form data across configuration changes, preventing runtime crashes.

Bug Fixes:
- Add custom listSaver for AzForm's SnapshotStateMap to prevent crashes on configuration changes
- Convert formData map to a list of pairs for saving and restore it as a mutable state map