### PR TITLE
feat: Add bubbleMode parameter to azSettings DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ AzNavRail can function as a system-wide overlay using the Android Bubble API. Th
 
 #### 1. Setup Bubble Activity
 
-Create an Activity that will serve as the content of the bubble. This activity should display your `AzNavRail` with `initiallyExpanded = true` and `enableRailDragging = false` (since the OS handles window dragging).
+Create an Activity that will serve as the content of the bubble. This activity should display your `AzNavRail`. You can simply set `bubbleMode = true` in `azSettings` to configure it correctly (`initiallyExpanded = true` and `enableRailDragging = false`).
 
 **AndroidManifest.xml:**
 ```xml
@@ -405,8 +405,7 @@ class BubbleActivity : ComponentActivity() {
             MyApplicationTheme {
                 // Reuse your screen content, ensuring it's configured for bubble mode
                 SampleScreen(
-                    enableRailDragging = false, // Bubble window handles dragging
-                    initiallyExpanded = true,   // Show expanded menu by default in bubble
+                    bubbleMode = true,              // Enable bubble mode
                     onUndockOverride = { finish() } // Undock in bubble closes it
                 )
             }
@@ -518,7 +517,7 @@ The DSL for configuring the `AzNavRail`.
 
 **Note:** Functions prefixed with `azMenu` will only appear in the expanded menu view. Functions prefixed with `azRail` will appear on the collapsed rail, and their text will be used as the label in the expanded menu.
 
--   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean, defaultShape: AzButtonShape, enableRailDragging: Boolean, headerIconShape: AzHeaderIconShape, onUndock: (() -> Unit)?)`: Configures the settings for the `AzNavRail`. `headerIconShape` can be `CIRCLE` (default), `ROUNDED`, or `NONE` (no clipping). `onUndock` allows overriding the default undock behavior (e.g., to launch a Bubble).
+-   `azSettings(displayAppNameInHeader: Boolean, packRailButtons: Boolean, expandedRailWidth: Dp, collapsedRailWidth: Dp, showFooter: Boolean, isLoading: Boolean, defaultShape: AzButtonShape, enableRailDragging: Boolean, headerIconShape: AzHeaderIconShape, onUndock: (() -> Unit)?, bubbleMode: Boolean)`: Configures the settings for the `AzNavRail`. `headerIconShape` can be `CIRCLE` (default), `ROUNDED`, or `NONE` (no clipping). `onUndock` allows overriding the default undock behavior (e.g., to launch a Bubble). `bubbleMode` (default `false`) simplifies bubble configuration by setting `enableRailDragging` to `false` and ensuring the rail is initially expanded.
 -   `azMenuItem(id: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
 -   `azMenuItem(id: String, text: String, route: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a menu item that only appears in the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text with the `\n` character.
 -   `azRailItem(id: String, text: String, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, onClick: () -> Unit)`: Adds a rail item that appears in both the collapsed rail and the expanded menu. Tapping it executes the action and collapses the rail. Supports multi-line text in the expanded menu.

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -118,7 +118,8 @@ fun AzNavRail(
         }
     }
 
