### PR TITLE
fix: drawBehindNavBar for the overlay sheet host (button nav)

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
@@ -144,10 +144,11 @@ class AzBottomSheetWindowHost(
 
         navBarExtensionState.value = resolveExtensionPx(configState.value)
         val params = buildParams(configState.value, controller.detent)
+        // Publish sheetView/sheetParams before addView so an inset callback firing during
+        // addView() sees non-null params and can resize the window.
         sheetView = composeView
         sheetParams = params
         wm.addView(composeView, params)
-        sheetParams = params
         // Kick an initial dispatch so the overlay window picks up insets without waiting for a
         // system change (rotation, IME, etc.).
         ViewCompat.requestApplyInsets(composeView)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -32,6 +33,7 @@ import com.hereliesaz.aznavrail.internal.AzBottomSheetShell
 import com.hereliesaz.aznavrail.internal.AzNavBarDecorWindow
 import com.hereliesaz.aznavrail.internal.AzNavMode
 import com.hereliesaz.aznavrail.internal.heightForDetent
+import com.hereliesaz.aznavrail.internal.navBarExtensionPx
 import com.hereliesaz.aznavrail.model.AzSheetConfig
 import com.hereliesaz.aznavrail.model.AzSheetDetent
 import kotlinx.coroutines.flow.combine
@@ -76,6 +78,9 @@ class AzBottomSheetWindowHost(
     private var sheetParams: WindowManager.LayoutParams? = null
     private var navBarDecor: AzNavBarDecorWindow? = null
     private var lastNavBarInsetPx: Int = 0
+    // Pixels the overlay window grows downward into the nav-bar region (drawBehindNavBar + button
+    // nav). Backed by a Compose state so the shell extends the card in lock-step with the window.
+    private val navBarExtensionState = mutableStateOf(0)
     private var collectJob: kotlinx.coroutines.Job? = null
 
     /**
@@ -91,6 +96,7 @@ class AzBottomSheetWindowHost(
             setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
             setContent {
                 BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                    val extensionDp = with(LocalDensity.current) { navBarExtensionState.value.toDp() }
                     AzBottomSheetShell(
                         controller = controller,
                         config = configState.value,
@@ -98,6 +104,7 @@ class AzBottomSheetWindowHost(
                         animate = false,
                         onSwipeLeft = null,
                         onSwipeRight = null,
+                        navBarExtensionDp = extensionDp,
                         content = content,
                     )
                 }
@@ -120,10 +127,22 @@ class AzBottomSheetWindowHost(
         // so both the Compose tree and the app below keep seeing them.
         ViewCompat.setOnApplyWindowInsetsListener(composeView) { v, insets ->
             lastNavBarInsetPx = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+            // Once we know the real nav-bar inset, (re)derive how far the window must grow behind
+            // the bar and resize it immediately — the initial layout may have run before insets
+            // were available, so HIDDEN/PEEK strips would otherwise stop above the bar.
+            val ext = resolveExtensionPx(configState.value)
+            if (ext != navBarExtensionState.value) {
+                navBarExtensionState.value = ext
+                sheetParams?.let { p ->
+                    p.height = windowHeightFor(controller.detent, configState.value)
+                    runCatching { wm.updateViewLayout(composeView, p) }
+                }
+            }
             ViewCompat.onApplyWindowInsets(v, insets)
             insets
         }
 
+        navBarExtensionState.value = resolveExtensionPx(configState.value)
         val params = buildParams(configState.value, controller.detent)
         wm.addView(composeView, params)
         sheetView = composeView
@@ -143,17 +162,13 @@ class AzBottomSheetWindowHost(
                 ) { detent, _, config -> detent to config }
                     .collect { (detent, config) ->
                         val current = sheetParams ?: return@collect
-                        val newHeight = heightForDetent(detent, /* parentHeight */ 0.dp, config)
-                        // For HIDDEN/PEEK the height is absolute Dp; for HALF/FULL we use
-                        // MATCH_PARENT and let the shell fill via fractions inside.
+                        // Keep the card's downward extension in sync with config changes (e.g.
+                        // toggling drawBehindNavBar live) before resizing the window.
+                        navBarExtensionState.value = resolveExtensionPx(config)
+                        // For HIDDEN/PEEK the height is absolute Dp (plus the nav-bar extension);
+                        // for HALF/FULL we use MATCH_PARENT and let the shell fill via fractions.
                         val needsFocus = detent == AzSheetDetent.HALF || detent == AzSheetDetent.FULL
-                        current.height = when (detent) {
-                            AzSheetDetent.HIDDEN, AzSheetDetent.PEEK -> {
-                                val d = context.resources.displayMetrics.density
-                                (newHeight.value * d).toInt()
-                            }
-                            AzSheetDetent.HALF, AzSheetDetent.FULL -> WindowManager.LayoutParams.MATCH_PARENT
-                        }
+                        current.height = windowHeightFor(detent, config)
                         current.flags = baseFlags(needsFocus)
                         runCatching { wm.updateViewLayout(composeView, current) }
                     }
