### PR TITLE
🔒 [security fix] Add validation to geographic Intents in SecretScreens

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/SecretScreens.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/SecretScreens.kt
@@ -440,9 +440,17 @@ internal fun HistoryList(
                 colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
                 modifier = Modifier.fillMaxWidth().clickable {
                     try {
-                        val uri = Uri.parse("geo:${entry.lat},${entry.lng}?q=${entry.lat},${entry.lng}")
-                        val intent = Intent(Intent.ACTION_VIEW, uri)
-                        context.startActivity(intent)
+                        if (entry.lat in -90.0..90.0 && entry.lng in -180.0..180.0) {
+                            val uri = Uri.parse("geo:${entry.lat},${entry.lng}?q=${entry.lat},${entry.lng}")
+                            if (uri.scheme == "geo") {
+                                val intent = Intent(Intent.ACTION_VIEW, uri)
+                                context.startActivity(intent)
+                            } else {
+                                Log.w("SecretScreens", "Invalid URI scheme: ${uri.scheme}")
+                            }
+                        } else {
+                            Log.w("SecretScreens", "Invalid coordinates: lat=${entry.lat}, lng=${entry.lng}")
+                        }
                     } catch (e: Exception) {
                         Log.e("SecretScreens", "Could not open map", e)
                     }


### PR DESCRIPTION
This commit addresses a security vulnerability where an unvalidated Intent was started using a `geo:` URI constructed from coordinate data.

Changes:
- Added latitude validation (range: -90.0 to 90.0).
- Added longitude validation (range: -180.0 to 180.0).
- Explicitly verified that the parsed URI scheme is "geo" before starting the Activity.
- Added warning logs for invalid data or schemes.

These checks prevent potential URI injection or malformed Intent attacks, especially when location data is received from external sources in Viewer mode.

## Summary by Sourcery

Validate and safely handle geo-based Intents launched from SecretScreens history entries to prevent misuse of malformed or untrusted coordinate data.

Bug Fixes:
- Add range validation for latitude and longitude before constructing geo URIs from history entries.
- Ensure only URIs with the geo scheme are used to start map-viewing Intents, logging and rejecting invalid schemes or coordinates.