### PR TITLE
Fix rail button dimensions and add configurable header icon shape

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
@@ -33,6 +35,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -56,8 +59,8 @@ import com.hereliesaz.aznavrail.internal.CyclerTransientState
 import com.hereliesaz.aznavrail.internal.Footer
 import com.hereliesaz.aznavrail.internal.MenuItem
 import com.hereliesaz.aznavrail.internal.RailItems
+import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzNavItem
-import com.hereliesaz.aznavrail.util.EqualWidthLayout
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.pow
@@ -326,10 +329,16 @@ fun AzNavRail(
                         if (isAppIcon) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 if (appIcon != null) {
+                                    val iconShape = when (scope.headerIconShape) {
+                                        AzButtonShape.CIRCLE -> CircleShape
+                                        AzButtonShape.SQUARE, AzButtonShape.RECTANGLE, AzButtonShape.NONE -> RoundedCornerShape(0.dp)
+                                    }
                                     Image(
                                         painter = rememberAsyncImagePainter(model = appIcon),
                                         contentDescription = "Toggle menu, showing $appName icon",
-                                        modifier = Modifier.size(AzNavRailDefaults.HeaderIconSize)
+                                        modifier = Modifier
+                                            .size(AzNavRailDefaults.HeaderIconSize)
+                                            .clip(iconShape)
                                     )
                                 } else {
                                     Icon(
@@ -577,8 +586,11 @@ fun AzNavRail(
                                     }
                                 }
 
-                                EqualWidthLayout(
-                                    verticalSpacing = if (scope.packRailButtons) 0.dp else AzNavRailDefaults.RailContentVerticalArrangement
+                                Column(
+                                    verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(
+                                        if (scope.packRailButtons) 0.dp else AzNavRailDefaults.RailContentVerticalArrangement
+                                    ),
+                                    horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
                                     RailItems(
                                         items = scope.navItems,

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -61,7 +61,7 @@ fun AzNavRailButton(
         AzButtonShape.SQUARE -> modifier
             .size(size)
             .aspectRatio(1f)
-        AzButtonShape.RECTANGLE, AzButtonShape.NONE -> modifier.height(48.dp)
+        AzButtonShape.RECTANGLE, AzButtonShape.NONE -> modifier.height(36.dp)
     }
 
     val disabledColor = color.copy(alpha = 0.5f)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -29,7 +29,8 @@ interface AzNavRailScope {
         showFooter: Boolean = true,
         isLoading: Boolean = false,
         defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
-        enableRailDragging: Boolean = false
+        enableRailDragging: Boolean = false,
+        headerIconShape: AzButtonShape = AzButtonShape.CIRCLE
     )
 
     /**
@@ -224,6 +225,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     var isLoading: Boolean = false
     var defaultShape: AzButtonShape = AzButtonShape.CIRCLE
     var enableRailDragging: Boolean = false
+    var headerIconShape: AzButtonShape = AzButtonShape.CIRCLE
 
     override fun azSettings(
         displayAppNameInHeader: Boolean,
@@ -233,7 +235,8 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         showFooter: Boolean,
         isLoading: Boolean,
         defaultShape: AzButtonShape,
-        enableRailDragging: Boolean
+        enableRailDragging: Boolean,
+        headerIconShape: AzButtonShape
     ) {
         require(expandedRailWidth > collapsedRailWidth) {
             """
@@ -254,6 +257,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         this.isLoading = isLoading
         this.defaultShape = defaultShape
         this.enableRailDragging = enableRailDragging
+        this.headerIconShape = headerIconShape
     }
 
     override fun azMenuItem(id: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
@@ -211,4 +211,11 @@ class AzNavRailTest {
         assertEquals(expectedItem.isSubItem, scope.navItems[1].isSubItem)
         assertEquals(expectedItem.hostId, scope.navItems[1].hostId)
     }
+
+    @Test
+    fun `azSettings should update headerIconShape`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azSettings(headerIconShape = com.hereliesaz.aznavrail.model.AzButtonShape.SQUARE)
+        assertEquals(com.hereliesaz.aznavrail.model.AzButtonShape.SQUARE, scope.headerIconShape)
+    }
 }


### PR DESCRIPTION
- Changed height of RECTANGLE and NONE shaped AzNavRailButtons to 36dp to match AzTextBox.
- Replaced EqualWidthLayout with Column in AzNavRail to allow rail items to hug their content width instead of being forced to the maximum width.
- Added `headerIconShape` parameter to `azSettings` in AzNavRailScope to allow customizing the app icon shape in the header (defaults to CIRCLE).
- Updated AzNavRail to clip the header icon based on the configured shape.
- Added unit test for `headerIconShape` setting.

## Summary by Sourcery

Adjust AzNavRail button layout and introduce configurable header icon shape.

New Features:
- Add a configurable headerIconShape option to azSettings for customizing the header app icon shape.

Bug Fixes:
- Align RECTANGLE and NONE AzNavRail button heights with AzTextBox by reducing their height to 36dp.
- Update AzNavRail layout to let rail items size to their content width instead of enforcing equal widths.

Enhancements:
- Clip the header app icon according to the configured headerIconShape setting.
- Replace EqualWidthLayout with a Column-based arrangement for rail items to better support packed button layouts.

Tests:
- Add a unit test verifying that azSettings correctly updates the headerIconShape in AzNavRailScope.