@@ -168,6 +183,7 @@ class AzBottomSheetWindowHost(
         sheetView = null
         sheetParams = null
         lastNavBarInsetPx = 0
+        navBarExtensionState.value = 0
         collectJob?.cancel()
         collectJob = null
         navBarDecor?.detach()
@@ -210,25 +226,55 @@ class AzBottomSheetWindowHost(
             @Suppress("DEPRECATION")
             WindowManager.LayoutParams.TYPE_SYSTEM_ALERT
         }
-        val height = when (detent) {
-            AzSheetDetent.HIDDEN, AzSheetDetent.PEEK -> {
-                val d = context.resources.displayMetrics.density
-                (heightForDetent(detent, 0.dp, config).value * d).toInt()
-            }
-            AzSheetDetent.HALF, AzSheetDetent.FULL -> WindowManager.LayoutParams.MATCH_PARENT
-        }
         val needsFocus = detent == AzSheetDetent.HALF || detent == AzSheetDetent.FULL
         return WindowManager.LayoutParams(
             WindowManager.LayoutParams.MATCH_PARENT,
-            height,
+            windowHeightFor(detent, config),
             type,
             baseFlags(needsFocus),
             PixelFormat.TRANSLUCENT,
         ).apply {
             gravity = Gravity.BOTTOM
+            // Anchor flush to the screen bottom; the height already includes any nav-bar extension.
+            y = 0
             @Suppress("DEPRECATION")
             softInputMode = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+            // Allow the window to lay out into the display cutout / system-bar area so the extended
+            // height can actually occupy the nav-bar region (paired with FLAG_LAYOUT_NO_LIMITS).
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+            }
         }
