### PR TITLE
Fix rail button size and icon shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.hereliesaz.aznavrail.AzNavRail
 import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 
 @Composable
 fun SampleScreen() {
@@ -94,7 +95,7 @@ fun SampleScreen() {
                 isLoading = isLoading,
                 defaultShape = AzButtonShape.RECTANGLE, // Set a default shape for all rail items
                 enableRailDragging = true, // Enable the draggable rail feature
-                headerIconShape = AzButtonShape.SQUARE // Set the header icon shape to SQUARE
+                headerIconShape = AzHeaderIconShape.ROUNDED // Set the header icon shape to ROUNDED
             )
 
             // A standard menu item - only appears in the expanded menu
@@ -409,7 +410,7 @@ The DSL for configuring the `AzNavRail`.
 
 **Note:** Functions prefixed with `azMenu` will only appear in the expanded menu view. Functions prefixed with `azRail` will appear on the collapsed rail, and their text will be used as the label in the expanded menu.
 
--   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean, defaultShape: AzButtonShape, enableRailDragging: Boolean, headerIconShape: AzButtonShape)`: Configures the settings for the `AzNavRail`.
+-   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean, defaultShape: AzButtonShape, enableRailDragging: Boolean, headerIconShape: AzHeaderIconShape)`: Configures the settings for the `AzNavRail`. `headerIconShape` can be `CIRCLE` (default), `ROUNDED`, or `NONE` (no clipping).
 -   `azMenuItem(id: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
 -   `azMenuItem(id: String, text: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
 -   `azRailItem(id: String, text: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text in the expanded menu.

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -59,7 +59,7 @@ import com.hereliesaz.aznavrail.internal.CyclerTransientState
 import com.hereliesaz.aznavrail.internal.Footer
 import com.hereliesaz.aznavrail.internal.MenuItem
 import com.hereliesaz.aznavrail.internal.RailItems
-import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzNavItem
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -329,16 +329,16 @@ fun AzNavRail(
                         if (isAppIcon) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 if (appIcon != null) {
-                                    val iconShape = when (scope.headerIconShape) {
-                                        AzButtonShape.CIRCLE -> CircleShape
-                                        AzButtonShape.SQUARE, AzButtonShape.RECTANGLE, AzButtonShape.NONE -> RoundedCornerShape(0.dp)
+                                    val baseModifier = Modifier.size(AzNavRailDefaults.HeaderIconSize)
+                                    val finalModifier = when (scope.headerIconShape) {
+                                        AzHeaderIconShape.CIRCLE -> baseModifier.clip(CircleShape)
+                                        AzHeaderIconShape.ROUNDED -> baseModifier.clip(RoundedCornerShape(12.dp))
+                                        AzHeaderIconShape.NONE -> baseModifier
                                     }
                                     Image(
                                         painter = rememberAsyncImagePainter(model = appIcon),
                                         contentDescription = "Toggle menu, showing $appName icon",
-                                        modifier = Modifier
-                                            .size(AzNavRailDefaults.HeaderIconSize)
-                                            .clip(iconShape)
+                                        modifier = finalModifier
                                     )
                                 } else {
                                     Icon(

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzNavItem
 
 /**
@@ -30,7 +31,7 @@ interface AzNavRailScope {
         isLoading: Boolean = false,
         defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
         enableRailDragging: Boolean = false,
-        headerIconShape: AzButtonShape = AzButtonShape.CIRCLE
+        headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE
     )
 
     /**
@@ -225,7 +226,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     var isLoading: Boolean = false
     var defaultShape: AzButtonShape = AzButtonShape.CIRCLE
     var enableRailDragging: Boolean = false
-    var headerIconShape: AzButtonShape = AzButtonShape.CIRCLE
+    var headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE
 
     override fun azSettings(
         displayAppNameInHeader: Boolean,
@@ -236,7 +237,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         isLoading: Boolean,
         defaultShape: AzButtonShape,
         enableRailDragging: Boolean,
-        headerIconShape: AzButtonShape
+        headerIconShape: AzHeaderIconShape
     ) {
         require(expandedRailWidth > collapsedRailWidth) {
             """

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzHeaderIconShape.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzHeaderIconShape.kt
@@ -1,0 +1,7 @@
+package com.hereliesaz.aznavrail.model
+
+enum class AzHeaderIconShape {
+    CIRCLE,
+    ROUNDED,
+    NONE
+}

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
@@ -215,7 +215,7 @@ class AzNavRailTest {
     @Test
     fun `azSettings should update headerIconShape`() {
         val scope = AzNavRailScopeImpl()
-        scope.azSettings(headerIconShape = com.hereliesaz.aznavrail.model.AzButtonShape.SQUARE)
-        assertEquals(com.hereliesaz.aznavrail.model.AzButtonShape.SQUARE, scope.headerIconShape)
+        scope.azSettings(headerIconShape = com.hereliesaz.aznavrail.model.AzHeaderIconShape.ROUNDED)
+        assertEquals(com.hereliesaz.aznavrail.model.AzHeaderIconShape.ROUNDED, scope.headerIconShape)
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dedicated header icon shape configuration for AzNavRail and refine button sizing behavior.

New Features:
- Add a separate AzHeaderIconShape enum to control the header icon’s clipping independently from rail button shapes, including a new ROUNDED option.

Enhancements:
- Update AzNavRailScope settings and implementation to use AzHeaderIconShape for header icons instead of AzButtonShape.
- Adjust header icon rendering to apply consistent sizing with conditional clipping based on the selected header icon shape.
- Clarify README documentation for rail button sizing when using RECTANGLE and NONE shapes, and document the new headerIconShape setting with its available options.

Tests:
- Update AzNavRail tests to validate headerIconShape behavior using the new AzHeaderIconShape enum.