### PR TITLE
doc: Add comment explaining disabled toggle for Undock item

Explicitly document why onToggle is set to an empty lambda for the "Undock" menu item in the footer. This prevents the default toggle behavior (collapsing the rail) which conflicts with the undocking action (switching to FAB mode).

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
@@ -83,7 +83,7 @@ internal fun Footer(
                 isSelected = false,
                 onClick = onUndock,
                 onCyclerClick = null,
-                onToggle = {},
+                onToggle = {}, // This is the fix: prevent onToggle from being called
                 onItemClick = {}
             )
         }


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add an inline code comment clarifying that the Undock menu item's onToggle is intentionally set to a no-op to avoid triggering the default toggle behavior.