### PR TITLE
docs: make tutorial-framework usage explicit + pin host-tap onInteraction contract

### DIFF
--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -452,13 +452,49 @@ The tutorial framework scripts interactive, multi-scene walkthroughs over a dimm
 
 Card auto-positioning: defaults to bottom. Flips to top when highlight center Y > 60% of screen height. `TapTarget` degrades to `TapAnywhere` if the highlight is not `AzHighlight.Item`.
 
-### 9.2 Help/Info Overlay Integration
+### 9.2 How advancement works (read this before building your own coach)
+
+This framework is the supported way to walk a user through the rail. **Do not roll your own
+overlay that waits for taps on rail items to "fall through" to the canvas — they never will.**
+The rail consumes its own pointer events by design (a tap on a nav control must not leak to the
+content behind it). `AzTutorialOverlay` does **not** depend on that leak; it advances through its
+own hit-testing layer:
+
+- **`TapTarget`** — the overlay draws an invisible, full-screen tap absorber plus a clickable box
+  positioned exactly over the spotlight punch-out (computed from `itemBoundsCache`). Tapping inside
+  the spotlight advances (or branches via `branches`); tapping outside is swallowed. Advancement is
+  driven by the overlay's own box, not by the rail item's `onClick`. This is why `TapTarget`
+  **requires** an `AzHighlight.Item(id)` whose bounds are known — without bounds it degrades to
+  `TapAnywhere`.
+- **`Event(name)`** — you advance imperatively by calling `controller.fireEvent(name)` from your own
+  logic. Pair this with `azAdvanced(onInteraction = ...)` (see below) when you want a *real* rail tap
+  — including expanding a host — to drive the tutorial.
+- **`TapAnywhere` / `Button`** — advance on any screen tap, or on an explicit "Next" button.
+
+**Required wiring for item spotlights.** `AzHighlight.Item(id)` and `TapTarget` both need the live,
+measured bounds of the rail item. The rail reports these through
+`azAdvanced(onItemGloballyPositioned = { id, rect -> ... })`; you collect them into a map and pass
+that same map to the overlay as `itemBoundsCache`. If the cache is missing an id, the spotlight
+renders no punch-out and `TapTarget` degrades to `TapAnywhere`. This handshake is shown end-to-end
+in §9.4 (steps 2 and 3) and is easy to forget — if your spotlight never appears, this is the first
+thing to check.
+
+**Driving a tutorial from real rail taps (`onInteraction`).** When you want the tutorial to advance
+because the user *actually used* the rail — tapped a leaf item, flipped a toggle, or expanded a host
+menu — wire `azAdvanced(onInteraction = { id, item -> ... })` and call `controller.fireEvent(...)`
+from it for the ids you care about. `onInteraction` fires for **every** interactive item in **both**
+the compact rail and the expanded menu: leaf items (`azRailItem` / `azRailSubItem`), toggles,
+cyclers, nested-rail opens, reloc drags, **and host items** (`azRailHostItem` — the expand/collapse
+tap reports the interaction just like a leaf tap). This is the correct, supported alternative to
+intercepting taps yourself, and it composes cleanly with `Event` advance conditions.
+
+### 9.3 Help/Info Overlay Integration
 
 - **Collapsed card:** Shows a "Tutorial available" hint when a tutorial exists for that item.
 - **Expanded card:** Shows a "Start Tutorial" button. Tapping it calls `tutorialController.startTutorial(id)` and dismisses the help overlay.
 - The old behavior (any tap immediately starts the tutorial) is removed.
 
