### PR TITLE
Fix AzNavRailButton expanding to full width for RECTANGLE/NONE shapes

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -82,13 +82,19 @@ fun AzNavRailButton(
         enabled = !disabled
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
+            val textModifier = if (shape == AzButtonShape.RECTANGLE || shape == AzButtonShape.NONE) {
+                Modifier
+            } else {
+                Modifier.weight(1f)
+            }
+
             AutoSizeText(
                 text = text,
                 style = MaterialTheme.typography.bodyMedium.copy(
                     textAlign = TextAlign.Center,
                     color = if (disabled) disabledColor else finalColor
                 ),
-                modifier = Modifier.weight(1f),
+                modifier = textModifier,
                 maxLines = if (text.contains("\n")) Int.MAX_VALUE else 1,
                 softWrap = false,
                 alignment = Alignment.Center,


### PR DESCRIPTION
The previous implementation applied `Modifier.weight(1f)` to the inner `AutoSizeText` regardless of the button shape. This caused buttons with `RECTANGLE` or `NONE` shapes (which default to `wrapContentWidth`) to aggressively expand and fill the available width of their parent container (e.g., a Row), pushing other elements off-screen.

This change conditionally applies `Modifier.weight(1f)` only for `CIRCLE` and `SQUARE` shapes, which have fixed dimensions. For `RECTANGLE` and `NONE`, the text modifier is left as default, allowing the button to correctly hug its content width.

## Summary by Sourcery

Bug Fixes:
- Stop RECTANGLE and NONE shaped AzNavRailButtons from stretching to fill available horizontal space by only applying weighted text layout to fixed-size shapes.