### PR TITLE
docs: sync nested sub-host coverage across all documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ are easy to navigate.
   item is expanded. They can also be placed in the rail or the menu. A rail Sub item must be the
   child of a rail host, but menu sub items may be the child of a rail host or menu host.
 
+- **Sub-Hosts (`azRailSubHostItem` / `azMenuSubHostItem`)**: A sub-item that is itself a host.
+  Hosts nest to **any depth**: opening a sub-host reveals its children inline while sibling
+  sub-items stay visible (accordion behavior at every level). Children attach to their host by
+  `hostId` reference, not by position.
+
 - **Nested Rails (`azNestedRail`)**: This is a distinct feature from Host Items. A Nested Rail opens a separate **popup overlay** adjacent to the parent item instead of expanding inline. It supports `VERTICAL` (column) and `HORIZONTAL` (row) alignment.
 
 - **Orientation Handling**: The rail supports two modes:

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ import { AzRoller } from '@HereLiesAz/aznavrail-react';
 
 -   **Host Items**: These are top-level items that can contain sub-items. They can be placed in the rail or the menu.
 -   **Sub-Items**: These are nested items that are only visible when their host item is expanded. They can also be placed in the rail or the menu.
+-   **Sub-Hosts**: A sub-item can itself be a host (`azRailSubHostItem` / `azMenuSubHostItem`), so hosts nest to **any depth**. Opening a sub-host reveals its children inline while sibling sub-items stay visible. Children attach to their host by `hostId` reference, not by position.
 -   **Exclusive Expansion**: Only one host item can be expanded at a time. Expanding a host item automatically collapses any other open host items.
 
 

--- a/SampleApp/COVERAGE.md
+++ b/SampleApp/COVERAGE.md
@@ -25,6 +25,7 @@ should be added before shipping.
 | `azRailCycler` / `azMenuCycler` (`disabledOptions`) | `MainApp.kt` (rail-cycler with disabled "C", menu-cycler) |
 | `azRailHostItem` / `azMenuHostItem` | `MainApp.kt` |
 | `azRailSubItem` / `azMenuSubItem` | `MainApp.kt` |
+| `azRailSubHostItem` / `azMenuSubHostItem` (nested host under a host) | `MainApp.kt` (`rail-subhost`, `menu-subhost`) |
 | `azRailSubToggle` / `azMenuSubToggle` | `MainApp.kt` (sub-toggle under menu-host) |
 | `azRailSubCycler` / `azMenuSubCycler` | `MainApp.kt` (sub-cycler under rail-host) |
 | `azHelpRailItem` | `MainApp.kt` (toggle-help) |

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -18,6 +18,11 @@
 - `MIGRATION_FROM_ANDROID.md` mapping the Compose DSL surface to the React JSX surface.
 - `KNOWN_GAPS.md` documenting platform-shaped gaps (`SYSTEM_ALERT_WINDOW`, `AzActivity`,
   the secret-screen TCP sync, the inset-aware variant on web).
+- `AzRailSubHostItem` / `AzMenuSubHostItem` — a sub-item that is itself a host. Hosts now
+  nest to any depth: opening a sub-host reveals its children inline while sibling sub-items
+  stay visible. Children attach to their host by `hostId` reference. Rail rendering is a
+  single recursive path with cycle detection so a self-referential or cyclic `hostId`
+  cannot loop.
 
 ### Changed
 - `onInteraction` callback now passes `AzNavItem` as 3rd argument for item-level analytics.

--- a/aznavrail-react/MIGRATION_FROM_ANDROID.md
+++ b/aznavrail-react/MIGRATION_FROM_ANDROID.md
@@ -13,6 +13,7 @@ the React/JSX surface exposed by `@HereLiesAz/aznavrail-react`.
 | `azRailCycler(...)` / `azMenuCycler(...)` | `<AzRailCycler ... />` / `<AzMenuCycler ... />` |
 | `azRailHostItem(...)` / `azMenuHostItem(...)` | `<AzRailHostItem ... />` / `<AzMenuHostItem ... />` |
 | `azRailSubItem(...)` / `azMenuSubItem(...)` | `<AzRailSubItem ... />` / `<AzMenuSubItem ... />` |
