### PR TITLE
Render vector graphics as rail-item content, filling the shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This document serves as a detailed specification and behavior guide for the AzNa
   text MUST MUST MUST fit inside the shape, no wrapping allowed without the developer explicitly
   deciding to do so with a newline character.
 
-- **Content Filling**: If a Rail Item's content is a `Color`, an Image Resource ID (`Int`), or an Image URL/Model (`Any`), it MUST fill the button shape completely (Fill/Crop) with 0 padding. Text and Numbers retain default padding.
+- **Content Filling**: If a Rail Item's content is a `Color`, an Image Resource ID (`Int`), a Compose `ImageVector` or `Painter` (vector graphics), or an Image URL/Model (`Any`), it MUST fill the button shape completely (Fill/Crop) with 0 padding, clipping as needed. `ImageVector` content is tinted with the item color. Text and Numbers retain default padding.
 
 - To be clear, if the developer has a multi-word string for a rail item, they DO need the ability to
   put the words on separate lines.

--- a/SampleApp/COVERAGE.md
+++ b/SampleApp/COVERAGE.md
@@ -20,7 +20,7 @@ should be added before shipping.
 | `azTheme` (`activeColor`, `defaultShape`, `headerIconShape`, `translucentBackground`, `helpLineColors`) | `MainApp.kt`, driven by `CustomizationDemoScreen` |
 | `azAdvanced` (`isLoading`, `helpEnabled`, `onDismissHelp`, `enableRailDragging`, `onRailDrag`, `onOverlayDrag`, `onUndock`, `helpList`, `tutorials`) | `MainApp.kt`, driven by `FabOverlayDemoScreen`, `HelpSystemDemoScreen`, `TutorialDemoScreen` |
 | `azMenuItem` | `MainApp.kt` (10× showcase menu items) |
-| `azRailItem` (Color/ResourceId/AzComposableContent variants, shape, disabled, classifiers, info) | `MainApp.kt` rail items |
+| `azRailItem` (Color/ResourceId/ImageVector/AzComposableContent content variants, shape, disabled, classifiers, info) | `MainApp.kt` rail items (`color-item`, `icon-item`, `vector-item`) |
 | `azRailToggle` / `azMenuToggle` | `MainApp.kt` (pack-rail, online, dark-mode, docking-side, no-menu, physical-docking) |
 | `azRailCycler` / `azMenuCycler` (`disabledOptions`) | `MainApp.kt` (rail-cycler with disabled "C", menu-cycler) |
 | `azRailHostItem` / `azMenuHostItem` | `MainApp.kt` |

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
@@ -3,6 +3,8 @@ package com.hereliesaz.SampleApp
 import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -247,6 +249,14 @@ fun MainApp() {
             content = android.R.drawable.ic_menu_agenda,
             info = "Demonstrates dynamic content with Resource ID",
             onClick = { Log.d(TAG, "Icon item clicked") },
+        )
+
+        azRailItem(
+            id = "vector-item",
+            text = "Vector",
+            content = Icons.Default.Delete,
+            info = "Demonstrates dynamic content with a Compose ImageVector (fills + clips the shape)",
+            onClick = { Log.d(TAG, "Vector item clicked") },
         )
 
         // ---------- AzButtonShape showcase: one rail item per shape value ----------

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 0.2.0
 
 ### Added
+- Rail-item `content` now accepts an **image source** (`require()` id or `{ uri }`) in addition
+  to a React node, and any graphic content (image source, `<Image>`, or a `react-native-svg`
+  `<Svg>`) **fills the item's shape** — scaled to cover and clipped — without changing the
+  item's dimensions. `<Image>` elements are coerced to `resizeMode="cover"`; other elements
+  are stretched to 100% × 100%. (Mirrors the Android `ImageVector`/`Painter` fill behavior.)
 - `AzBottomSheet` — cross-platform port of the Android `AzBottomSheet`, including the
   four-detent (HIDDEN/PEEK/HALF/FULL) state machine, drag handle, scrim, optional
   horizontal-swipe callbacks, and animated detent transitions. Built on the React Native

--- a/aznavrail-react/jest.setup.js
+++ b/aznavrail-react/jest.setup.js
@@ -40,6 +40,7 @@ jest.mock('react-native', () => {
         vibrate: jest.fn(),
     },
     View: ({children, ...props}) => React.createElement('View', props, children),
+    Image: ({children, ...props}) => React.createElement('Image', props, children),
     Text: ({children, ...props}) => React.createElement('Text', props, children),
     TouchableOpacity: ({children, onPress, ...props}) => React.createElement('TouchableOpacity', {onPress, ...props}, children),
     Pressable: ({children, onPress, ...props}) => React.createElement('Pressable', {onPress, ...props}, children),

--- a/aznavrail-react/src/__tests__/AzButton.test.tsx
+++ b/aznavrail-react/src/__tests__/AzButton.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Image, View } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 import { AzButton } from '../components/AzButton';
 import { AzButtonShape } from '../types';
