### PR TITLE
docs: update README with bubbleTargetActivity usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Use the `bubbleTargetActivity` parameter in your main activity's `AzNavRail` set
 ```kotlin
 AzNavRail {
     azSettings(
-        // Enable drag dragging so the Undock button appears
+        // Enable rail dragging so the Undock button appears
         enableRailDragging = true,
         // Provide the class of the Activity to launch as a bubble
         bubbleTargetActivity = BubbleActivity::class.java


### PR DESCRIPTION
Updated the README.md to reflect the new `bubbleTargetActivity` parameter in `azSettings` for simpler Android Bubble integration. Removed the outdated manual `createBubble` example.

## Summary by Sourcery

Introduce a configurable bubble target activity for AzNavRail and centralize Bubble API integration while updating samples and documentation.

New Features:
- Add a bubbleTargetActivity parameter to AzNavRail settings to automatically launch a specified Activity as an Android Bubble when undocked or dragged.

Enhancements:
- Centralize Bubble creation logic into a reusable BubbleHelper utility and update AzNavRail behavior to favor bubbleTargetActivity over internal floating mode when provided.

Documentation:
- Update README and agent documentation to describe bubbleTargetActivity usage, simplify Bubble setup instructions, and reflect the updated azSettings API signature.