### PR TITLE
Fix/react subitems and test await 15621854283673383421

### DIFF
--- a/aznavrail-react/src/__tests__/AzNavRailFull.test.tsx
+++ b/aznavrail-react/src/__tests__/AzNavRailFull.test.tsx
@@ -17,15 +17,15 @@ describe('AzNavRail Full Suite', () => {
       jest.clearAllMocks();
   });
 
-  it('renders loading overlay at root level when isLoading is true', async () => {
+  it('renders loading overlay at root level when isLoading is true', () => {
     let component: renderer.ReactTestRenderer;
-    await renderer.act(async () => {
-      component = renderer.create(
+    renderer.act(() => {
+component = renderer.create(
         <AzNavRail isLoading={true}>
           <Text>Content</Text>
         </AzNavRail>
       );
-    });
+});
     const root = component.root;
 
     // Find view with zIndex 10000
@@ -37,31 +37,31 @@ describe('AzNavRail Full Suite', () => {
     expect(loader.length).toBe(1);
 
     // Explicitly unmount to avoid warnings
-    await renderer.act(async () => {
-        component.unmount();
+    renderer.act(() => {
+      component.unmount();
     });
   });
 
-  it('handles RelocItemHandler drag and drop reordering', async () => {
+  it('handles RelocItemHandler drag and drop reordering', () => {
     const mockOnRelocate = jest.fn();
 
     let component: renderer.ReactTestRenderer;
-    await renderer.act(async () => {
-        component = renderer.create(
+    renderer.act(() => {
+component = renderer.create(
           <AzNavRail initiallyExpanded={false}>
             <AzRailHostItem id="host" text="Host" />
             <AzRailRelocItem id="reloc1" hostId="host" text="Reloc1" onRelocate={mockOnRelocate} />
             <AzRailRelocItem id="reloc2" hostId="host" text="Reloc2" />
           </AzNavRail>
         );
-    });
+});
 
     const root = component.root;
     const buttons = root.findAllByType(AzButton);
     const hostBtn = buttons.find((b) => b.props.text === 'Host');
 
     // Expand host
-    await renderer.act(async () => {
+    renderer.act(() => {
         hostBtn.props.onClick();
     });
 
@@ -74,7 +74,7 @@ describe('AzNavRail Full Suite', () => {
     // Find its index in the items array. The wrapper gets index from mapping over `effectiveRailItems`
     const index = firstWrapper.props.index;
 
-    await renderer.act(async () => {
+    renderer.act(() => {
         // Simulate dragging down past the second item (dy = 60)
         firstWrapper.props.onDragMove(60, index);
 
@@ -87,28 +87,28 @@ describe('AzNavRail Full Suite', () => {
     expect(mockOnRelocate).toHaveBeenCalledWith(0, 1, ['reloc2', 'reloc1']);
 
     // Explicitly unmount to avoid warnings
-    await renderer.act(async () => {
-        component.unmount();
+    renderer.act(() => {
+      component.unmount();
     });
   });
 
-  it('enforces NONE shape for SubItems regardless of props', async () => {
+  it('enforces NONE shape for SubItems regardless of props', () => {
     let component: renderer.ReactTestRenderer;
-    await renderer.act(async () => {
-        component = renderer.create(
+    renderer.act(() => {
+component = renderer.create(
           <AzNavRail initiallyExpanded={false}>
             <AzRailHostItem id="host" text="Host" />
             <AzRailSubItem id="sub" hostId="host" text="Sub" shape={AzButtonShape.SQUARE} />
           </AzNavRail>
         );
-    });
+});
 
     const root = component.root;
     const buttons = root.findAllByType(AzButton);
     const hostBtn = buttons.find((b: any) => b.props.text === 'Host');
 
     // Expand host
-    await renderer.act(async () => {
+    renderer.act(() => {
         hostBtn.props.onClick();
     });
 
@@ -119,8 +119,8 @@ describe('AzNavRail Full Suite', () => {
     expect(subBtn.props.shape).toBe(AzButtonShape.NONE);
 
     // Explicitly unmount to avoid warnings
-    await renderer.act(async () => {
-        component.unmount();
+    renderer.act(() => {
+      component.unmount();
     });
   });
 });

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import './AzNavRail.css';
 import MenuItem from './MenuItem';
 import AzNavRailButton from './AzNavRailButton';
 import HelpOverlay from './HelpOverlay';
 import AzNestedRailPopup from './AzNestedRailPopup';
-import { RelocItemHandler } from '../utils/RelocItemHandler';
+import { RelocItemHandler } from '../util/RelocItemHandler';
 import AzDivider from './AzDivider';
 import AzTextBox from './AzTextBox';
 
@@ -120,6 +120,12 @@ const AzNavRail = ({
     localNavItems.forEach(processItem);
     return map;
   }, [localNavItems]);
+
+  const getEffectiveSubItems = useCallback((item) => {
+    const subItemsFromMap = subItemsMap[item.id] || [];
+    const subItemsFromProp = item.items || [];
+    return subItemsFromMap.length > 0 ? subItemsFromMap : subItemsFromProp;
+  }, [subItemsMap]);
 
   const cyclerTimers = useRef({});
   const dragStartY = useRef(0);
@@ -285,11 +291,9 @@ const AzNavRail = ({
         ? { ...item, selectedOption: cyclerStates[item.id]?.displayedOption }
         : item;
 
-      const subItemsFromMap = subItemsMap[item.id] || [];
-      const subItemsFromProp = item.items || [];
-      const subItems = subItemsFromMap.length > 0 ? subItemsFromMap : subItemsFromProp;
+      const effectiveSubItems = getEffectiveSubItems(item);
 
-      const isHost = item.isHost || subItems.length > 0;
+      const isHost = item.isHost || effectiveSubItems.length > 0;
       const isHostExpanded = hostStates[item.id];
       const isActive = checkIsActive(item);
 
@@ -307,7 +311,7 @@ const AzNavRail = ({
               />
               {isHost && isHostExpanded && (
                   <div className="az-nav-rail-subitems">
-                      {subItems.map(subItem => renderMenuItem(subItem, depth + 1))}
+                      {effectiveSubItems.map(subItem => renderMenuItem(subItem, depth + 1))}
                   </div>
               )}
           </React.Fragment>
@@ -320,15 +324,15 @@ const AzNavRail = ({
         if (item.isRailItem || item.items) {
             visible.push(item);
             if (hostStates[item.id]) {
-               const subItems = subItemsMap[item.id] || [];
-               subItems.forEach(sub => {
+               const mapSubs = getEffectiveSubItems(item);
+               mapSubs.forEach(sub => {
                    if (sub.isRailItem) visible.push(sub);
                });
             }
         }
     });
     return visible;
-  }, [navItems, hostStates, subItemsMap]);
+  }, [navItems, hostStates, subItemsMap, getEffectiveSubItems]);
 
   const effectiveRailItems = useMemo(() => {
     return navItems.filter(item => item.isRailItem || item.items || subItemsMap[item.id]);
@@ -351,7 +355,7 @@ const AzNavRail = ({
     <>
     <div
       className={`az-nav-rail ${isExpanded ? 'expanded' : 'collapsed'} ${dockingSide === 'RIGHT' ? 'right' : ''}`}
-      style={{ width: isExpanded ? expandedRailWidth : collapsedRailWidth }}
+      style={{ width: isExpanded ? expandedRailWidth : collapsedRailWidth, backgroundColor: translucentBackground || '#f0f0f0' }}
     >
       <div className="header" onClick={onToggle}>
         {displayAppNameInHeader ? (
@@ -583,7 +587,7 @@ const AzNavRail = ({
             railWidth={collapsedRailWidth}
             onDismiss={onDismissInfoScreen}
             nestedRailVisibleId={nestedRailVisibleId}
-            helpList={helpList}
+            helpList={settings?.helpList || {}}
         />
     )}
 

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -511,12 +511,7 @@ const AzNavRail = ({
                                     return;
                                 }
                                 if (item.items || subItemsMap[item.id]) {
-                                    if (infoScreen) {
-                                        toggleHost(item);
-                                    } else {
-                                        setIsExpanded(true);
-                                        setHostStates(prev => ({ ...prev, [item.id]: true }));
-                                    }
+                                    toggleHost(item);
                                 }
                             }}
                             infoScreen={infoScreen}


### PR DESCRIPTION
## Summary by Sourcery

Align AzNavRail subitem handling and expansion behavior with internal state while simplifying related React tests.

Bug Fixes:
- Ensure host items correctly use either mapped or inline subitems for rendering, host detection, and visibility calculations.
- Apply translucent background color to the rail container when configured and provide a safe default when not.
- Standardize host toggle behavior so clicking items with subitems always goes through the same toggle logic regardless of info screen state.
- Pass help list configuration to the settings/info panel from nested settings when present, avoiding undefined help list usage.

Enhancements:
- Refactor subitem resolution into a reusable helper for consistent use across rendering and visibility computations.
- Simplify React test cases by converting unnecessary async renderer.act calls to synchronous usage.