### PR TITLE
Optimize setup_android.sh by skipping redundant installations

### DIFF
--- a/setup_android.sh
+++ b/setup_android.sh
@@ -3,9 +3,13 @@
 set -euo pipefail
 
 # --- 1. Install Java Development Kit (JDK) ---
-echo "➡️ Installing OpenJDK 17..."
-sudo apt-get update
-sudo apt-get install -y openjdk-17-jdk
+if dpkg -s openjdk-17-jdk >/dev/null 2>&1; then
+    echo "➡️ OpenJDK 17 is already installed, skipping..."
+else
+    echo "➡️ Installing OpenJDK 17..."
+    sudo apt-get update
+    sudo apt-get install -y openjdk-17-jdk
+fi
 
 # --- 2. Install Android Command Line Tools ---
 echo "➡️ Setting up Android SDK..."
@@ -16,16 +20,20 @@ TOOLS_VERSION="11076708"
 TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-${TOOLS_VERSION}_latest.zip"
 TOOLS_ZIP="/tmp/android-tools.zip"
 
-# Download and place the tools in their final destination
-mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
-wget -q "$TOOLS_URL" -O "$TOOLS_ZIP"
+if [ -f "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
+    echo "➡️ Android Command Line Tools are already installed, skipping download..."
+else
+    # Download and place the tools in their final destination
+    mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+    wget -q "$TOOLS_URL" -O "$TOOLS_ZIP"
 
-# Unzip and restructure the directory
-# The zip file contains a single 'cmdline-tools' folder. We unzip it and rename it to 'latest'.
-rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
-unzip -oq "$TOOLS_ZIP" -d "$ANDROID_SDK_ROOT/cmdline-tools"
-mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
-rm "$TOOLS_ZIP"
+    # Unzip and restructure the directory
+    # The zip file contains a single 'cmdline-tools' folder. We unzip it and rename it to 'latest'.
+    rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+    unzip -oq "$TOOLS_ZIP" -d "$ANDROID_SDK_ROOT/cmdline-tools"
+    mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+    rm "$TOOLS_ZIP"
+fi
 
 # --- 3. Set Environment Variables Permanently ---
 echo "➡️ Configuring environment variables..."


### PR DESCRIPTION
Updates the setup_android.sh script with idempotency checks so that the Java and Android SDK installations are skipped if they already exist, significantly speeding up subsequent environment initializations.

---
*PR created automatically by Jules for task [16256630219184760641](https://jules.google.com/task/16256630219184760641) started by @HereLiesAz*

## Summary by Sourcery

Make the Android setup script idempotent by skipping Java and Android command-line tools installation when they are already present.

New Features:
- Add checks to skip installing OpenJDK 17 if it is already installed.
- Add checks to skip downloading and extracting Android command-line tools if they are already installed.