+| `azRailSubHostItem(...)` / `azMenuSubHostItem(...)` | `<AzRailSubHostItem ... />` / `<AzMenuSubHostItem ... />` |
 | `azNestedRail(id, text, alignment) { ... }` | `<AzNestedRail id text alignment>... </AzNestedRail>` |
 | `azRailRelocItem(id, hostId, ...) { hiddenMenu }` | `<AzRailRelocItem id hostId hiddenMenu={...}>` |
 | `azDivider()` | `<AzDivider />` |

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -302,6 +302,28 @@ azHelpSubItem(id = "help-sub-item", hostId = "rail-host", text = "Help Sub")
 azRailSubCycler(id = "sub-cycler", hostId = "rail-host", options = listOf("A", "B"), selectedOption = "A")
 ```
 
+### Nested hosts (sub-items that are also hosts)
+
+A sub-item can itself be a host with its own sub-items via `azRailSubHostItem` /
+`azMenuSubHostItem`. Hosts nest to **any depth**: opening a sub-host reveals its children
+inline while its sibling sub-items stay visible (accordion behavior at every level).
+
+Children are matched to their host by `hostId` (a reference, not by position), so a sub-host's
+children are unambiguous even when they sit among other sub-items.
+
+```kotlin
+azRailHostItem(id = "rail-host", text = "Rail Host")
+azRailSubItem(id = "rail-sub-1", hostId = "rail-host", text = "Rail Sub 1")
+
+// "rail-subhost" is a child of "rail-host" AND a host for its own children.
+azRailSubHostItem(id = "rail-subhost", hostId = "rail-host", text = "Rail Sub Host")
+azRailSubItem(id = "nested-a", hostId = "rail-subhost", text = "Nested A")
+azRailSubItem(id = "nested-b", hostId = "rail-subhost", text = "Nested B")
+```
+
+> The parent host referenced by `hostId` must be declared **before** the sub-host, and a
+> sub-host may not reference itself.
+
 ---
 
 ## 5. Drag & Drop (Relocatable Items)

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -302,6 +302,28 @@ azHelpSubItem(id = "help-sub-item", hostId = "rail-host", text = "Help Sub")
 azRailSubCycler(id = "sub-cycler", hostId = "rail-host", options = listOf("A", "B"), selectedOption = "A")
 ```
 
+### Nested hosts (sub-items that are also hosts)
+
+A sub-item can itself be a host with its own sub-items via `azRailSubHostItem` /
+`azMenuSubHostItem`. Hosts nest to **any depth**: opening a sub-host reveals its children
+inline while its sibling sub-items stay visible (accordion behavior at every level).
+
+Children are matched to their host by `hostId` (a reference, not by position), so a sub-host's
+children are unambiguous even when they sit among other sub-items.
+
+```kotlin
+azRailHostItem(id = "rail-host", text = "Rail Host")
+azRailSubItem(id = "rail-sub-1", hostId = "rail-host", text = "Rail Sub 1")
+
+// "rail-subhost" is a child of "rail-host" AND a host for its own children.
+azRailSubHostItem(id = "rail-subhost", hostId = "rail-host", text = "Rail Sub Host")
+azRailSubItem(id = "nested-a", hostId = "rail-subhost", text = "Nested A")
+azRailSubItem(id = "nested-b", hostId = "rail-subhost", text = "Nested B")
+```
+
+> The parent host referenced by `hostId` must be declared **before** the sub-host, and a
+> sub-host may not reference itself.
+
 ---
 
 ## 5. Drag & Drop (Relocatable Items)

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -84,6 +84,8 @@ The following functions are used to define the rail structure.
 * `azRailHostItem(id, text, route, content, color, shape, disabled, screenTitle, info, onClick)`
 * `azMenuSubItem(id, hostId, text, route, content, color, shape, disabled, screenTitle, info, onClick)`
 * `azRailSubItem(id, hostId, text, route, content, color, shape, disabled, screenTitle, info, classifiers, onFocus, onClick)`
+* `azMenuSubHostItem(id, hostId, text, route, content, color, shape, disabled, screenTitle, info, classifiers, menuText, textColor, fillColor, onClick)` — a sub-item that is itself a host; nests to any depth.
+* `azRailSubHostItem(id, hostId, text, route, content, color, shape, disabled, screenTitle, info, classifiers, menuText, textColor, fillColor, onClick)` — a sub-item that is itself a host; nests to any depth.
 * `azMenuSubToggle(id, hostId, isChecked, toggleOnText, toggleOffText, route, color, shape, disabled, screenTitle, info, onClick)`
 * `azRailSubToggle(id, hostId, isChecked, toggleOnText, toggleOffText, route, color, shape, disabled, screenTitle, info, onClick)`
 * `azMenuSubCycler(id, hostId, options, selectedOption, route, color, shape, disabled, disabledOptions, screenTitle, info, onClick)`


### PR DESCRIPTION
## Summary

PR #451 introduced `azRailSubHostItem` / `azMenuSubHostItem` (sub-items that are themselves hosts, nesting to any depth) but only documented them in `README.md` and the `assets/` copy of the complete guide. This PR brings the **rest** of the documentation in line so nothing references the host builders without also covering sub-hosts.

## Changes

- **`aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md`** and **`docs/AZNAVRAIL_COMPLETE_GUIDE.md`** — add the "Nested hosts (sub-items that are also hosts)" section. (These two copies had drifted from `assets/` and were missing it.)
- **`docs/DSL.md`** — list `azMenuSubHostItem` / `azRailSubHostItem` with full signatures.
- **`SampleApp/COVERAGE.md`** — map the new builders to their `MainApp.kt` demo (`rail-subhost`, `menu-subhost`).
- **`aznavrail-react/MIGRATION_FROM_ANDROID.md`** — add the Android → React mapping row.
- **`aznavrail-react/CHANGELOG.md`** — note the new React components + cycle detection under 0.2.0.
- **`AGENTS.md`** and **`README.md`** — describe sub-hosts in the hierarchy sections.

Docs-only change; no source or test files touched.

https://claude.ai/code/session_01Wpv9thkrHYKZvpeYjNz4de

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wpv9thkrHYKZvpeYjNz4de)_