### PR TITLE
Fix: prevent onToggle from being called in Footer

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
@@ -83,7 +83,7 @@ internal fun Footer(
                 isSelected = false,
                 onClick = onUndock,
                 onCyclerClick = null,
-                onToggle = {}, // This is the fix: prevent onToggle from being called
+                onToggle = {},
                 onItemClick = {}
             )
         }


### PR DESCRIPTION
Removed the redundant comment in Footer.kt as the fix (assigning an empty lambda to onToggle) is already implemented. The code effectively prevents the 'Undock' action from collapsing the rail.

## Summary by Sourcery

Enhancements:
- Clean up Footer by removing a redundant comment related to the onToggle behavior.