@@ -123,5 +124,44 @@ describe('AzButton', () => {
 
     expect(textNode.props.numberOfLines).toBe(1);
     expect(textNode.props.adjustsFontSizeToFit).toBe(true);
+  });
+
+  describe('custom content fills the shape', () => {
+    it('renders an image source as a filling cover Image', () => {
+      const { UNSAFE_getByType, queryByText } = render(
+        <AzButton {...defaultProps} hasCustomContent content={{ uri: 'https://example.com/x.png' }} />
+      );
+      const image = UNSAFE_getByType(Image);
+      expect(image.props.resizeMode).toBe('cover');
+      expect(image.props.style.width).toBe('100%');
+      expect(image.props.style.height).toBe('100%');
+      // Text label is replaced by the graphic.
+      expect(queryByText('Test Button')).toBeNull();
+    });
+
+    it('clones an <Image> element to fill and cover', () => {
+      const { UNSAFE_getByType } = render(
+        <AzButton {...defaultProps} hasCustomContent content={<Image source={{ uri: 'https://example.com/y.png' }} />} />
+      );
+      const image = UNSAFE_getByType(Image);
+      expect(image.props.resizeMode).toBe('cover');
+      // Merged style array carries the fill sizing.
+      const flat = Array.isArray(image.props.style) ? Object.assign({}, ...image.props.style.filter(Boolean)) : image.props.style;
+      expect(flat.width).toBe('100%');
+      expect(flat.height).toBe('100%');
+    });
+
+    it('stretches a generic vector element (e.g. an <Svg>) to fill', () => {
+      // A stand-in for a react-native-svg <Svg> element: any element gets fill sizing merged.
+      const { getByTestId } = render(
+        <AzButton {...defaultProps} hasCustomContent content={<View testID="svg" />} />
+      );
+      const node = getByTestId('svg');
+      // The cloned element receives the fill style (as the first entry of the merged array).
+      const styles = ([] as any[]).concat(node.props.style).filter(Boolean);
+      const merged = Object.assign({}, ...styles);
+      expect(merged.width).toBe('100%');
+      expect(merged.height).toBe('100%');
+    });
   });
 });

--- a/aznavrail-react/src/components/AzButton.tsx
+++ b/aznavrail-react/src/components/AzButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { TouchableOpacity, Text, ViewStyle, TextStyle, View, StyleSheet } from 'react-native';
+import { TouchableOpacity, Text, ViewStyle, TextStyle, View, StyleSheet, ImageSourcePropType } from 'react-native';
 import { AzButtonShape } from '../types';
 import { AzLoad } from './AzLoad';
