### PR TITLE
chore: remove unused imports in AzNavRailTest.kt

### DIFF
--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailTest.kt
@@ -2,14 +2,10 @@ package com.hereliesaz.aznavrail
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.rememberNavController
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import com.hereliesaz.aznavrail.model.AzDockingSide
 import com.hereliesaz.aznavrail.model.AzNavItem
-import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import org.junit.Assert.assertEquals
 import org.junit.Rule


### PR DESCRIPTION
Removed several unused imports in `AzNavRailTest.kt` to improve code cleanliness and maintainability:
- `androidx.compose.ui.test.onNodeWithText`
- `androidx.compose.ui.test.performClick`
- `androidx.compose.runtime.remember`
- `com.hereliesaz.aznavrail.model.AzButtonShape`

## Summary by Sourcery

Enhancements:
- Remove unused imports from AzNavRailTest.kt to improve test code clarity and maintainability.