### PR TITLE
docs: sync vector-content coverage across remaining docs

### DIFF
--- a/aznavrail-react/src/types.ts
+++ b/aznavrail-react/src/types.ts
@@ -318,7 +318,11 @@ export interface AzNavItem {
   // New properties for parity
   /** Classifier tags used to filter or highlight this item when `activeClassifiers` is set. */
   classifiers?: Set<string>;
-  /** Custom React content rendered inside the button instead of text. */
+  /**
+   * Custom content rendered inside the button instead of text. A React node (e.g. an `<Image>`
+   * or a `react-native-svg` `<Svg>`) or an image source (`require()` id / `{ uri }`). Graphics
+   * fill the item's shape (cover) and are clipped to it; dimensions are unchanged.
+   */
   content?: any;
   /** True when this item opens a nested-rail popup when tapped. */
   isNestedRail?: boolean;
@@ -362,7 +366,11 @@ export interface AzNavItemProps {
   shape?: AzButtonShape;
   /** Help text shown for this item in the info overlay. */
   info?: string;
-  /** Custom React content rendered inside the button instead of the text label. */
+  /**
+   * Custom content rendered inside the button instead of the text label. A React node (e.g. an
+   * `<Image>` or a `react-native-svg` `<Svg>`) or an image source (`require()` id / `{ uri }`).
+   * Graphics fill the item's shape (cover) and are clipped to it; dimensions are unchanged.
+   */
   content?: any;
   /** Classifier tags used for filtering or highlighting with `activeClassifiers`. */
   classifiers?: Set<string>;
@@ -525,7 +533,11 @@ export interface AzItemConfig {
   classifiers?: Set<string>;
   /** Called when the item gains focus. */
   onFocus?: () => void;
-  /** Custom React content rendered inside the button. */
+  /**
+   * Custom content rendered inside the button. A React node (e.g. an `<Image>` or a
+   * `react-native-svg` `<Svg>`) or an image source (`require()` id / `{ uri }`). Graphics fill
+   * the item's shape (cover) and are clipped to it; dimensions are unchanged.
+   */
   content?: any;
   /** Border and icon tint color. */
   color?: string;

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -97,8 +97,9 @@ Items are added sequentially. The order in the DSL determines the order in the r
     or any image model Coil can load (`Bitmap`, URL, `File`, `Uri`, …). All non-text graphics
     **fill the item's shape** (scaled to cover, clipped to the shape) without changing the
     item's dimensions. `ImageVector` content is tinted with the item's color, so monochrome
-    Material icons adopt the rail's color. This applies to main-rail, nested-rail, and
-    standalone (`AzButton`) buttons alike.
+    Material icons adopt the rail's color. This applies to both main-rail and nested-rail items
+    (the DSL `content` field). The standalone `AzButton`/`AzToggle`/`AzCycler` instead take a
+    composable `itemContent` lambda, which is also clipped to the button shape.
 
 ```kotlin
 // Menu-only item

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -158,8 +158,9 @@ Items are added sequentially. The order in the DSL determines the order in the r
     or any image model Coil can load (`Bitmap`, URL, `File`, `Uri`, …). All non-text graphics
     **fill the item's shape** (scaled to cover, clipped to the shape) without changing the
     item's dimensions. `ImageVector` content is tinted with the item's color, so monochrome
-    Material icons adopt the rail's color. This applies to main-rail, nested-rail, and
-    standalone (`AzButton`) buttons alike.
+    Material icons adopt the rail's color. This applies to both main-rail and nested-rail items
+    (the DSL `content` field). The standalone `AzButton`/`AzToggle`/`AzCycler` instead take a
+    composable `itemContent` lambda, which is also clipped to the button shape.
 
 ```kotlin
 // Menu-only item

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -153,7 +153,13 @@ Items are added sequentially. The order in the DSL determines the order in the r
 *   **Menu Item:** Only appears in the expanded drawer.
 *   **Help Rail Item:** Dedicated trigger for the Help overlay.
 *   **Rail Item:** Appears in the rail (and drawer).
-*   **Content Types:** Supports Text, resource IDs (Icons), and `Color`.
+*   **Content Types:** The `content` field accepts Text, a `Color`, a drawable/vector
+    resource id (`Int`), a Compose `ImageVector` (e.g. `Icons.Default.Home`) or `Painter`,
+    or any image model Coil can load (`Bitmap`, URL, `File`, `Uri`, …). All non-text graphics
+    **fill the item's shape** (scaled to cover, clipped to the shape) without changing the
+    item's dimensions. `ImageVector` content is tinted with the item's color, so monochrome
+    Material icons adopt the rail's color. This applies to main-rail, nested-rail, and
+    standalone (`AzButton`) buttons alike.
 
 ```kotlin
 // Menu-only item
@@ -179,6 +185,9 @@ azRailItem(id = "color-item", text = "Color", content = Color.Red)
 
 // Rail item with Icon Resource
 azRailItem(id = "icon-item", text = "Icon", content = android.R.drawable.ic_menu_agenda)
+
+// Rail item with a Compose ImageVector (fills + clips to the shape, tinted with the item color)
+azRailItem(id = "vector-item", text = "Delete", content = Icons.Default.Delete)
 
 // Rail item with specific shape override
 azRailItem(id = "none-shape", text = "No Shape", shape = AzButtonShape.NONE)

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -158,8 +158,9 @@ Items are added sequentially. The order in the DSL determines the order in the r
     or any image model Coil can load (`Bitmap`, URL, `File`, `Uri`, …). All non-text graphics
     **fill the item's shape** (scaled to cover, clipped to the shape) without changing the
     item's dimensions. `ImageVector` content is tinted with the item's color, so monochrome
-    Material icons adopt the rail's color. This applies to main-rail, nested-rail, and
-    standalone (`AzButton`) buttons alike.
+    Material icons adopt the rail's color. This applies to both main-rail and nested-rail items
+    (the DSL `content` field). The standalone `AzButton`/`AzToggle`/`AzCycler` instead take a
+    composable `itemContent` lambda, which is also clipped to the button shape.
 
 ```kotlin
 // Menu-only item

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -153,7 +153,13 @@ Items are added sequentially. The order in the DSL determines the order in the r
 *   **Menu Item:** Only appears in the expanded drawer.
 *   **Help Rail Item:** Dedicated trigger for the Help overlay.
 *   **Rail Item:** Appears in the rail (and drawer).
-*   **Content Types:** Supports Text, resource IDs (Icons), and `Color`.
+*   **Content Types:** The `content` field accepts Text, a `Color`, a drawable/vector
+    resource id (`Int`), a Compose `ImageVector` (e.g. `Icons.Default.Home`) or `Painter`,
+    or any image model Coil can load (`Bitmap`, URL, `File`, `Uri`, …). All non-text graphics
+    **fill the item's shape** (scaled to cover, clipped to the shape) without changing the
+    item's dimensions. `ImageVector` content is tinted with the item's color, so monochrome
+    Material icons adopt the rail's color. This applies to main-rail, nested-rail, and
+    standalone (`AzButton`) buttons alike.
 
 ```kotlin
 // Menu-only item
@@ -179,6 +185,9 @@ azRailItem(id = "color-item", text = "Color", content = Color.Red)
 
 // Rail item with Icon Resource
 azRailItem(id = "icon-item", text = "Icon", content = android.R.drawable.ic_menu_agenda)
+
+// Rail item with a Compose ImageVector (fills + clips to the shape, tinted with the item color)
+azRailItem(id = "vector-item", text = "Delete", content = Icons.Default.Delete)
 
 // Rail item with specific shape override
 azRailItem(id = "none-shape", text = "No Shape", shape = AzButtonShape.NONE)

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -71,6 +71,11 @@ fun azAdvanced(
 
 The following functions are used to define the rail structure.
 
+> **`content`** accepts a `String`, a `Color`, a drawable/vector resource id (`Int`), a Compose
+> `ImageVector` or `Painter`, or any image model Coil can load (`Bitmap`, URL, `File`, `Uri`).
+> Non-text graphics fill the item's shape (cover) and are clipped to it; `ImageVector` content is
+> tinted with the item color.
+
 * `azMenuItem(id, text, route, content, color, shape, disabled, screenTitle, info, onClick)`
 * `azHelpRailItem(id, text, content, color, shape)`
 * `azRailItem(id, text, route, content, color, shape, disabled, screenTitle, info, classifiers, onFocus, onClick)`


### PR DESCRIPTION
## Summary

Follow-up to #453. That PR added `ImageVector`/`Painter` rail-item content (Android) and image-source/SVG fill (React), but only documented it in the `assets/` guide copy, `AGENTS.md`, `COVERAGE.md`, and the React `CHANGELOG`. This brings the **rest** of the docs in line so nothing references rail-item `content` types without covering vectors.

## Changes

- **`aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md`** and **`docs/AZNAVRAIL_COMPLETE_GUIDE.md`** — expand the "Content Types" section and add the `ImageVector` example. (These two copies had drifted from `assets/`.)
- **`docs/DSL.md`** — note what `content` accepts and the fill/tint behavior.
- **`aznavrail-react/src/types.ts`** — document that `content` accepts an image source or a vector/SVG element and fills the shape (the three item-prop interfaces).

Docs/comment-only change; no runtime code touched. React `tsc --noEmit` passes.

https://claude.ai/code/session_01Wpv9thkrHYKZvpeYjNz4de

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wpv9thkrHYKZvpeYjNz4de)_

## Summary by Sourcery

Document supported rail-item content types and vector behavior consistently across Android and React docs and type definitions.

Enhancements:
- Clarify React AzNav rail item type comments to describe supported content node/source types and how graphics fill and clip to the item shape.

Documentation:
- Expand AzNavRail content-type documentation to cover vector/image sources, fill behavior, and tinting across the complete guide and DSL docs.