+    }
+
+    /**
+     * Window height (px) for a [detent]. HIDDEN/PEEK resolve to an absolute pixel height; HALF/FULL
+     * use `MATCH_PARENT` and let the shell fill via fractions. When [AzSheetConfig.drawBehindNavBar]
+     * is active on button-nav, the absolute heights grow by the nav-bar inset so the window extends
+     * behind the bar (the top edge stays put because the window is anchored `Gravity.BOTTOM`).
+     */
+    private fun windowHeightFor(detent: AzSheetDetent, config: AzSheetConfig): Int = when (detent) {
+        AzSheetDetent.HIDDEN, AzSheetDetent.PEEK -> {
+            val d = context.resources.displayMetrics.density
+            (heightForDetent(detent, 0.dp, config).value * d).toInt() + resolveExtensionPx(config)
+        }
+        AzSheetDetent.HALF, AzSheetDetent.FULL -> WindowManager.LayoutParams.MATCH_PARENT
+    }
+
+    /**
+     * Pixels by which the window grows downward into the nav-bar region. Uses the live measured
+     * navigation-bar inset when available (the authoritative button-vs-gesture signal), falling back
+     * to the consumer-supplied [navBarHeightPx] under button navigation before insets first arrive.
+     */
+    private fun resolveExtensionPx(config: AzSheetConfig): Int {
+        val measured = lastNavBarInsetPx
+        val inset = if (measured > 0) measured else if (AzNavMode.isButtonNav(context)) navBarHeightPx else 0
+        return navBarExtensionPx(
+            drawBehindNavBar = config.drawBehindNavBar,
+            buttonNav = AzNavMode.isButtonNav(context),
+            navBarInsetPx = inset,
+        )
     }
 
     private fun baseFlags(focusable: Boolean): Int {
@@ -254,6 +300,9 @@ class AzBottomSheetWindowHost(
 
     /** Exposed for tests: the last navigation-bar bottom inset (px) delivered to the sheet view. */
     internal fun lastNavBarInsetPx(): Int = lastNavBarInsetPx
+
+    /** Exposed for tests: the px the window currently grows downward behind the nav bar. */
+    internal fun navBarExtensionPxForTest(): Int = navBarExtensionState.value
 
     /** Exposed for tests: the live sheet view, or null when detached. */
     internal fun sheetViewForTest(): View? = sheetView

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
@@ -152,7 +152,7 @@ class AzBottomSheetWindowHost(
         // system change (rotation, IME, etc.).
         ViewCompat.requestApplyInsets(composeView)
 
-        lifecycleOwner.lifecycleScope.launch {
+        collectJob = lifecycleOwner.lifecycleScope.launch {
             lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 // Combine in configState (via snapshotFlow) alongside the detent so updateConfig()
                 // re-applies the WindowManager layout immediately, not just on the next detent change.
@@ -180,13 +180,15 @@ class AzBottomSheetWindowHost(
     /** Removes the sheet (and decor) overlay windows. Safe to call multiple times. */
     fun detach() {
         val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        // Cancel the collector before removing the view so it can't fire updateViewLayout() on an
+        // already-detached window in the gap between removal and cancellation.
+        collectJob?.cancel()
+        collectJob = null
         sheetView?.let { runCatching { wm.removeView(it) } }
         sheetView = null
         sheetParams = null
         lastNavBarInsetPx = 0
         navBarExtensionState.value = 0
-        collectJob?.cancel()
-        collectJob = null
         navBarDecor?.detach()
         navBarDecor = null
     }
@@ -308,6 +310,9 @@ class AzBottomSheetWindowHost(
 
     /** Exposed for tests: the live sheet view, or null when detached. */
     internal fun sheetViewForTest(): View? = sheetView
+
+    /** Exposed for tests: whether the detent/config collector coroutine is still running. */
+    internal fun isCollectorActiveForTest(): Boolean = collectJob?.isActive == true
 
     @Suppress("unused")
     private val unusedView: View? get() = sheetView

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
@@ -269,10 +269,11 @@ class AzBottomSheetWindowHost(
      */
     private fun resolveExtensionPx(config: AzSheetConfig): Int {
         val measured = lastNavBarInsetPx
-        val inset = if (measured > 0) measured else if (AzNavMode.isButtonNav(context)) navBarHeightPx else 0
+        val isButton = AzNavMode.isButtonNav(context)
+        val inset = if (measured > 0) measured else if (isButton) navBarHeightPx else 0
         return navBarExtensionPx(
             drawBehindNavBar = config.drawBehindNavBar,
-            buttonNav = AzNavMode.isButtonNav(context),
+            buttonNav = isButton,
             navBarInsetPx = inset,
         )
     }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHost.kt
@@ -144,8 +144,9 @@ class AzBottomSheetWindowHost(
 
         navBarExtensionState.value = resolveExtensionPx(configState.value)
         val params = buildParams(configState.value, controller.detent)
-        wm.addView(composeView, params)
         sheetView = composeView
+        sheetParams = params
+        wm.addView(composeView, params)
         sheetParams = params
         // Kick an initial dispatch so the overlay window picks up insets without waiting for a
         // system change (rotation, IME, etc.).

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzBottomSheetShell.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzBottomSheetShell.kt
@@ -50,6 +50,11 @@ import com.hereliesaz.aznavrail.model.AzSheetDetent
  *   `config.animateInTree`; the system-overlay path passes `false` since the window itself jumps.
  * @param onSwipeLeft / [onSwipeRight] Optional horizontal-swipe callbacks gated by
  *   [AzSheetConfig.horizontalSwipeEnabled].
+ * @param navBarExtensionDp Extra height by which the *card* extends downward into the navigation-bar
+ *   region when the system-overlay host opts into [AzSheetConfig.drawBehindNavBar]. The detent's
+ *   exposed (above-bar) height is resolved against `parentHeight - navBarExtensionDp` and this band
+ *   is added back on, so the card's top edge does not move while its content flows behind the bar.
+ *   Defaults to `0.dp` (the in-tree path never extends the card).
  * @param content Caller-provided sheet content.
  */
 @Composable
@@ -61,10 +66,14 @@ internal fun AzBottomSheetShell(
     onSwipeLeft: (() -> Unit)?,
     onSwipeRight: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    navBarExtensionDp: Dp = 0.dp,
     content: @Composable BoxScope.() -> Unit,
 ) {
     val density = LocalDensity.current
-    val targetHeight = heightForDetent(controller.detent, parentHeight, config)
+    // Resolve the detent against the exposed (above-bar) height, then add the nav-bar band back so
+    // the card grows downward by exactly the extension without shifting its top edge.
+    val targetHeight =
+        heightForDetent(controller.detent, parentHeight - navBarExtensionDp, config) + navBarExtensionDp
     val animatedHeight by animateDpAsState(
         targetValue = if (animate) targetHeight else targetHeight,
         label = "az-sheet-height",

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzBottomSheetShell.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzBottomSheetShell.kt
@@ -73,7 +73,7 @@ internal fun AzBottomSheetShell(
     // Resolve the detent against the exposed (above-bar) height, then add the nav-bar band back so
     // the card grows downward by exactly the extension without shifting its top edge.
     val targetHeight =
-        heightForDetent(controller.detent, parentHeight - navBarExtensionDp, config) + navBarExtensionDp
+        heightForDetent(controller.detent, (parentHeight - navBarExtensionDp).coerceAtLeast(0.dp), config) + navBarExtensionDp
     val animatedHeight by animateDpAsState(
         targetValue = if (animate) targetHeight else targetHeight,
         label = "az-sheet-height",

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzSheetMetrics.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzSheetMetrics.kt
@@ -21,3 +21,26 @@ internal fun heightForDetent(
     AzSheetDetent.HALF -> parentHeight * config.halfFraction
     AzSheetDetent.FULL -> parentHeight * config.fullFraction
 }
+
+/**
+ * Pixels by which the system-overlay sheet window should grow *downward*, into the
+ * navigation-bar region, when [AzSheetConfig.drawBehindNavBar] is enabled.
+ *
+ * The window stays anchored `Gravity.BOTTOM` with `y = 0`, so adding this to the window height
+ * extends it behind the bar without moving the top edge of any detent. The growth only applies in
+ * button navigation, where the measured navigation-bar inset is non-zero; in gesture navigation the
+ * inset is ~0, making this a no-op.
+ *
+ * Crucially this is *not* added to the consumer-visible detent height — the exposed (above-bar)
+ * height stays the value the consumer sized its detents to. Only the actual window grows; the extra
+ * band is where content flows behind the nav-bar buttons.
+ *
+ * @param drawBehindNavBar [AzSheetConfig.drawBehindNavBar].
+ * @param buttonNav Whether the device uses button (3-button / 2-button) navigation.
+ * @param navBarInsetPx The measured navigation-bar inset in pixels (0 in gesture navigation).
+ */
+internal fun navBarExtensionPx(
+    drawBehindNavBar: Boolean,
+    buttonNav: Boolean,
+    navBarInsetPx: Int,
+): Int = if (drawBehindNavBar && buttonNav && navBarInsetPx > 0) navBarInsetPx else 0

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHostTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHostTest.kt
@@ -180,6 +180,115 @@ class AzBottomSheetWindowHostTest {
     }
 
     @Test
+    fun drawBehindNavBar_growsHiddenWindow_byNavBarInset_underButtonNav() {
+        val ctx = newContext()
+        val owner = TestOwner().also { it.registry.currentState = Lifecycle.State.RESUMED }
+        val controller = AzSheetController(initial = AzSheetDetent.HIDDEN)
+        val host = AzBottomSheetWindowHost(
+            context = ctx,
+            controller = controller,
+            config = AzSheetConfig(hiddenStripDp = 28.dp, drawBehindNavBar = true),
+            lifecycleOwner = owner,
+            viewModelStoreOwner = owner,
+            savedStateRegistryOwner = owner,
+            navBarHeightPx = 0,
+        ) { Box(modifier = androidx.compose.ui.Modifier) {} }
+
+        host.attach()
+        idleMain()
+        val density = ctx.resources.displayMetrics.density
+        val basePx = (28f * density).toInt()
+
+        // Deliver a button-nav-sized inset; the window must grow downward by exactly that inset
+        // while the exposed (above-bar) strip height is unchanged.
+        val navBar = 60
+        val view = host.sheetViewForTest()!!
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, navBar))
+            .build()
+        ViewCompat.dispatchApplyWindowInsets(view, insets)
+        idleMain()
+
+        assertEquals(
+            "drawBehindNavBar must grow the HIDDEN overlay window by the measured nav-bar inset.",
+            basePx + navBar,
+            host.currentParams()!!.height,
+        )
+        assertEquals(navBar, host.navBarExtensionPxForTest())
+
+        host.detach()
+    }
+
+    @Test
+    fun drawBehindNavBar_disabled_doesNotGrowWindow() {
+        val ctx = newContext()
+        val owner = TestOwner().also { it.registry.currentState = Lifecycle.State.RESUMED }
+        val controller = AzSheetController(initial = AzSheetDetent.HIDDEN)
+        val host = AzBottomSheetWindowHost(
+            context = ctx,
+            controller = controller,
+            config = AzSheetConfig(hiddenStripDp = 28.dp, drawBehindNavBar = false),
+            lifecycleOwner = owner,
+            viewModelStoreOwner = owner,
+            savedStateRegistryOwner = owner,
+        ) { Box(modifier = androidx.compose.ui.Modifier) {} }
+
+        host.attach()
+        idleMain()
+        val density = ctx.resources.displayMetrics.density
+
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, 60))
+            .build()
+        ViewCompat.dispatchApplyWindowInsets(host.sheetViewForTest()!!, insets)
+        idleMain()
+
+        assertEquals(
+            "Without drawBehindNavBar the window height must equal the bare detent height.",
+            (28f * density).toInt(),
+            host.currentParams()!!.height,
+        )
+        assertEquals(0, host.navBarExtensionPxForTest())
+
+        host.detach()
+    }
+
+    @Test
+    fun drawBehindNavBar_setsLayoutNoLimits_andCutoutMode() {
+        val ctx = newContext()
+        val owner = TestOwner().also { it.registry.currentState = Lifecycle.State.RESUMED }
+        val controller = AzSheetController(initial = AzSheetDetent.HIDDEN)
+        val host = AzBottomSheetWindowHost(
+            context = ctx,
+            controller = controller,
+            config = AzSheetConfig(drawBehindNavBar = true),
+            lifecycleOwner = owner,
+            viewModelStoreOwner = owner,
+            savedStateRegistryOwner = owner,
+        ) { Box(modifier = androidx.compose.ui.Modifier) {} }
+
+        host.attach()
+        idleMain()
+        val params = host.currentParams()!!
+        assertTrue(
+            "The overlay must set FLAG_LAYOUT_NO_LIMITS so the WM does not clamp it above the nav bar.",
+            (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS) != 0,
+        )
+        assertTrue(
+            "The overlay must set FLAG_LAYOUT_IN_SCREEN.",
+            (params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN) != 0,
+        )
+        assertEquals(
+            "The overlay must lay out into the system-bar / cutout area.",
+            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS,
+            params.layoutInDisplayCutoutMode,
+        )
+        assertEquals("The overlay must be anchored flush to the screen bottom.", 0, params.y)
+
+        host.detach()
+    }
+
+    @Test
     fun attach_wiresWindowInsets_withoutConsumingThem() {
         val ctx = newContext()
         val owner = TestOwner().also { it.registry.currentState = Lifecycle.State.RESUMED }

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHostTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheetWindowHostTest.kt
@@ -80,6 +80,35 @@ class AzBottomSheetWindowHostTest {
     }
 
     @Test
+    fun detach_cancelsCollectorCoroutine() {
+        val ctx = newContext()
+        val owner = TestOwner().also { it.registry.currentState = Lifecycle.State.RESUMED }
+        val controller = AzSheetController(initial = AzSheetDetent.PEEK)
+        val host = AzBottomSheetWindowHost(
+            context = ctx,
+            controller = controller,
+            lifecycleOwner = owner,
+            viewModelStoreOwner = owner,
+            savedStateRegistryOwner = owner,
+        ) { Box(modifier = androidx.compose.ui.Modifier) {} }
+
+        host.attach()
+        idleMain()
+        assertTrue(
+            "After attach() the detent/config collector must be running.",
+            host.isCollectorActiveForTest(),
+        )
+
+        host.detach()
+        idleMain()
+        assertFalse(
+            "detach() must cancel the collector coroutine — it was previously leaked because the " +
+                "launch result was never assigned to collectJob.",
+            host.isCollectorActiveForTest(),
+        )
+    }
+
+    @Test
     fun attach_isIdempotent() {
         val ctx = newContext()
         val owner = TestOwner().also { it.registry.currentState = androidx.lifecycle.Lifecycle.State.RESUMED }

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/internal/AzSheetMetricsTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/internal/AzSheetMetricsTest.kt
@@ -1,0 +1,48 @@
+package com.hereliesaz.aznavrail.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [navBarExtensionPx] — the px by which the system-overlay sheet window grows
+ * downward into the navigation-bar region when [com.hereliesaz.aznavrail.model.AzSheetConfig.drawBehindNavBar]
+ * is enabled.
+ */
+class AzSheetMetricsTest {
+
+    @Test
+    fun extension_isInset_whenDrawBehindNavBarUnderButtonNavWithInset() {
+        assertEquals(
+            "drawBehindNavBar + button nav + measured inset must grow the window by exactly the inset.",
+            48,
+            navBarExtensionPx(drawBehindNavBar = true, buttonNav = true, navBarInsetPx = 48),
+        )
+    }
+
+    @Test
+    fun extension_isZero_whenDrawBehindNavBarDisabled() {
+        assertEquals(
+            "Without drawBehindNavBar the window never grows behind the bar.",
+            0,
+            navBarExtensionPx(drawBehindNavBar = false, buttonNav = true, navBarInsetPx = 48),
+        )
+    }
+
+    @Test
+    fun extension_isZero_underGestureNav() {
+        assertEquals(
+            "In gesture nav (buttonNav=false) drawBehindNavBar is a no-op.",
+            0,
+            navBarExtensionPx(drawBehindNavBar = true, buttonNav = false, navBarInsetPx = 48),
+        )
+    }
+
+    @Test
+    fun extension_isZero_whenInsetIsZero() {
+        assertEquals(
+            "A zero measured inset (gesture-style thin bar) means nothing to grow into.",
+            0,
+            navBarExtensionPx(drawBehindNavBar = true, buttonNav = true, navBarInsetPx = 0),
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-aznavrail = "9.2"
+aznavrail = "9.10"
 # Android & Jetpack
 composeBom = "2026.05.00"
 coreKtx = "1.18.0"


### PR DESCRIPTION
## Problem

`AzSheetConfig.drawBehindNavBar = true` is meant to make the bottom-sheet overlay draw **behind** the system navigation bar so a consumer can render content in the nav-bar band. In a `TYPE_APPLICATION_OVERLAY` host it wasn't working: the sheet stopped exactly at the top of the nav bar (collapsed HIDDEN/PEEK strips sat above a solid 3-button bar). The window was being clamped to the area above the bar.

## Fix

1. **Extend the sheet window behind the bar.** When `drawBehindNavBar` is true and the measured nav-bar inset is `> 0` (button nav), the overlay window now grows downward by exactly the inset for every detent (HIDDEN/PEEK get explicit `height + inset`; HALF/FULL remain `MATCH_PARENT` and now fill the full screen). The window stays `Gravity.BOTTOM` with `y = 0`, so the **top edge of each detent does not move** — it only grows downward into the nav-bar region. On gesture nav the inset is ~0, so it's a no-op.

2. **Window flags.** The overlay already set `FLAG_LAYOUT_NO_LIMITS` and `FLAG_LAYOUT_IN_SCREEN`; this adds `layoutInDisplayCutoutMode = LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS` (API 28+) and pins `y = 0` so the window manager stops clamping the overlay above the nav bar.

3. **Exposed-height semantics preserved.** The card resolves its detent against `parentHeight - extension` and then adds the band back (`AzBottomSheetShell.navBarExtensionDp`), so consumer-visible / fraction-based detent heights stay the exposed (above-bar) value — only the actual window grows, no double-counting.

4. **Nav-bar band transparency.** `AzNavBarDecorWindow` already paints semi-transparent (`decorAlphaFor` caps at `0.5` and is fully transparent at HIDDEN) when `drawBehindNavBar` + button nav, so it does not paint an opaque background over the extended region. Unchanged.

## Files

- `internal/AzSheetMetrics.kt` — new `navBarExtensionPx()` helper.
- `internal/AzBottomSheetShell.kt` — new `navBarExtensionDp` param (defaults `0.dp`; in-tree path unaffected).
- `bottomsheet/AzBottomSheetWindowHost.kt` — grow window heights, recompute extension on inset/config change, set `y = 0` + cutout mode.
- `gradle/libs.versions.toml` — bump `aznavrail` to `9.10`.

## Tests

- New `AzSheetMetricsTest` (4/4 pass) covers the extension helper across button/gesture nav and zero-inset.
- New `AzBottomSheetWindowHostTest` cases: HIDDEN window grows by the delivered inset, no growth when disabled, and the layout flags/cutout-mode/`y=0` are set.

> Note: the Robolectric `AzBottomSheetWindowHostTest` could not execute in the CI sandbox because Robolectric's `android-all` runtime download is blocked (SSL handshake to Maven Central). The pure-JVM `AzSheetMetricsTest` and `AzNavBarDecorWindowTest` pass, and all main + test sources compile.

## Verify on device

Button-nav device with an overlay sheet: the top edge of each detent is unchanged, and content rendered in the bottom `navBarHeightPx` of the sheet is visible behind/around the nav-bar buttons. Gesture-nav behavior is identical to before.

https://claude.ai/code/session_01QUEd36NDo55KvkddkWmqa4

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUEd36NDo55KvkddkWmqa4)_