### PR TITLE
Support string resource IDs in helpList

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -74,7 +74,7 @@ interface AzNavRailScope {
      * @param helpList An optional map of Item ID to help text.
      * @param tutorials An optional map of Item ID to interactive AzTutorials.
      */
-    fun azAdvanced(isLoading: Boolean = false, helpEnabled: Boolean = false, onDismissHelp: (() -> Unit)? = null, overlayService: Class<out android.app.Service>? = null, onUndock: (() -> Unit)? = null, enableRailDragging: Boolean = false, onRailDrag: ((Float, Float) -> Unit)? = null, onOverlayDrag: ((Float, Float) -> Unit)? = null, onItemGloballyPositioned: ((String, Rect) -> Unit)? = null, secLoc: String? = null, secLocPort: Int = 10203, helpList: Map<String, String> = emptyMap(), tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial> = emptyMap())
+    fun azAdvanced(isLoading: Boolean = false, helpEnabled: Boolean = false, onDismissHelp: (() -> Unit)? = null, overlayService: Class<out android.app.Service>? = null, onUndock: (() -> Unit)? = null, enableRailDragging: Boolean = false, onRailDrag: ((Float, Float) -> Unit)? = null, onOverlayDrag: ((Float, Float) -> Unit)? = null, onItemGloballyPositioned: ((String, Rect) -> Unit)? = null, secLoc: String? = null, secLocPort: Int = 10203, helpList: Map<String, Any> = emptyMap(), tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial> = emptyMap())
 
     /**
      * A comprehensive configuration method combining settings, theme, and advanced options.
@@ -103,7 +103,7 @@ interface AzNavRailScope {
         usePhysicalDocking: Boolean = false,
         secLoc: String? = null,
         secLocPort: Int = 10203,
-        helpList: Map<String, String> = emptyMap(),
+        helpList: Map<String, Any> = emptyMap(),
         tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial> = emptyMap(),
         helpLineColors: List<Color> = emptyList()
     )
@@ -449,7 +449,7 @@ class AzNavRailScopeImpl : AzNavRailScope {
         this.helpLineColors = helpLineColors
     }
 
-    override fun azAdvanced(isLoading: Boolean, helpEnabled: Boolean, onDismissHelp: (() -> Unit)?, overlayService: Class<out android.app.Service>?, onUndock: (() -> Unit)?, enableRailDragging: Boolean, onRailDrag: ((Float, Float) -> Unit)?, onOverlayDrag: ((Float, Float) -> Unit)?, onItemGloballyPositioned: ((String, Rect) -> Unit)?, secLoc: String?, secLocPort: Int, helpList: Map<String, String>, tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial>) {
+    override fun azAdvanced(isLoading: Boolean, helpEnabled: Boolean, onDismissHelp: (() -> Unit)?, overlayService: Class<out android.app.Service>?, onUndock: (() -> Unit)?, enableRailDragging: Boolean, onRailDrag: ((Float, Float) -> Unit)?, onOverlayDrag: ((Float, Float) -> Unit)?, onItemGloballyPositioned: ((String, Rect) -> Unit)?, secLoc: String?, secLocPort: Int, helpList: Map<String, Any>, tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial>) {
         this.advancedConfig = AzAdvancedConfig(
             isLoading = isLoading,
             helpEnabled = helpEnabled,
@@ -490,7 +490,7 @@ class AzNavRailScopeImpl : AzNavRailScope {
         usePhysicalDocking: Boolean,
         secLoc: String?,
         secLocPort: Int,
-        helpList: Map<String, String>,
+        helpList: Map<String, Any>,
         tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial>,
         helpLineColors: List<Color>
     ) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/HelpOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/HelpOverlay.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -33,7 +34,7 @@ internal fun HelpOverlay(
     helpLineColors: List<Color> = emptyList(),
     onDismiss: () -> Unit,
     itemBoundsCache: Map<String, Rect> = emptyMap(),
-    helpList: Map<String, String> = emptyMap(),
+    helpList: Map<String, Any> = emptyMap(),
     nestedRailOpenId: String? = null,
     tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial> = emptyMap(),
     onTutorialLaunch: ((String) -> Unit)? = null
@@ -46,7 +47,11 @@ internal fun HelpOverlay(
                 flatItems.addAll(nestedHost.nestedRailItems)
             }
         }
-        flatItems.filter { !it.info.isNullOrBlank() || !helpList[it.id].isNullOrBlank() || tutorials.containsKey(it.id) }
+        flatItems.filter { item ->
+            val listTextRaw = helpList[item.id]
+            val hasValidListText = listTextRaw != null && (listTextRaw !is String || listTextRaw.isNotBlank())
+            !item.info.isNullOrBlank() || hasValidListText || tutorials.containsKey(item.id)
+        }
     }
     val safeZones = LocalAzSafeZones.current
     val density = LocalDensity.current
@@ -128,7 +133,8 @@ internal fun HelpOverlay(
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                     val infoText = item.info
-                    val listText = helpList[item.id]
+                    val listTextRaw = helpList[item.id]
+                    val listText = if (listTextRaw is Int) stringResource(id = listTextRaw) else listTextRaw as? String
 
                     if (!infoText.isNullOrBlank()) {
                         Text(

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/NestedRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/NestedRail.kt
@@ -39,7 +39,7 @@ internal fun NestedRail(
     onItemSelected: (AzNavItem) -> Unit,
     alignment: AzNestedRailAlignment,
     isRightDocked: Boolean,
-    helpList: Map<String, String> = emptyMap(),
+    helpList: Map<String, Any> = emptyMap(),
     onItemGloballyPositioned: ((String, androidx.compose.ui.geometry.Rect) -> Unit)? = null
 ) {
     val configuration = LocalConfiguration.current

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzAdvancedConfig.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzAdvancedConfig.kt
@@ -19,6 +19,6 @@ data class AzAdvancedConfig(
     val onItemGloballyPositioned: ((String, Rect) -> Unit)? = null,
     val secLoc: String? = null,
     val secLocPort: Int = 10203,
-    val helpList: Map<String, String> = emptyMap(),
+    val helpList: Map<String, Any> = emptyMap(),
     val tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial> = emptyMap()
 )


### PR DESCRIPTION
Fixes an issue where users were unable to use string resources within the `helpList` mapping. The `helpList` mapping type has been updated to `Map<String, Any>`, allowing users to pass `@StringRes` IDs natively without needing a `@Composable` context. In `HelpOverlay.kt`, integer values are now evaluated safely with `stringResource`.

---
*PR created automatically by Jules for task [14483469490295264447](https://jules.google.com/task/14483469490295264447) started by @HereLiesAz*

## Summary by Sourcery

Allow help overlay help text to be supplied as either raw strings or string resource IDs.

New Features:
- Support passing @StringRes integer IDs in the helpList mapping alongside string values for help overlays.

Bug Fixes:
- Ensure help overlay items are correctly included when help text is supplied via non-blank values in the updated helpList type.

Enhancements:
- Propagate the new flexible helpList type through AzNavRailScope, NestedRail, and AzAdvancedConfig to keep configuration consistent.