+import { renderFillContent } from './fillContent';
 
 /** Props for the shared `AzButton` component used by the main rail and components subdir. */
 export interface AzButtonProps {
@@ -27,8 +28,12 @@ export interface AzButtonProps {
   testID?: string;
   /** When true, `content` is rendered instead of the text label. */
   hasCustomContent?: boolean;
-  /** Custom React content rendered inside the button when `hasCustomContent` is true. */
-  content?: React.ReactNode;
+  /**
+   * Custom content rendered inside the button when `hasCustomContent` is true. May be a React
+   * node (including an `<Image>` or a `react-native-svg` `<Svg>`) or an image source
+   * (`require()` id / `{ uri }`). Graphics fill the shape (cover) and are clipped to it.
+   */
+  content?: React.ReactNode | ImageSourcePropType;
 }
 
 // Default size for circle/square
@@ -110,9 +115,7 @@ export const AzButton: React.FC<AzButtonProps> = ({
       <AzLoad />
     </View>
   ) : customContentNode ? (
-    <View style={{ width: '100%', height: '100%', overflow: 'hidden', alignItems: 'center', justifyContent: 'center' }}>
-      {customContentNode}
-    </View>
+    renderFillContent(customContentNode)
   ) : (
     <View style={{ padding: 8, width: '100%', height: '100%', alignItems: 'center', justifyContent: 'center' }}>
       <Text

--- a/aznavrail-react/src/components/fillContent.tsx
+++ b/aznavrail-react/src/components/fillContent.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Image, ImageSourcePropType, StyleSheet, View } from 'react-native';
+
+/**
+ * Renders custom button `content` so it fills the item's shape (the React equivalent of Android's
+ * `ContentScale.Crop` + shape clip). Clipping is acceptable — graphics are scaled to cover the
+ * button bounds without changing the item's dimensions.
+ *
+ * Accepts:
+ * - an image source (`number` from `require()`, or an `{ uri }` / array `ImageSourcePropType`) —
+ *   rendered as a filling `<Image resizeMode="cover">`;
+ * - a React element (a user `<Image>`, or an `<Svg>` from the consumer's `react-native-svg`) —
+ *   cloned to fill (merged `width: '100%', height: '100%'` style, plus `resizeMode="cover"` when it
+ *   is an RN `Image`);
+ * - any other React node — rendered as-is inside the fill+clip container.
+ */
+export function renderFillContent(content: React.ReactNode | ImageSourcePropType): React.ReactNode {
+  return (
+    <View style={[StyleSheet.absoluteFill, styles.fill]} pointerEvents="box-none">
+      {renderInner(content)}
+    </View>
+  );
+}
+
+const FILL_STYLE = { width: '100%', height: '100%' } as const;
+
+function isImageSource(value: unknown): value is ImageSourcePropType {
+  if (typeof value === 'number') return true; // require('./x.png')
+  if (Array.isArray(value)) return true; // array of sources
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !React.isValidElement(value) &&
+    typeof (value as { uri?: unknown }).uri === 'string'
+  );
+}
+
+function renderInner(content: React.ReactNode | ImageSourcePropType): React.ReactNode {
+  if (isImageSource(content)) {
+    return <Image source={content} resizeMode="cover" style={FILL_STYLE} />;
+  }
+
+  if (React.isValidElement(content)) {
+    const element = content as React.ReactElement<any>;
+    const mergedStyle = [FILL_STYLE, element.props?.style];
+    const extraProps: Record<string, unknown> = { style: mergedStyle };
+    // RN Image fills its box via resizeMode rather than CSS object-fit.
+    if (element.type === Image) {
+      extraProps.resizeMode = element.props?.resizeMode ?? 'cover';
+    }
+    return React.cloneElement(element, extraProps);
+  }
+
+  return content;
+}
+
+const styles = StyleSheet.create({
+  fill: { overflow: 'hidden', alignItems: 'stretch', justifyContent: 'center' },
+});

--- a/aznavrail-react/src/native/AzButton.tsx
+++ b/aznavrail-react/src/native/AzButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { TouchableOpacity, Text, ViewStyle, TextStyle, View, StyleSheet } from 'react-native';
+import { TouchableOpacity, Text, ViewStyle, TextStyle, View, StyleSheet, ImageSourcePropType } from 'react-native';
 import { AzButtonShape } from '../types';
 import { AzLoad } from './AzLoad';
+import { renderFillContent } from '../components/fillContent';
 
 /** Props for the native `AzButton` primitive used internally by the rail. */
 export interface AzButtonProps {
@@ -25,8 +26,12 @@ export interface AzButtonProps {
   testID?: string;
   /** When true, `content` is rendered instead of the text label and size is computed differently. */
   hasCustomContent?: boolean;
-  /** Custom React content rendered inside the button when `hasCustomContent` is true. */
-  content?: React.ReactNode;
+  /**
+   * Custom content rendered inside the button when `hasCustomContent` is true. May be a React
+   * node (including an `<Image>` or a `react-native-svg` `<Svg>`) or an image source
+   * (`require()` id / `{ uri }`). Graphics fill the shape (cover) and are clipped to it.
+   */
+  content?: React.ReactNode | ImageSourcePropType;
 }
 
 /** Native implementation: Touchable button with configurable shape, fill, and optional custom content. */
@@ -68,7 +73,10 @@ export const AzButton: React.FC<AzButtonProps> = ({
   const actualFillColor = fillColor || defaultFillColor;
 
   if (hasCustomContent) {
-    containerStyle.minWidth = size;
+    // Custom graphics fill a fixed, shape-clipped box (same dimensions as the text variant).
+    containerStyle.width = size;
+    containerStyle.height = size;
+    containerStyle.borderRadius = isCircle ? size / 2 : 0;
   } else {
     if (isCircle) {
       containerStyle.width = size;
@@ -102,7 +110,7 @@ export const AzButton: React.FC<AzButtonProps> = ({
       <AzLoad />
     </View>
   ) : customContentNode ? (
-    customContentNode
+    renderFillContent(customContentNode)
   ) : (
     <Text
       style={textStyle}

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -92,7 +92,13 @@ Items are added sequentially. The order in the DSL determines the order in the r
 *   **Menu Item:** Only appears in the expanded drawer.
 *   **Help Rail Item:** Dedicated trigger for the Help overlay.
 *   **Rail Item:** Appears in the rail (and drawer).
-*   **Content Types:** Supports Text, resource IDs (Icons), and `Color`.
+*   **Content Types:** The `content` field accepts Text, a `Color`, a drawable/vector
+    resource id (`Int`), a Compose `ImageVector` (e.g. `Icons.Default.Home`) or `Painter`,
+    or any image model Coil can load (`Bitmap`, URL, `File`, `Uri`, …). All non-text graphics
+    **fill the item's shape** (scaled to cover, clipped to the shape) without changing the
+    item's dimensions. `ImageVector` content is tinted with the item's color, so monochrome
+    Material icons adopt the rail's color. This applies to main-rail, nested-rail, and
+    standalone (`AzButton`) buttons alike.
 
 ```kotlin
 // Menu-only item
@@ -118,6 +124,9 @@ azRailItem(id = "color-item", text = "Color", content = Color.Red)
 
 // Rail item with Icon Resource
 azRailItem(id = "icon-item", text = "Icon", content = android.R.drawable.ic_menu_agenda)
+
+// Rail item with a Compose ImageVector (fills + clips to the shape, tinted with the item color)
+azRailItem(id = "vector-item", text = "Delete", content = Icons.Default.Delete)
 
 // Rail item with specific shape override
 azRailItem(id = "none-shape", text = "No Shape", shape = AzButtonShape.NONE)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -30,9 +30,12 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -69,7 +72,11 @@ import com.hereliesaz.aznavrail.util.text.AutoSizeText
  * @param isLoading When true, the button content is hidden and [AzLoad] is shown in its place.
  * @param contentPadding Padding applied around text content (ignored when [itemContent] is set).
  * @param itemContent Arbitrary content to render inside the button instead of [text]. Accepts
- *   [Color], [AzComposableContent], [Int] (resource ID), [String], or any image model.
+ *   [Color], [AzComposableContent], [Int] (resource ID), [String], an
+ *   [androidx.compose.ui.graphics.vector.ImageVector] or
+ *   [androidx.compose.ui.graphics.painter.Painter] (vector graphics), or any image model
+ *   loadable by Coil (Bitmap, URL, File, Uri, …). All non-text graphics fill the button
+ *   shape (Crop) and are clipped to it.
  * @param onLongClick Long-press handler.
  * @param onGloballyPositioned Reports the window-space bounds of the button after layout.
  */
@@ -220,6 +227,23 @@ private fun ItemContentRenderer(itemContent: Any, color: Color, enabled: Boolean
             }
         }
         is String -> TextContent(itemContent, color)
+        // Vector graphics. Coil cannot render an ImageVector/Painter (it throws
+        // "Unsupported type: ImageVector"), so these must be drawn with foundation Image
+        // before the Coil fallback. Tinted with the button color so monochrome icons
+        // (e.g. Icons.Default.*) adopt the rail's color, and cropped to fill the shape.
+        is ImageVector -> Image(
+            imageVector = itemContent,
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(color),
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize().alpha(if (enabled) 1f else 0.5f)
+        )
+        is Painter -> Image(
+            painter = itemContent,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize().alpha(if (enabled) 1f else 0.5f)
+        )
         else -> {
             Image(
                 painter = rememberAsyncImagePainter(model = itemContent),

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/RailContent.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/RailContent.kt
@@ -138,6 +138,7 @@ internal fun RailContent(
             shape = item.shape ?: defaultShape,
             enabled = isEnabled,
             isSelected = isSelected,
+            itemContent = item.content,
             rotationDegrees = rotationDegrees
         )
     }

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/ItemContentRendererTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/ItemContentRendererTest.kt
@@ -1,0 +1,70 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.rememberNavController
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression coverage for rendering vector graphics as button content.
+ *
+ * Previously an [androidx.compose.ui.graphics.vector.ImageVector] (e.g. `Icons.Default.Delete`)
+ * fell through to Coil's `rememberAsyncImagePainter`, which throws
+ * `IllegalArgumentException: Unsupported type: ImageVector`, crashing any rail/nested-rail button
+ * whose `content` was a vector. These tests ensure the shared content renderer composes such
+ * content without throwing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ItemContentRendererTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun azNavRailButton_rendersImageVectorContent_withoutThrowing() {
+        composeTestRule.setContent {
+            AzNavRailButton(
+                onClick = {},
+                text = "x",
+                itemContent = Icons.Default.Delete,
+            )
+        }
+        composeTestRule.waitForIdle()
+        assertTrue(true)
+    }
+
+    @Test
+    fun azNavRailButton_rendersPainterContent_withoutThrowing() {
+        composeTestRule.setContent {
+            AzNavRailButton(
+                onClick = {},
+                text = "x",
+                itemContent = ColorPainter(Color.Red),
+            )
+        }
+        composeTestRule.waitForIdle()
+        assertTrue(true)
+    }
+
+    @Test
+    fun azRailItem_withImageVectorContent_rendersOnMainRail_withoutThrowing() {
+        composeTestRule.setContent {
+            AzHostActivityLayout(
+                navController = rememberNavController()
+            ) {
+                azRailItem(id = "delete", text = "Delete", content = Icons.Default.Delete)
+            }
+        }
+        composeTestRule.waitForIdle()
+        assertTrue(true)
+    }
+}

--- a/sample-pwa/src/App.tsx
+++ b/sample-pwa/src/App.tsx
@@ -148,6 +148,18 @@ function App() {
       />
 
       <AzRailItem
+        id="vector-item"
+        text="Vector"
+        content={{
+          // An inline SVG (vector graphic) — fills and is clipped to the item's shape.
+          uri:
+            "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='%236200ee' d='M3 6h18v2H3zm2 3h14l-1 12H6zM9 4h6v2H9z'/></svg>",
+        }}
+        info="Dynamic content with a vector graphic (SVG) that fills the shape."
+        onClick={() => console.log('vector item')}
+      />
+
+      <AzRailItem
         id="profile"
         text="Profile"
         disabled


### PR DESCRIPTION
## Summary

Rail items can already show image content (`Color`, drawable resource, bitmap/URL via Coil) instead of text. This adds first-class **vector-graphic** support and fixes a crash, on **both Android and React**, and makes all graphic content **fill the item's shape** (clipping as needed) without changing the item's dimensions.

### The crash (Android)
`ItemContentRenderer` routed any unrecognized `content` to Coil's `rememberAsyncImagePainter`, which throws `IllegalArgumentException: Unsupported type: ImageVector`. So a Compose `ImageVector` (e.g. `Icons.Default.Delete`) crashed any rail / nested-rail button whose `content` was a vector (reported via `NestedRail` → `NestedItemWrapper` → `AzNavRailButton` → `ItemContentRenderer`).

## Changes

**Android**
- `AzNavRailButton.ItemContentRenderer`: explicit `ImageVector` and `Painter` branches (foundation `Image`, `ContentScale.Crop`, `fillMaxSize`) **before** the Coil fallback. `ImageVector` is tinted with the item color so monochrome Material icons adopt the rail color.
- `RailContent`: now passes `itemContent = item.content` so **top-level rail items** render graphics (previously only nested rails / standalone `AzButton` did). Null-default → text behavior unchanged.
- All graphic content fills the shape (Crop) and is clipped to it; dimensions unchanged.

**React**
- `AzButton` (shared + native) fills the shape via a new shared `renderFillContent` helper: image sources (`require()` id / `{ uri }`) render as a filling cover `<Image>`; React elements (incl. a consumer's `react-native-svg` `<Svg>`) are stretched to 100% and clipped; `<Image>` elements are coerced to `resizeMode="cover"`. `content` prop type widened to `ReactNode | ImageSourcePropType`. (No new runtime dependency — SVG content is user-provided.)

**Tests**
- Android `ItemContentRendererTest` (Robolectric): `ImageVector`, `Painter`, and DSL `azRailItem(content = Icons.Default.Delete)` compose without throwing — regression for the reported crash.
- React `AzButton` tests: image source, cloned `<Image>`, and a generic vector element all receive fill sizing. (`jest.setup.js` gains an `Image` mock.)

**Docs / samples**: complete guide content-types section, `AGENTS.md` Content-Filling spec, `SampleApp/COVERAGE.md`; `SampleApp/MainApp.kt` and `sample-pwa` demo a vector content item; React `CHANGELOG`.

## Verification
- `:SampleApp:assembleDebug` ✅ (the CI build check, with the new vector item)
- `:aznavrail:compileDebugKotlin` ✅, test sources compile ✅
- React `tsc --noEmit` ✅, `bob build` ✅, new `AzButton` tests pass ✅
- `sample-pwa` `tsc -b && vite build` ✅
- Note: the Robolectric test can't *execute* in the sandbox (no network to fetch `android-all-instrumented`) — it compiles and will run in CI. One pre-existing, unrelated React test failure (`AzButton` RECTANGLE) is untouched by this PR.

https://claude.ai/code/session_01Wpv9thkrHYKZvpeYjNz4de

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wpv9thkrHYKZvpeYjNz4de)_