-### 9.3 Android — Full Example
+### 9.4 Android — Full Example
 
 ```kotlin
 import com.hereliesaz.aznavrail.tutorial.*
@@ -556,7 +592,7 @@ val hasRead = controller.isTutorialRead("tut-1")
 
 Persistence: `SharedPreferences` file `az_tutorial_prefs`, key `az_navrail_read_tutorials`. State is read on `rememberAzTutorialController()` and written on each `markTutorialRead()`.
 
-### 9.4 React Native — Full Example
+### 9.5 React Native — Full Example
 
 ```tsx
 import {
@@ -638,7 +674,7 @@ controller.fireEvent('menu_opened');
 
 Persistence: `@react-native-async-storage/async-storage` (optional peer dependency). Falls back to in-memory if not installed. Key: `az_navrail_read_tutorials`.
 
-### 9.5 Web — Full Example
+### 9.6 Web — Full Example
 
 ```tsx
 import {
@@ -671,7 +707,7 @@ Spotlight implementation: `box-shadow: 0 0 0 9999px rgba(0,0,0,0.7)` applied to 
 
 Persistence: `localStorage`. Key: `az_navrail_read_tutorials`.
 
-### 9.6 Variable Branching
+### 9.7 Variable Branching
 
 Pass a `variables` map to `startTutorial`. Scenes with `branchVar` set evaluate their `branches` map on entry and redirect to the matching scene ID. A scene used only for branching can have an empty `cards` list and a transparent `content`.
 
@@ -687,7 +723,7 @@ controller.startTutorial('tut-1', { userLevel: 'advanced' });
 
 Circular branch detection: if a branch chain loops back to an already-visited scene, a warning is logged and the tutorial advances to the next scene by index. If no next scene exists, the tutorial ends.
 
-### 9.7 Event-Driven Advance
+### 9.8 Event-Driven Advance
 
 Use `AzAdvanceCondition.Event("event_name")` (Kotlin) or `{ type: 'Event', name: 'event_name' }` (TS) on a card. When your app logic fires that event, the overlay automatically advances.
 
@@ -698,11 +734,11 @@ controller.fireEvent("menu_opened")
 
 The overlay observes `pendingEvent` and calls `consumeEvent()` internally on match. You do not need to call `consumeEvent()` yourself.
 
-### 9.8 Checklist Cards
+### 9.9 Checklist Cards
 
 Provide `checklistItems` on a card. The Next button is disabled until every item is checked. Compatible with any advance condition (the checklist gates the advance even for `TapAnywhere`).
 
-### 9.9 Media Cards
+### 9.10 Media Cards
 
 Provide `mediaContent` (a composable/component) on a card. It is rendered between the title and the body text, clipped to a max height of 120dp/120px with 8dp/8px corner rounding. Useful for images, animated GIFs, or short video previews.
 

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -543,13 +543,49 @@ The tutorial framework scripts interactive, multi-scene walkthroughs over a dimm
 
 Card auto-positioning: defaults to bottom. Flips to top when highlight center Y > 60% of screen height. `TapTarget` degrades to `TapAnywhere` if the highlight is not `AzHighlight.Item`.
 
-### 9.2 Help/Info Overlay Integration
+### 9.2 How advancement works (read this before building your own coach)
+
+This framework is the supported way to walk a user through the rail. **Do not roll your own
+overlay that waits for taps on rail items to "fall through" to the canvas — they never will.**
+The rail consumes its own pointer events by design (a tap on a nav control must not leak to the
+content behind it). `AzTutorialOverlay` does **not** depend on that leak; it advances through its
+own hit-testing layer:
+
+- **`TapTarget`** — the overlay draws an invisible, full-screen tap absorber plus a clickable box
+  positioned exactly over the spotlight punch-out (computed from `itemBoundsCache`). Tapping inside
+  the spotlight advances (or branches via `branches`); tapping outside is swallowed. Advancement is
+  driven by the overlay's own box, not by the rail item's `onClick`. This is why `TapTarget`
+  **requires** an `AzHighlight.Item(id)` whose bounds are known — without bounds it degrades to
+  `TapAnywhere`.
+- **`Event(name)`** — you advance imperatively by calling `controller.fireEvent(name)` from your own
+  logic. Pair this with `azAdvanced(onInteraction = ...)` (see below) when you want a *real* rail tap
+  — including expanding a host — to drive the tutorial.
+- **`TapAnywhere` / `Button`** — advance on any screen tap, or on an explicit "Next" button.
+
+**Required wiring for item spotlights.** `AzHighlight.Item(id)` and `TapTarget` both need the live,
+measured bounds of the rail item. The rail reports these through
+`azAdvanced(onItemGloballyPositioned = { id, rect -> ... })`; you collect them into a map and pass
+that same map to the overlay as `itemBoundsCache`. If the cache is missing an id, the spotlight
+renders no punch-out and `TapTarget` degrades to `TapAnywhere`. This handshake is shown end-to-end
+in §9.4 (steps 2 and 3) and is easy to forget — if your spotlight never appears, this is the first
+thing to check.
+
+**Driving a tutorial from real rail taps (`onInteraction`).** When you want the tutorial to advance
+because the user *actually used* the rail — tapped a leaf item, flipped a toggle, or expanded a host
+menu — wire `azAdvanced(onInteraction = { id, item -> ... })` and call `controller.fireEvent(...)`
+from it for the ids you care about. `onInteraction` fires for **every** interactive item in **both**
+the compact rail and the expanded menu: leaf items (`azRailItem` / `azRailSubItem`), toggles,
+cyclers, nested-rail opens, reloc drags, **and host items** (`azRailHostItem` — the expand/collapse
+tap reports the interaction just like a leaf tap). This is the correct, supported alternative to
+intercepting taps yourself, and it composes cleanly with `Event` advance conditions.
+
+### 9.3 Help/Info Overlay Integration
 
 - **Collapsed card:** Shows a "Tutorial available" hint when a tutorial exists for that item.
 - **Expanded card:** Shows a "Start Tutorial" button. Tapping it calls `tutorialController.startTutorial(id)` and dismisses the help overlay.
 - The old behavior (any tap immediately starts the tutorial) is removed.
 
-### 9.3 Android — Full Example
+### 9.4 Android — Full Example
 
 ```kotlin
 import com.hereliesaz.aznavrail.tutorial.*
@@ -647,7 +683,7 @@ val hasRead = controller.isTutorialRead("tut-1")
 
 Persistence: `SharedPreferences` file `az_tutorial_prefs`, key `az_navrail_read_tutorials`. State is read on `rememberAzTutorialController()` and written on each `markTutorialRead()`.
 
-### 9.4 React Native — Full Example
+### 9.5 React Native — Full Example
 
 ```tsx
 import {
@@ -729,7 +765,7 @@ controller.fireEvent('menu_opened');
 
 Persistence: `@react-native-async-storage/async-storage` (optional peer dependency). Falls back to in-memory if not installed. Key: `az_navrail_read_tutorials`.
 
-### 9.5 Web — Full Example
+### 9.6 Web — Full Example
 
 The web library is a TypeScript port of Android. New files: `web/AzTutorialController.tsx`, `web/AzTutorialOverlay.tsx`, `web/HelpOverlay.tsx`.
 
@@ -764,7 +800,7 @@ Spotlight implementation: `box-shadow: 0 0 0 9999px rgba(0,0,0,0.7)` applied to 
 
 Persistence: `localStorage`. Key: `az_navrail_read_tutorials`.
 
-### 9.6 Variable Branching
+### 9.7 Variable Branching
 
 Pass a `variables` map to `startTutorial`. Scenes with `branchVar` set evaluate their `branches` map on entry and redirect to the matching scene ID. A scene used only for branching can have an empty `cards` list and a transparent `content`.
 
@@ -780,7 +816,7 @@ controller.startTutorial('tut-1', { userLevel: 'advanced' });
 
 Circular branch detection: if a branch chain loops back to an already-visited scene, a warning is logged and the tutorial advances to the next scene by index. If no next scene exists, the tutorial ends.
 
-### 9.7 Event-Driven Advance
+### 9.8 Event-Driven Advance
 
 Use `AzAdvanceCondition.Event("event_name")` (Kotlin) or `{ type: 'Event', name: 'event_name' }` (TS) on a card. When your app logic fires that event, the overlay automatically advances.
 
@@ -791,11 +827,11 @@ controller.fireEvent("menu_opened")
 
 The overlay observes `pendingEvent` and calls `consumeEvent()` internally on match. You do not need to call `consumeEvent()` yourself.
 
-### 9.8 Checklist Cards
+### 9.9 Checklist Cards
 
 Provide `checklistItems` on a card. The Next button is disabled until every item is checked. Compatible with any advance condition (the checklist gates the advance even for `TapAnywhere`).
 
-### 9.9 Media Cards
+### 9.10 Media Cards
 
 Provide `mediaContent` (a composable/component) on a card. It is rendered between the title and the body text, clipped to a max height of 120dp/120px with 8dp/8px corner rounding. Useful for images, animated GIFs, or short video previews.
 

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/internal/HandleHostItemClickTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/internal/HandleHostItemClickTest.kt
@@ -1,0 +1,83 @@
+package com.hereliesaz.aznavrail.internal
+
+import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzNavItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for [handleHostItemClick], the shared host-tap dispatcher used by both the
+ * compact rail ([RailContent]) and the expanded menu ([MenuItem]).
+ *
+ * Consumers that listen for `azAdvanced(onInteraction = ...)` rely on a host tap being reported
+ * exactly like a leaf tap: tapping an expandable host item (e.g. an `azRailHostItem`) must toggle
+ * its expansion AND invoke the item's `onClick` callback — the lambda that, in both call sites,
+ * ends by firing `scope.advancedConfig.onInteraction`. If a future refactor toggled expansion
+ * without invoking `onClick`, host taps would silently stop emitting `onInteraction` and any
+ * consumer driving UI off that signal (e.g. an onboarding coach advancing to the next item) would
+ * stall. These tests pin that contract in place.
+ */
+class HandleHostItemClickTest {
+
+    private fun hostItem(id: String = "host"): AzNavItem = AzNavItem(
+        id = id,
+        text = "Host",
+        isRailItem = true,
+        isHost = true,
+        shape = AzButtonShape.CIRCLE
+    )
+
+    @Test
+    fun `host tap toggles expansion and invokes onClick`() {
+        var hostToggled = false
+        var clicked = false
+        var itemClicked = false
+
+        handleHostItemClick(
+            item = hostItem(),
+            navController = null,
+            onClick = { clicked = true },
+            onItemClick = { itemClicked = true },
+            onHostClick = { hostToggled = true }
+        )
+
+        assertTrue("host expansion should toggle on tap", hostToggled)
+        assertTrue("onClick (the onInteraction carrier) should fire on host tap", clicked)
+        assertTrue("onItemClick should fire on host tap", itemClicked)
+    }
+
+    @Test
+    fun `host tap fires callbacks in expand-then-report order`() {
+        val order = mutableListOf<String>()
+
+        handleHostItemClick(
+            item = hostItem(),
+            navController = null,
+            onClick = { order.add("onClick") },
+            onItemClick = { order.add("onItemClick") },
+            onHostClick = { order.add("onHostClick") }
+        )
+
+        // Expansion is toggled first, then the interaction is reported via onClick, then the
+        // general item-click handler runs. The relative order of onClick before onItemClick
+        // matters: consumers see the interaction before any collapse side-effects.
+        assertEquals(listOf("onHostClick", "onClick", "onItemClick"), order)
+    }
+
+    @Test
+    fun `host tap without an onClick handler still toggles expansion`() {
+        var hostToggled = false
+
+        // A host declared without its own onClick must not crash and must still expand.
+        handleHostItemClick(
+            item = hostItem(),
+            navController = null,
+            onClick = null,
+            onItemClick = {},
+            onHostClick = { hostToggled = true }
+        )
+
+        assertTrue(hostToggled)
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -54,7 +54,7 @@ All items now support the following **Reactive Binding Fields**. Provide the nam
 * `isLoadingProperty`: Binds the global loading spinner to a `Boolean` property.
 * `helpEnabled`: When `true`, auto-injects a Help item into the menu drawer if no explicit `azHelpRailItem` / `azHelpSubItem` is registered. The overlay itself is toggled exclusively by tapping a help item (there is no public API to open it externally).
 * `helpList`: An optional mapping of `RailItem` IDs to help texts to be shown in the help overlay alongside `info`.
-* `onInteraction`: Optional callback `((String, AzNavItem) -> Unit)?` invoked whenever any rail item is interacted with (click, toggle, cycler advance, nested rail open, reloc drag). Receives the item's ID and the `AzNavItem` itself.
+* `onInteraction`: Optional callback `((String, AzNavItem) -> Unit)?` invoked whenever any rail item is interacted with (click, toggle, cycler advance, nested rail open, reloc drag, **and host expand/collapse**). Receives the item's ID and the `AzNavItem` itself. Fires for both leaf items (`azRailItem` / `azRailSubItem`) and host items (`azRailHostItem`), in both the compact rail and the expanded menu — so a host tap that opens a sub-menu is observable exactly like a leaf tap. This is the supported way to react to "the user used the rail" (e.g. to drive a tutorial's `AzAdvanceCondition.Event` via `controller.fireEvent(...)`); it does not require — and is not affected by — the rail consuming its own taps.
 
 ### Help overlay scoping & rendering
 

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -518,13 +518,49 @@ The tutorial framework scripts interactive, multi-scene walkthroughs over a dimm
 
 Card auto-positioning: defaults to bottom. Flips to top when highlight center Y > 60% of screen height. `TapTarget` degrades to `TapAnywhere` if the highlight is not `AzHighlight.Item`.
 
-### 9.2 Help/Info Overlay Integration
+### 9.2 How advancement works (read this before building your own coach)
+
+This framework is the supported way to walk a user through the rail. **Do not roll your own
+overlay that waits for taps on rail items to "fall through" to the canvas — they never will.**
+The rail consumes its own pointer events by design (a tap on a nav control must not leak to the
+content behind it). `AzTutorialOverlay` does **not** depend on that leak; it advances through its
+own hit-testing layer:
+
+- **`TapTarget`** — the overlay draws an invisible, full-screen tap absorber plus a clickable box
+  positioned exactly over the spotlight punch-out (computed from `itemBoundsCache`). Tapping inside
+  the spotlight advances (or branches via `branches`); tapping outside is swallowed. Advancement is
+  driven by the overlay's own box, not by the rail item's `onClick`. This is why `TapTarget`
+  **requires** an `AzHighlight.Item(id)` whose bounds are known — without bounds it degrades to
+  `TapAnywhere`.
+- **`Event(name)`** — you advance imperatively by calling `controller.fireEvent(name)` from your own
+  logic. Pair this with `azAdvanced(onInteraction = ...)` (see below) when you want a *real* rail tap
+  — including expanding a host — to drive the tutorial.
+- **`TapAnywhere` / `Button`** — advance on any screen tap, or on an explicit "Next" button.
+
+**Required wiring for item spotlights.** `AzHighlight.Item(id)` and `TapTarget` both need the live,
+measured bounds of the rail item. The rail reports these through
+`azAdvanced(onItemGloballyPositioned = { id, rect -> ... })`; you collect them into a map and pass
+that same map to the overlay as `itemBoundsCache`. If the cache is missing an id, the spotlight
+renders no punch-out and `TapTarget` degrades to `TapAnywhere`. This handshake is shown end-to-end
+in §9.4 (steps 2 and 3) and is easy to forget — if your spotlight never appears, this is the first
+thing to check.
+
+**Driving a tutorial from real rail taps (`onInteraction`).** When you want the tutorial to advance
+because the user *actually used* the rail — tapped a leaf item, flipped a toggle, or expanded a host
+menu — wire `azAdvanced(onInteraction = { id, item -> ... })` and call `controller.fireEvent(...)`
+from it for the ids you care about. `onInteraction` fires for **every** interactive item in **both**
+the compact rail and the expanded menu: leaf items (`azRailItem` / `azRailSubItem`), toggles,
+cyclers, nested-rail opens, reloc drags, **and host items** (`azRailHostItem` — the expand/collapse
+tap reports the interaction just like a leaf tap). This is the correct, supported alternative to
+intercepting taps yourself, and it composes cleanly with `Event` advance conditions.
+
+### 9.3 Help/Info Overlay Integration
 
 - **Collapsed card:** Shows a "Tutorial available" hint when a tutorial exists for that item.
 - **Expanded card:** Shows a "Start Tutorial" button. Tapping it calls `tutorialController.startTutorial(id)` and dismisses the help overlay.
 - The old behavior (any tap immediately starts the tutorial) is removed.
 
-### 9.3 Android — Full Example
+### 9.4 Android — Full Example
 
 ```kotlin
 import com.hereliesaz.aznavrail.tutorial.*
@@ -622,7 +658,7 @@ val hasRead = controller.isTutorialRead("tut-1")
 
 Persistence: `SharedPreferences` file `az_tutorial_prefs`, key `az_navrail_read_tutorials`. State is read on `rememberAzTutorialController()` and written on each `markTutorialRead()`.
 
-### 9.4 React Native — Full Example
+### 9.5 React Native — Full Example
 
 ```tsx
 import {
@@ -704,7 +740,7 @@ controller.fireEvent('menu_opened');
 
 Persistence: `@react-native-async-storage/async-storage` (optional peer dependency). Falls back to in-memory if not installed. Key: `az_navrail_read_tutorials`.
 
-### 9.5 Web — Full Example
+### 9.6 Web — Full Example
 
 The web library is a TypeScript port of Android. New files: `web/AzTutorialController.tsx`, `web/AzTutorialOverlay.tsx`, `web/HelpOverlay.tsx`.
 
@@ -739,7 +775,7 @@ Spotlight implementation: `box-shadow: 0 0 0 9999px rgba(0,0,0,0.7)` applied to 
 
 Persistence: `localStorage`. Key: `az_navrail_read_tutorials`.
 
-### 9.6 Variable Branching
+### 9.7 Variable Branching
 
 Pass a `variables` map to `startTutorial`. Scenes with `branchVar` set evaluate their `branches` map on entry and redirect to the matching scene ID. A scene used only for branching can have an empty `cards` list and a transparent `content`.
 
@@ -755,7 +791,7 @@ controller.startTutorial('tut-1', { userLevel: 'advanced' });
 
 Circular branch detection: if a branch chain loops back to an already-visited scene, a warning is logged and the tutorial advances to the next scene by index. If no next scene exists, the tutorial ends.
 
-### 9.7 Event-Driven Advance
+### 9.8 Event-Driven Advance
 
 Use `AzAdvanceCondition.Event("event_name")` (Kotlin) or `{ type: 'Event', name: 'event_name' }` (TS) on a card. When your app logic fires that event, the overlay automatically advances.
 
@@ -766,11 +802,11 @@ controller.fireEvent("menu_opened")
 
 The overlay observes `pendingEvent` and calls `consumeEvent()` internally on match. You do not need to call `consumeEvent()` yourself.
 
-### 9.8 Checklist Cards
+### 9.9 Checklist Cards
 
 Provide `checklistItems` on a card. The Next button is disabled until every item is checked. Compatible with any advance condition (the checklist gates the advance even for `TapAnywhere`).
 
-### 9.9 Media Cards
+### 9.10 Media Cards
 
 Provide `mediaContent` (a composable/component) on a card. It is rendered between the title and the body text, clipped to a max height of 120dp/120px with 8dp/8px corner rounding. Useful for images, animated GIFs, or short video previews.
 

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -59,7 +59,7 @@ fun azAdvanced(
 )
 ~~~
 
-`onInteraction` is called whenever any rail item is interacted with — click, toggle, cycler advance, nested rail open, or reloc drag. It receives the item's `id` and the `AzNavItem` itself, enabling analytics integration and UI feedback without per-item callbacks.
+`onInteraction` is called whenever any rail item is interacted with — click, toggle, cycler advance, nested rail open, reloc drag, or host expand/collapse. It fires for both leaf items (`azRailItem` / `azRailSubItem`) and host items (`azRailHostItem`), in both the compact rail and the expanded menu, so opening a host menu is observable just like tapping a leaf. It receives the item's `id` and the `AzNavItem` itself, enabling analytics, UI feedback, and tutorial advancement (pair it with `controller.fireEvent(...)` and an `AzAdvanceCondition.Event` card) without per-item callbacks.
 
 ## Hidden Menu Builders (for `azRailRelocItem`)
 * `listItem(text, route)`


### PR DESCRIPTION
## Summary

This branch was opened to make tapping rail items (Design → Open → Sketch → Text) advance an onboarding coach. Investigation showed the **library already supports this** — both via the built-in tutorial framework (`AzAdvanceCondition.TapTarget`) and via `azAdvanced(onInteraction = ...)`, which fires for *every* item type in both rail modes. The conditional library patch (Part B) was **not** warranted; the real gap was that the behavior and integration contract weren't documented clearly, which is what led a consumer to roll a custom coach that fought the rail's (correct) tap-consumption.

This PR therefore does two things: **documents the tutorial framework explicitly**, and **pins the host-tap `onInteraction` contract with a regression test**. No production behavior changes.

## 1. Documentation (primary)

Added a new **§9.2 "How advancement works (read this before building your own coach)"** to the Tutorial Framework guide (`docs/` + the two shipped in-app copies under `aznavrail/src/main/{assets,resources}`), making previously-implicit mechanics explicit:

- **Don't wait for rail taps to fall through to the canvas** — they never will; the rail consumes its own pointer events by design. `AzTutorialOverlay` advances via its own hit-testing layer, not via tap leak-through.
- **How `TapTarget` actually works**: a full-screen tap absorber plus a clickable box positioned over the spotlight punch-out (from `itemBoundsCache`) — which is why it requires an `AzHighlight.Item(id)` with known bounds and otherwise degrades to `TapAnywhere`.
- **The required `onItemGloballyPositioned` → `itemBoundsCache` handshake**, called out as an easy-to-miss step ("if your spotlight never appears, check this first").
- **`onInteraction` as the supported signal** for "the user used the rail", clarifying it fires for **host items** (expand/collapse) as well as leaves, in both the compact rail and the expanded menu, and how to pair it with an `AzAdvanceCondition.Event` card via `controller.fireEvent(...)`.

Also tightened the `onInteraction` one-liners in `docs/API.md` and `docs/DSL.md` to include host expand/collapse coverage. Subsection numbering renumbered consistently across all three guide copies.

## 2. Regression test (supporting)

`HandleHostItemClickTest` pins the contract the consumer depends on: a host tap must toggle expansion **and** invoke `onClick` (the `onInteraction` carrier), in expand-then-report order, and must not crash without an `onClick`. If a future refactor toggled host expansion without invoking `onClick`, host taps would silently stop reporting interactions — this test catches it.

## Verified behavior (no code change needed)

`onInteraction(id, item)` already fires for every tutorial target in both modes:

| Item type | Compact rail | Expanded menu |
|---|---|---|
| Host (`azRailHostItem`) | `RailItems.kt:652` (via `handleHostItemClick` → `onClick`) | `AzNavRail.kt:841` (via `handleHostItemClick` → `onClick`) |
| Leaf sub-item (`azRailSubItem`) | `RailItems.kt:652` | `AzNavRail.kt:841` |
| Reloc sub-item (`azRailRelocItem`) | `RailItems.kt:577` (tap) / `:551` (drop) | `AzNavRail.kt:841` |
| Nested-rail sub-item | `RailItems.kt:686` / `:721` | — |

## Note

The Android unit test couldn't be executed in this environment (no Android SDK; `:aznavrail:testDebugUnitTest` fails at "SDK location not found"). The test is pure Kotlin/JUnit referencing only `handleHostItemClick`, `AzNavItem`, and `AzButtonShape`, mirroring the existing `RelocItemHandlerTest`, so it compiles with the module. Please confirm green in CI.

https://claude.ai/code/session_01H1JAZNyDEi1Ffx1TZbKeRb

## Summary by Sourcery

Document how the tutorial framework advances and how host tap interactions are surfaced, and add regression coverage to pin the host-tap onInteraction contract without changing runtime behavior.

Documentation:
- Expand the tutorial framework guide with a new section explaining advancement modes (TapTarget, Event, TapAnywhere/Button), required item bounds wiring, and using onInteraction to drive tutorials from real rail usage across all platforms.
- Clarify API and DSL docs for onInteraction to explicitly cover host expand/collapse and its role as the supported signal for rail usage-driven tutorials.

Tests:
- Add HandleHostItemClickTest to verify that host taps toggle expansion, invoke onClick in a defined order, and behave safely when onClick is null, pinning the onInteraction behavior relied on by consumers.