### PR TITLE
Implement independent header icon shape and fix button sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ This "navigrenuail" provides a vertical navigation rail that expands to a full m
 - **Text-Only DSL API**: A simple, declarative API for building your navigation.
 - **Multi-line Menu Items**: Supports multi-line text with automatic indentation.
 - **Stateless and Observable**: Hoist and manage state in your own composables.
--   **Customizable Shapes**: Choose from `CIRCLE`, `SQUARE`, `RECTANGLE`, or `NONE` for rail buttons.
--   **Uniform Rectangle Width**: All rectangular buttons automatically share the same width, determined by the widest rectangle.
+-   **Customizable Shapes**: Choose from `CIRCLE`, `SQUARE`, `RECTANGLE`, or `NONE` for rail buttons. `RECTANGLE` and `NONE` shapes automatically size to fit their text content and have a fixed height of 36dp.
 - **Smart Collapse Behavior**: Menu items intelligently collapse the rail after interactions.
 - **Delayed Cycler Action**: Cycler items have a built-in delay to prevent accidental triggers.
 - **Customizable Colors**: Apply custom colors to individual rail buttons.
@@ -67,6 +66,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.hereliesaz.aznavrail.AzNavRail
 import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 
 @Composable
 fun SampleScreen() {
@@ -94,7 +94,8 @@ fun SampleScreen() {
                 packRailButtons = false,
                 isLoading = isLoading,
                 defaultShape = AzButtonShape.RECTANGLE, // Set a default shape for all rail items
-                enableRailDragging = true // Enable the draggable rail feature
+                enableRailDragging = true, // Enable the draggable rail feature
+                headerIconShape = AzHeaderIconShape.ROUNDED // Set the header icon shape to ROUNDED
             )
 
             // A standard menu item - only appears in the expanded menu
@@ -409,7 +410,7 @@ The DSL for configuring the `AzNavRail`.
 
 **Note:** Functions prefixed with `azMenu` will only appear in the expanded menu view. Functions prefixed with `azRail` will appear on the collapsed rail, and their text will be used as the label in the expanded menu.
 
--   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean, defaultShape: AzButtonShape, enableRailDragging: Boolean)`: Configures the settings for the `AzNavRail`.
+-   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean, defaultShape: AzButtonShape, enableRailDragging: Boolean, headerIconShape: AzHeaderIconShape)`: Configures the settings for the `AzNavRail`. `headerIconShape` can be `CIRCLE` (default), `ROUNDED`, or `NONE` (no clipping).
 -   `azMenuItem(id: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
 -   `azMenuItem(id: String, text: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
 -   `azRailItem(id: String, text: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text in the expanded menu.

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
@@ -33,6 +35,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -56,8 +59,8 @@ import com.hereliesaz.aznavrail.internal.CyclerTransientState
 import com.hereliesaz.aznavrail.internal.Footer
 import com.hereliesaz.aznavrail.internal.MenuItem
 import com.hereliesaz.aznavrail.internal.RailItems
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzNavItem
-import com.hereliesaz.aznavrail.util.EqualWidthLayout
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.pow
@@ -326,10 +329,16 @@ fun AzNavRail(
                         if (isAppIcon) {
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 if (appIcon != null) {
+                                    val baseModifier = Modifier.size(AzNavRailDefaults.HeaderIconSize)
+                                    val finalModifier = when (scope.headerIconShape) {
+                                        AzHeaderIconShape.CIRCLE -> baseModifier.clip(CircleShape)
+                                        AzHeaderIconShape.ROUNDED -> baseModifier.clip(RoundedCornerShape(12.dp))
+                                        AzHeaderIconShape.NONE -> baseModifier
+                                    }
                                     Image(
                                         painter = rememberAsyncImagePainter(model = appIcon),
                                         contentDescription = "Toggle menu, showing $appName icon",
-                                        modifier = Modifier.size(AzNavRailDefaults.HeaderIconSize)
+                                        modifier = finalModifier
                                     )
                                 } else {
                                     Icon(
@@ -577,8 +586,11 @@ fun AzNavRail(
                                     }
                                 }
 
-                                EqualWidthLayout(
-                                    verticalSpacing = if (scope.packRailButtons) 0.dp else AzNavRailDefaults.RailContentVerticalArrangement
+                                Column(
+                                    verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(
+                                        if (scope.packRailButtons) 0.dp else AzNavRailDefaults.RailContentVerticalArrangement
+                                    ),
+                                    horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
                                     RailItems(
                                         items = scope.navItems,

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -61,7 +61,7 @@ fun AzNavRailButton(
         AzButtonShape.SQUARE -> modifier
             .size(size)
             .aspectRatio(1f)
-        AzButtonShape.RECTANGLE, AzButtonShape.NONE -> modifier.height(48.dp)
+        AzButtonShape.RECTANGLE, AzButtonShape.NONE -> modifier.height(36.dp)
     }
 
     val disabledColor = color.copy(alpha = 0.5f)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzNavItem
 
 /**
@@ -29,7 +30,8 @@ interface AzNavRailScope {
         showFooter: Boolean = true,
         isLoading: Boolean = false,
         defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
-        enableRailDragging: Boolean = false
+        enableRailDragging: Boolean = false,
+        headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE
     )
 
     /**
@@ -224,6 +226,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     var isLoading: Boolean = false
     var defaultShape: AzButtonShape = AzButtonShape.CIRCLE
     var enableRailDragging: Boolean = false
+    var headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE
 
     override fun azSettings(
         displayAppNameInHeader: Boolean,
@@ -233,7 +236,8 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         showFooter: Boolean,
         isLoading: Boolean,
         defaultShape: AzButtonShape,
-        enableRailDragging: Boolean
+        enableRailDragging: Boolean,
+        headerIconShape: AzHeaderIconShape
     ) {
         require(expandedRailWidth > collapsedRailWidth) {
             """
@@ -254,6 +258,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         this.isLoading = isLoading
         this.defaultShape = defaultShape
         this.enableRailDragging = enableRailDragging
+        this.headerIconShape = headerIconShape
     }
 
     override fun azMenuItem(id: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzHeaderIconShape.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzHeaderIconShape.kt
@@ -1,0 +1,7 @@
+package com.hereliesaz.aznavrail.model
+
+enum class AzHeaderIconShape {
+    CIRCLE,
+    ROUNDED,
+    NONE
+}

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
@@ -211,4 +211,11 @@ class AzNavRailTest {
         assertEquals(expectedItem.isSubItem, scope.navItems[1].isSubItem)
         assertEquals(expectedItem.hostId, scope.navItems[1].hostId)
     }
+
+    @Test
+    fun `azSettings should update headerIconShape`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azSettings(headerIconShape = com.hereliesaz.aznavrail.model.AzHeaderIconShape.ROUNDED)
+        assertEquals(com.hereliesaz.aznavrail.model.AzHeaderIconShape.ROUNDED, scope.headerIconShape)
+    }
 }


### PR DESCRIPTION
- Added `AzHeaderIconShape` enum (CIRCLE, ROUNDED, NONE).
- Updated `azSettings` to accept `headerIconShape`.
- Refactored `AzNavRail` layout to use `Column` instead of `EqualWidthLayout`, allowing buttons to hug content width.
- Changed height of RECTANGLE and NONE buttons to 36dp.
- Updated README and tests.

## Summary by Sourcery

Add configurable header icon shapes and adjust rail button layout and sizing for better alignment with content.

New Features:
- Introduce AzHeaderIconShape enum to control header icon clipping style independently of rail button shapes.
- Extend azSettings to accept a headerIconShape parameter for customizing the header icon appearance.

Enhancements:
- Change the nav rail content container to a Column with spaced arrangement so rectangular buttons hug their content width.
- Reduce RECTANGLE and NONE button height to 36dp for a more compact layout.

Documentation:
- Update README to document headerIconShape usage and the new sizing behavior for RECTANGLE and NONE shapes.

Tests:
- Add a unit test ensuring azSettings correctly updates the headerIconShape in AzNavRailScope.