### PR TITLE
fix(bubble): use resource-based icon for bubbles to avoid bitmap warn…

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/BubbleHelper.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/BubbleHelper.kt
@@ -43,8 +43,14 @@ internal object BubbleHelper {
 
         // Try to get the app icon, fallback to system default
         val icon = try {
-            val appIconDrawable = context.packageManager.getApplicationIcon(context.packageName)
-            IconCompat.createWithBitmap(appIconDrawable.toBitmap())
+            val pm = context.packageManager
+            val appInfo = pm.getApplicationInfo(context.packageName, 0)
+            if (appInfo.icon != 0) {
+                IconCompat.createWithResource(context, appInfo.icon)
+            } else {
+                val appIconDrawable = pm.getApplicationIcon(context.packageName)
+                IconCompat.createWithBitmap(appIconDrawable.toBitmap())
+            }
         } catch (e: Exception) {
             IconCompat.createWithResource(context, android.R.drawable.sym_def_app_icon)
         }


### PR DESCRIPTION
…ings

## Summary by Sourcery

Bug Fixes:
- Avoid warnings by preferring a resource-based app icon for bubble notifications, with a safe fallback path when no icon resource is defined.