-    var isExpanded by rememberSaveable(initiallyExpanded) { mutableStateOf(initiallyExpanded) }
+    val initialExpansion = if (scope.bubbleMode) true else initiallyExpanded
+    var isExpanded by rememberSaveable(initialExpansion) { mutableStateOf(initialExpansion) }
     var railOffset by remember { mutableStateOf(IntOffset.Zero) }
     var isFloating by remember { mutableStateOf(false) }
     var showFloatingButtons by remember { mutableStateOf(false) }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -25,6 +25,7 @@ interface AzNavRailScope {
      * @param enableRailDragging Whether to enable the draggable rail (FAB mode).
      * @param headerIconShape The shape of the header icon.
      * @param onUndock An optional callback to override the default undock behavior (e.g., to launch a Bubble).
+     * @param bubbleMode Whether to enable Bubble mode. If true, `enableRailDragging` is forced to false, and the rail is initially expanded.
      */
     fun azSettings(
         displayAppNameInHeader: Boolean = false,
@@ -36,7 +37,8 @@ interface AzNavRailScope {
         defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
         enableRailDragging: Boolean = false,
         headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
-        onUndock: (() -> Unit)? = null
+        onUndock: (() -> Unit)? = null,
+        bubbleMode: Boolean = false
     )
 
     /**
@@ -233,6 +235,7 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
     var enableRailDragging: Boolean = false
     var headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE
     var onUndock: (() -> Unit)? = null
+    var bubbleMode: Boolean = false
 
     override fun azSettings(
         displayAppNameInHeader: Boolean,
@@ -244,7 +247,8 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         defaultShape: AzButtonShape,
         enableRailDragging: Boolean,
         headerIconShape: AzHeaderIconShape,
-        onUndock: (() -> Unit)?
+        onUndock: (() -> Unit)?,
+        bubbleMode: Boolean
     ) {
         require(expandedRailWidth > collapsedRailWidth) {
             """
@@ -264,9 +268,10 @@ internal class AzNavRailScopeImpl : AzNavRailScope {
         this.showFooter = showFooter
         this.isLoading = isLoading
         this.defaultShape = defaultShape
-        this.enableRailDragging = enableRailDragging
+        this.enableRailDragging = if (bubbleMode) false else enableRailDragging
         this.headerIconShape = headerIconShape
         this.onUndock = onUndock
+        this.bubbleMode = bubbleMode
     }
 
     override fun azMenuItem(id: String, text: String, disabled: Boolean, screenTitle: String?, onClick: () -> Unit) {

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
@@ -218,4 +218,19 @@ class AzNavRailTest {
         scope.azSettings(headerIconShape = com.hereliesaz.aznavrail.model.AzHeaderIconShape.ROUNDED)
         assertEquals(com.hereliesaz.aznavrail.model.AzHeaderIconShape.ROUNDED, scope.headerIconShape)
     }
+
+    @Test
+    fun `azSettings should update bubbleMode`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azSettings(bubbleMode = true)
+        assertEquals(true, scope.bubbleMode)
+    }
+
+    @Test
+    fun `azSettings with bubbleMode should disable enableRailDragging`() {
+        val scope = AzNavRailScopeImpl()
+        scope.azSettings(bubbleMode = true, enableRailDragging = true)
+        assertEquals(true, scope.bubbleMode)
+        assertEquals(false, scope.enableRailDragging)
+    }
 }


### PR DESCRIPTION
This commit adds a `bubbleMode` parameter to the `azSettings` DSL function. When `bubbleMode` is set to `true`:
- `enableRailDragging` is forced to `false`, disabling the drag functionality and the Undock button.
- The `AzNavRail` component is initialized in an expanded state (`initiallyExpanded = true`).

This simplifies the configuration for Android Bubble activities, allowing a single setting to enable the correct behavior.

Unit tests have been added to verify the `AzNavRailScopeImpl` logic. Documentation has been updated to reflect the new parameter and its usage.

## Summary by Sourcery

Add a bubble mode configuration to AzNavRail to simplify setup for Android Bubble activities and adjust rail behavior accordingly.

New Features:
- Introduce a bubbleMode parameter to the azSettings DSL to enable bubble-specific behavior for AzNavRail.

Enhancements:
- Automatically disable rail dragging and start the rail expanded when bubbleMode is enabled.
- Store bubbleMode in AzNavRailScopeImpl and derive the initial expansion state from it in AzNavRail.

Documentation:
- Document the new bubbleMode parameter in the README and update the Bubble Activity usage example to rely on it.

Tests:
- Add unit tests to verify that azSettings correctly updates bubbleMode and forces enableRailDragging to false when bubbleMode is enabled.