### PR TITLE
Add drop-down menu mode and sizable header icon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,4 +142,27 @@ In landscape mode, the RailItems are still way too small, and should be the same
 
 There's a quirky bug with the generated screen title. When I click an AzRailToggle or an AzRailCycler, it displays the text on the button that was present when clicked. It SHOULD display the text of the option that is active.
 
+The app icon in the header must be sizable to a specific diameter. Provide `headerIconSize`
+(a `Dp` on Android via `azTheme`/`azSettings`, a pixel number on React). When unset, the icon keeps
+its legacy behavior of sizing to the rail width. When set, the header icon is rendered at exactly
+that width and height.
+
+Drop-down menu mode: the rail can be used as a drop-down menu via `dropdownMenu = true` in
+`azConfig`/`azSettings` (a `dropdownMenu` boolean in React settings). In this mode:
+
+- `onscreen()` content is allowed the entire width of the screen (the rail reserves no horizontal
+  band). The rail renders as a floating top-anchored trigger above the content.
+- The app icon takes the place of the hamburger menu icon. The bleeding app-name header is not used
+  here; it is always the icon.
+- Tapping the icon causes either the menu items or the rail items to unfold like an accordion
+  downward, reusing the exact fold/unfold mechanism already programmed for the floating-rail (FAB)
+  feature. Tapping the icon again, tapping an item, or tapping outside folds them back up.
+- The developer selects which set unfolds via `dropdownSource` (`RAIL` or `MENU`). There is no
+  collapsing the rail or expanding the menu; whichever they choose is the one and only set the
+  drop-down shows.
+- This mode works at the explicit exclusion of: FAB mode/draggable rail and the overlay service,
+  rail↔menu expansion, `noMenu`, all swipe gestures, physical docking/rotate-in-place, the footer,
+  nested-rail popups, the rail width settings, the bleeding app-name header, the rail safe-zone
+  padding, and the help overlay/tutorials. Host items still expand inline as an accordion.
+
 As an option, I am changing how the AzNavRail switches from portrait to landscape mode. Instead of maintaining its position on the side of the screen, it maintains its position on the side of the device, and all elements of the rail each rotate in place. This may take some careful consideration for whatever logic is needed in different circumstances, like how RailHostItems are expanded, or the difference between the rail being docked on the right or left in portrait mode. Also--PAY ATTENTION--if the rail is docked to the left in portrait mode, rotating the device clockwise means it will be at the top of the screen. But if I rotate counter-clockwise, it should be at the bottom of the screen. And if I turned the device upside down, the rail should be on the left side.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Add JitPack to your `settings.gradle.kts`:
 - **Tutorial Framework**: Scripted multi-scene tutorials with spotlights, 4 advance conditions (Button, TapTarget, TapAnywhere, Event), variable-driven branching, TapTarget branching, checklist cards, media cards, and cross-platform read-state persistence.
 - **Left/Right Docking**: Position the rail on the left or right side of the screen.
 - **No Menu Mode**: Treat all items as rail items, removing the side drawer.
+- **Drop-down Menu Mode**: Use the rail as a top-anchored drop-down. The app icon replaces the hamburger; tapping it unfolds *either* the rail items or the menu items like an accordion, while `onscreen` content gets the full screen width. (`dropdownMenu = true`)
+- **Sizable Header Icon**: Set the app-icon to an exact diameter via `headerIconSize`.
 - **AzHostActivityLayout**: A layout container that enforces strict safe zones and automatic alignment rules.
 - **AzNavHost**: A wrapper around `androidx.navigation.compose.NavHost` for seamless integration.
 - **Smart Transitions**: `AzNavHost` automatically configures directional transitions (slide in/out) based on the docking side (e.g., standard LTR or mirrored for Right dock).
@@ -435,6 +437,80 @@ const settings: AzNavRailSettings = {
     enableRailDragging: true
 };
 // Pass settings to AzNavRail
+```
+
+### Drop-down Menu Mode
+
+Use the rail as a classic **drop-down menu**. Instead of a docked side strip, the rail collapses
+to a single **app-icon trigger anchored at the top of the screen — the app icon takes the place of
+the hamburger menu icon**. Tapping it unfolds the items downward like an accordion (the exact
+fold/unfold behaviour reused from FAB mode); tapping the icon again, tapping an item, or tapping
+outside folds them back up. With this mode enabled, `onscreen` content is given the **entire width
+of the screen** (the rail reserves no horizontal band).
+
+Enable it with `dropdownMenu = true` and choose **one** of two renderings with `dropdownSource`:
+
+- `AzDropdownSource.RAIL` *(default)* — unfolds the **rail items** as the packed rail buttons.
+- `AzDropdownSource.MENU` — unfolds the **menu items** as the full drawer rows.
+
+There is no rail-to-menu expansion and no menu-to-rail collapse: whichever source you pick is the
+one and only set the drop-down shows.
+
+```kotlin
+AzHostActivityLayout(navController = navController) {
+    azConfig(
+        dropdownMenu = true,
+        dropdownSource = AzDropdownSource.MENU, // or AzDropdownSource.RAIL
+    )
+    azTheme(headerIconSize = 56.dp)
+
+    azRailItem(id = "home", text = "Home", route = "home")
+    azMenuItem(id = "settings", text = "Settings", route = "settings")
+
+    onscreen { /* now spans the full screen width */ }
+}
+```
+
+> **This mode runs at the explicit exclusion of many other features.** When `dropdownMenu` is true,
+> the following are intentionally disabled/ignored:
+>
+> - **FAB mode / draggable rail** (`enableRailDragging`, `overlayService`, `onUndock`, `onOverlayDrag`) — no undocking or dragging.
+> - **Rail ↔ menu expansion** (`initiallyExpanded`, the two-state drawer) — there is only the single drop-down.
+> - **`noMenu`** — superseded by `dropdownSource`.
+> - **Swipe gestures** — both the horizontal swipe-to-open/close and the vertical swipe-to-undock. Only a tap toggles the drop-down.
+> - **Physical docking / rotate-in-place** (`usePhysicalDocking`) — the trigger always anchors to the top.
+> - **The footer** (`showFooter`) — not shown.
+> - **Nested-rail popups** (`azNestedRail`) — not supported. (Host items still expand inline as an accordion.)
+> - **Rail width settings** (`expandedWidth`/`collapsedWidth`) — ignored for `RAIL`; the panel sizes to its content. (`MENU` uses `expandedWidth` for the panel width.)
+> - **The bleeding app-name header** (`displayAppName`) — the header is always the app icon.
+> - **The rail safe-zone padding** (top/bottom 10%) — the trigger sits at the top edge. Content safe zones still apply to `onscreen`.
+> - **Help overlay & tutorials** — not driven from the drop-down (their positioning relies on the docked rail).
+
+**React Implementation:**
+```tsx
+import { AzNavRailSettings, AzDropdownSource } from '@HereLiesAz/aznavrail-react';
+
+const settings: AzNavRailSettings = {
+    dropdownMenu: true,
+    dropdownSource: AzDropdownSource.MENU, // or AzDropdownSource.RAIL
+    headerIconSize: 56,
+};
+// Pass settings to <AzNavRail settings={settings} ... />
+```
+
+### Sizable Header Icon
+
+By default the app icon in the header sizes itself to the rail width. To pin it to an **exact
+diameter**, set `headerIconSize` (a `Dp` on Android, a pixel `number` on React):
+
+```kotlin
+azTheme(headerIconSize = 48.dp)
+// or via the combined helper:
+azSettings(headerIconSize = 48.dp)
+```
+
+```tsx
+const settings: AzNavRailSettings = { headerIconSize: 48 };
 ```
 
 

--- a/aznavrail-react/MIGRATION_FROM_ANDROID.md
+++ b/aznavrail-react/MIGRATION_FROM_ANDROID.md
@@ -37,6 +37,20 @@ azTheme(activeColor = MaterialTheme.colorScheme.primary)
 </AzNavRail>
 ```
 
+### Drop-down menu mode & header icon size
+
+| Android | React |
+| --- | --- |
+| `azConfig(dropdownMenu = true, dropdownSource = AzDropdownSource.RAIL)` | `<AzNavRail dropdownMenu dropdownSource={AzDropdownSource.RAIL}>` (or via `settings` on the web build) |
+| `azConfig(dropdownSource = AzDropdownSource.MENU)` | `dropdownSource={AzDropdownSource.MENU}` |
+| `azTheme(headerIconSize = 48.dp)` / `azSettings(headerIconSize = 48.dp)` | `headerIconSize={48}` |
+
+Drop-down mode collapses the rail to a top-anchored app-icon trigger (the icon replaces the
+hamburger) that unfolds either the rail items or the menu items like an accordion, giving the screen
+content the full width. It excludes FAB/dragging, rail↔menu expansion, `noMenu`, swipe gestures,
+physical docking, the footer, nested-rail popups, the bleeding app-name header, and the help overlay
+— matching the Android behaviour. `headerIconSize` is a pixel `number` on React vs a `Dp` on Android.
+
 ## Bottom sheets
 
 The Android library registers sheets via `AzNavHostScope.azBottomSheet(controller, config, ...)`
@@ -100,6 +114,8 @@ The Android callback receives `(itemId: String, item: AzNavItem)`. The React cal
 
 ## What's new in 0.3.0
 
+- **Drop-down menu mode** (`dropdownMenu` + `dropdownSource`) and a **sizable header icon**
+  (`headerIconSize`) reach parity with Android. See "Drop-down menu mode & header icon size" above.
 - Bottom sheet **drag-to-collapse is gentler**: a downward drag now steps **down one detent**
   (`FULL → HALF → PEEK → HIDDEN`) instead of snapping straight to HIDDEN, mirroring the
   up-drag's one-step expand. Matches the Android `9.2` `AzSheetGestures` change.

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Text,
   TouchableOpacity,
+  TouchableWithoutFeedback,
   Animated,
   StyleSheet,
   PanResponder,
@@ -13,7 +14,7 @@ import {
   UIManager,
 } from 'react-native';
 import { AzNavRailContext } from './AzNavRailScope';
-import { AzNavItem, AzNavRailSettings, AzButtonShape, AzDockingSide, AzHeaderIconShape, AzNestedRailAlignment } from './types';
+import { AzNavItem, AzNavRailSettings, AzButtonShape, AzDockingSide, AzDropdownSource, AzHeaderIconShape, AzNestedRailAlignment } from './types';
 import { AzNavRailDefaults } from './AzNavRailDefaults';
 import { AzButton } from './components/AzButton';
 import { AzToggle } from './components/AzToggle';
@@ -62,6 +63,9 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
       enableRailDragging = false,
       dockingSide = AzDockingSide.LEFT,
       noMenu = false,
+      dropdownMenu = false,
+      dropdownSource = AzDropdownSource.RAIL,
+      headerIconSize,
       infoScreen = false,
       onDismissInfoScreen,
       activeColor,
@@ -101,6 +105,9 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
       enableRailDragging: dslOverrides.enableRailDragging ?? enableRailDragging,
       dockingSide: dslOverrides.dockingSide ?? dockingSide,
       noMenu: dslOverrides.noMenu ?? noMenu,
+      dropdownMenu: dslOverrides.dropdownMenu ?? dropdownMenu,
+      dropdownSource: dslOverrides.dropdownSource ?? dropdownSource,
+      headerIconSize: dslOverrides.headerIconSize ?? headerIconSize,
       infoScreen: dslOverrides.infoScreen ?? infoScreen,
       activeColor: dslOverrides.activeColor ?? activeColor,
       headerIconShape: dslOverrides.headerIconShape ?? headerIconShape,
@@ -111,6 +118,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
   };
 
   const [isExpanded, setIsExpanded] = useState(initiallyExpanded && !config.noMenu);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isFloating, setIsFloating] = useState(false);
   const [showFloatingButtons, setShowFloatingButtons] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -527,6 +535,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                     }
                     if (item.onClick) item.onClick();
                     if (item.collapseOnClick && !config.noMenu) setIsExpanded(false);
+                    if (item.collapseOnClick) setIsDropdownOpen(false);
                 }}
             />
           </View>
@@ -553,7 +562,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                   onItemClick={() => {
                       logInteraction('Menu item clicked', item.text, item);
                       if (item.onClick) item.onClick();
-                      if (item.collapseOnClick) setIsExpanded(false);
+                      if (item.collapseOnClick) { setIsExpanded(false); setIsDropdownOpen(false); }
                   }}
                   renderSubItems={() => (
                       <>
@@ -631,6 +640,58 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
   };
 
   const flexDirection = config.dockingSide === AzDockingSide.RIGHT ? 'row-reverse' : 'row';
+
+  // DROP-DOWN MENU MODE.
+  //
+  // The rail becomes a single app-icon trigger anchored at the top; the icon replaces the
+  // hamburger. Tapping it unfolds the chosen item set (`config.dropdownSource`) downward; tapping
+  // it again, tapping an item, or tapping outside folds it back up. The rail reserves no width so
+  // `children` (the screen content) spans the full width underneath. FAB/dragging, rail-to-menu
+  // expansion, swipes, the footer, nested-rail popups and the help overlay are all bypassed here.
+  if (config.dropdownMenu) {
+      const iconSize = (config as any).headerIconSize ?? AzNavRailDefaults.HeaderIconSize;
+      const isRight = config.dockingSide === AzDockingSide.RIGHT;
+      return (
+          <AzNavRailContext.Provider value={{ register, unregister, updateSettings, getDividerId, hasItem }}>
+              <View style={{ flex: 1 }}>
+                  <View style={{ flex: 1 }}>{children}</View>
+
+                  {isDropdownOpen && (
+                      <TouchableWithoutFeedback onPress={() => { logInteraction('Dropdown tap outside', 'folded'); setIsDropdownOpen(false); }}>
+                          <View style={[StyleSheet.absoluteFill, { zIndex: 999 }]} />
+                      </TouchableWithoutFeedback>
+                  )}
+
+                  <View style={{ position: 'absolute', top: 0, left: isRight ? undefined : 0, right: isRight ? 0 : undefined, padding: AzNavRailDefaults.HeaderPadding, alignItems: isRight ? 'flex-end' : 'flex-start', zIndex: 1000 }}>
+                      <TouchableOpacity
+                          onPress={() => { const o = !isDropdownOpen; setIsDropdownOpen(o); logInteraction('Dropdown trigger tapped', o ? `unfolding ${config.dropdownSource}` : 'folding'); }}
+                          accessibilityRole="button"
+                          accessibilityLabel="Menu"
+                      >
+                          <View style={{ width: iconSize, height: iconSize, backgroundColor: 'gray', borderRadius: getHeaderBorderRadius(), alignItems: 'center', justifyContent: 'center' }}>
+                              <Text style={{ color: 'white' }}>Icon</Text>
+                          </View>
+                      </TouchableOpacity>
+
+                      {isDropdownOpen && (
+                          <ScrollView
+                              style={[styles.dropdownPanel, { maxHeight: screenHeightRef.current * 0.8 }]}
+                              contentContainerStyle={config.dropdownSource === AzDropdownSource.MENU ? { width: config.expandedRailWidth } : { alignItems: 'center' }}
+                          >
+                              {config.dropdownSource === AzDropdownSource.MENU
+                                  ? menuItems.map(item => item.isDivider ? <View key={item.id} style={styles.divider} /> : renderMenuItem(item))
+                                  : effectiveRailItems.map((item, index) => renderRailItem(item, index))}
+                          </ScrollView>
+                      )}
+                  </View>
+
+                  {isLoading && (
+                      <View style={styles.loaderOverlay}><AzLoad /></View>
+                  )}
+              </View>
+          </AzNavRailContext.Provider>
+      );
+  }
 
   return (
     <AzNavRailContext.Provider value={{ register, unregister, updateSettings, getDividerId, hasItem }}>
@@ -816,6 +877,17 @@ const styles = StyleSheet.create({
     paddingHorizontal: AzNavRailDefaults.RailContentHorizontalPadding,
     paddingVertical: 8,
     alignItems: 'center',
+  },
+  dropdownPanel: {
+    marginTop: 4,
+    backgroundColor: '#f0f0f0',
+    borderRadius: 12,
+    padding: 8,
+    elevation: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.18,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 8 },
   },
   menuContent: {
     flex: 1,

--- a/aznavrail-react/src/types.ts
+++ b/aznavrail-react/src/types.ts
@@ -36,6 +36,18 @@ export enum AzNestedRailAlignment {
   HORIZONTAL = 'HORIZONTAL',
 }
 
+/**
+ * Selects which set of items the rail reveals when it is used as a drop-down menu
+ * (see `AzNavRailSettings.dropdownMenu`). There is exactly one set — the app icon acts as the
+ * trigger and tapping it unfolds whichever set this names.
+ */
+export enum AzDropdownSource {
+  /** Unfold the rail items, rendered as the packed rail buttons. */
+  RAIL = 'RAIL',
+  /** Unfold the menu items, rendered as the full drawer rows. */
+  MENU = 'MENU',
+}
+
 /** General orientation flag used by layout helpers. */
 export enum AzOrientation {
   /** Components arranged in a column. */
@@ -78,6 +90,21 @@ export interface AzNavRailSettings {
   dockingSide?: AzDockingSide;
   /** When true, the rail never expands into a menu — icon-only mode is permanent. */
   noMenu?: boolean;
+  /**
+   * When true, the rail is used as a drop-down menu: it collapses to a single app-icon trigger
+   * anchored at the top (the icon replaces the hamburger) and unfolds `dropdownSource` downward
+   * like an accordion when tapped. Content is given the full screen width. This mode runs at the
+   * explicit exclusion of FAB/dragging, rail-to-menu expansion, swipe gestures, physical docking,
+   * the footer, nested-rail popups, the bleeding app-name header, and the help overlay.
+   */
+  dropdownMenu?: boolean;
+  /**
+   * Which set of items the drop-down reveals — `RAIL` (the packed rail buttons) or `MENU` (the
+   * full drawer rows). Only honoured when `dropdownMenu` is true. Defaults to `RAIL`.
+   */
+  dropdownSource?: AzDropdownSource;
+  /** Exact diameter (px) of the app icon in the header. When omitted the icon uses its default size. */
+  headerIconSize?: number;
   /** When true, the help/info overlay is displayed over the screen. */
   infoScreen?: boolean;
   /** Called when the user dismisses the info screen overlay. */

--- a/aznavrail-react/src/web/AzNavRail.css
+++ b/aznavrail-react/src/web/AzNavRail.css
@@ -12,6 +12,65 @@
   border-left: 1px solid rgba(0, 0, 0, 0.12);
 }
 
+/* ---- Drop-down menu mode ---- */
+/* The rail is a floating top-anchored trigger; it reserves no width so page content can run
+   edge-to-edge underneath it. */
+.az-nav-rail.dropdown {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: auto;
+  width: auto;
+  background-color: transparent;
+  border: none;
+  z-index: 1000;
+  align-items: flex-start;
+}
+
+.az-nav-rail.dropdown.right {
+  left: auto;
+  right: 0;
+  align-items: flex-end;
+}
+
+/* Full-screen invisible layer that folds the panel back up on an outside click. */
+.az-dropdown-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+
+/* The unfolded accordion of items, dropping down directly under the icon trigger. */
+.az-dropdown-panel {
+  display: flex;
+  flex-direction: column;
+  margin-top: 4px;
+  max-height: 80vh;
+  overflow-y: auto;
+  border-radius: 12px;
+  background-color: #f0f0f0;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  animation: az-dropdown-unfold 0.18s ease-out;
+}
+
+.az-dropdown-panel.rail {
+  align-items: center;
+  padding: 8px;
+}
+
+.az-dropdown-panel.menu {
+  padding: 8px;
+}
+
+.az-dropdown-panel.packed .az-nav-rail-button {
+  margin: 0;
+}
+
+@keyframes az-dropdown-unfold {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .header {
   padding: 16px;
   text-align: center;

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -34,6 +34,9 @@ const AzNavRail = ({
     onDismissInfoScreen,
     dockingSide = 'LEFT',
     noMenu = false,
+    dropdownMenu = false,
+    dropdownSource = 'RAIL',
+    headerIconSize,
     activeClassifiers = new Set(), // Set of strings
     activeColor,
     translucentBackground,
@@ -55,10 +58,16 @@ const AzNavRail = ({
   }, [effectiveNoMenu, isExpanded]);
 
   const [showFooterPopup, setShowFooterPopup] = useState(false);
+  // Drop-down menu mode: a single boolean gates whether the chosen item set is unfolded under
+  // the app-icon trigger (reusing the floating-rail fold/unfold idea).
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const onToggle = () => {
       if (infoScreen) return;
-      if (effectiveNoMenu) {
+      if (dropdownMenu) {
+          // In drop-down mode an item click closes the panel (action + fold up).
+          setIsDropdownOpen(false);
+      } else if (effectiveNoMenu) {
           setShowFooterPopup(!showFooterPopup);
       } else {
           setIsExpanded(!isExpanded);
@@ -351,6 +360,68 @@ const AzNavRail = ({
           default: return 'app-icon circle';
       }
   };
+
+  // Renders a single rail item inside the drop-down panel (RAIL source). Hosts expand inline as an
+  // accordion; cyclers stay open for multi-tap; any other tap performs its action and folds up.
+  // Nested-rail popups and reloc dragging are intentionally not supported in drop-down mode.
+  const renderDropdownRailItem = (item) => {
+      if (item.isDivider) return <AzDivider key={item.id} />;
+      const finalItem = item.isCycler
+        ? { ...item, selectedOption: cyclerStates[item.id]?.displayedOption }
+        : item;
+      const isActive = checkIsActive(item);
+      const isHostItem = item.isHost || !!item.items || !!subItemsMap[item.id];
+      return (
+          <React.Fragment key={item.id}>
+              <div ref={(el) => updateItemBound(item.id, el)} style={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
+                  <AzNavRailButton
+                      item={{ ...finalItem, isActive }}
+                      onCyclerClick={() => handleCyclerClick(item)}
+                      onClickOverride={
+                          isHostItem
+                            ? () => toggleHost(item)
+                            : (item.isCycler
+                                ? undefined
+                                : () => { if (item.onClick) item.onClick(); setIsDropdownOpen(false); })
+                      }
+                      style={{ borderColor: isActive && activeColor ? activeColor : (item.color || 'blue') }}
+                  />
+              </div>
+              {isHostItem && hostStates[item.id] && (subItemsMap[item.id] || [])
+                  .filter(sub => sub.isRailItem)
+                  .map(sub => renderDropdownRailItem(sub))}
+          </React.Fragment>
+      );
+  };
+
+  if (dropdownMenu) {
+      const iconStyle = headerIconSize ? { width: headerIconSize, height: headerIconSize } : undefined;
+      return (
+          <>
+              {isDropdownOpen && (
+                  <div
+                      className="az-dropdown-scrim"
+                      onClick={() => setIsDropdownOpen(false)}
+                  />
+              )}
+              <div className={`az-nav-rail dropdown ${dockingSide === 'RIGHT' ? 'right' : ''} ${isDropdownOpen ? 'open' : ''}`}>
+                  <div className="header" onClick={() => setIsDropdownOpen(o => !o)}>
+                      <img src="/app-icon.png" alt="Menu" className={getHeaderIconClass()} style={iconStyle} />
+                  </div>
+                  {isDropdownOpen && (
+                      <div
+                          className={`az-dropdown-panel ${dropdownSource === 'MENU' ? 'menu' : 'rail'} ${packRailButtons ? 'packed' : ''}`}
+                          style={dropdownSource === 'MENU' ? { width: expandedRailWidth, backgroundColor: translucentBackground || undefined } : { backgroundColor: translucentBackground || undefined }}
+                      >
+                          {dropdownSource === 'MENU'
+                              ? menuItems.map(item => renderMenuItem(item))
+                              : effectiveRailItems.map(item => renderDropdownRailItem(item))}
+                      </div>
+                  )}
+              </div>
+          </>
+      );
+  }
 
   return (
     <>

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavHost.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavHost.kt
@@ -360,10 +360,13 @@ fun AzHostActivityLayout(
             Box(modifier = Modifier.fillMaxSize()) { item.content() }
         }
 
-        val startPadding = if (visualSide == AzVisualSide.LEFT) railWidth else 0.dp
-        val endPadding = if (visualSide == AzVisualSide.RIGHT) railWidth else 0.dp
-        val topPadding = if (visualSide == AzVisualSide.TOP) railWidth else 0.dp
-        val bottomPadding = if (visualSide == AzVisualSide.BOTTOM) railWidth else 0.dp
+        // In drop-down mode the rail is a floating top-anchored trigger, not a docked side-strip,
+        // so it reserves no horizontal/vertical band: onscreen content spans the full screen width.
+        val isDropdown = railScope.dropdownMenu
+        val startPadding = if (!isDropdown && visualSide == AzVisualSide.LEFT) railWidth else 0.dp
+        val endPadding = if (!isDropdown && visualSide == AzVisualSide.RIGHT) railWidth else 0.dp
+        val topPadding = if (!isDropdown && visualSide == AzVisualSide.TOP) railWidth else 0.dp
+        val bottomPadding = if (!isDropdown && visualSide == AzVisualSide.BOTTOM) railWidth else 0.dp
 
         // Identify active item and pull actual transient states
         val railScopeImpl = scope.getRailScopeImpl()
@@ -386,7 +389,7 @@ fun AzHostActivityLayout(
         val titleAlignment = if (visualDockingSideProxy == AzDockingSide.LEFT) Alignment.CenterEnd else Alignment.CenterStart
         val titlePaddingSide = if (visualDockingSideProxy == AzDockingSide.LEFT) Modifier.padding(end = 32.dp) else Modifier.padding(start = 32.dp)
 
-        if (currentTitle != null && currentTitle != AzNavRailDefaults.NO_TITLE && currentTitle.isNotBlank()) {
+        if (!isDropdown && currentTitle != null && currentTitle != AzNavRailDefaults.NO_TITLE && currentTitle.isNotBlank()) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -77,6 +77,7 @@ import com.hereliesaz.aznavrail.internal.MenuItem
 import com.hereliesaz.aznavrail.internal.RailItems
 import com.hereliesaz.aznavrail.internal.SecretScreens
 import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzDropdownSource
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzNavItem
 import com.hereliesaz.aznavrail.model.AzNestedRailAlignment
@@ -357,6 +358,167 @@ fun AzNavRail(
         }
     }
 
+    // DROP-DOWN MENU MODE.
+    //
+    // When enabled, the rail abandons its docked side-strip identity entirely and behaves as a
+    // single app-icon trigger anchored at the top (the icon replaces the hamburger). Tapping it
+    // unfolds the chosen item set downward — reusing the same fold/unfold idea as FAB mode: a
+    // single boolean gates whether the items render. There is no rail<->menu expansion, no
+    // dragging, no swipes, no footer, no nested-rail popups, and no help overlay here; this branch
+    // returns before any of that machinery is reached. `onscreen` content is widened to the full
+    // screen by AzHostActivityLayout (it zeroes the rail-offset padding in this mode).
+    if (scope.dropdownMenu) {
+        var isDropdownOpen by remember { mutableStateOf(false) }
+        val dropAlignment = if (visualDockingSide == AzDockingSide.RIGHT) Alignment.TopEnd else Alignment.TopStart
+        val iconDiameter = if (scope.headerIconSize != androidx.compose.ui.unit.Dp.Unspecified) {
+            scope.headerIconSize
+        } else {
+            minOf(100.dp, scope.collapsedWidth)
+        }
+        val maxPanelHeight = (configuration.screenHeightDp * 0.8f).dp
+
+        // Shared rail-cycler debounce handler, identical to the docked rail's behaviour.
+        val onDropdownCyclerClick: (AzNavItem) -> Unit = { item ->
+            val state = cyclerStates[item.id]
+            if (state != null && !item.disabled) {
+                state.job?.cancel()
+                val options = item.options ?: emptyList()
+                val enabledOptions = options.filterNot { it in (item.disabledOptions ?: emptyList()) }
+                if (enabledOptions.isNotEmpty()) {
+                    val currentIndex = enabledOptions.indexOf(state.displayedOption)
+                    val nextOption = enabledOptions[(currentIndex + 1) % enabledOptions.size]
+                    scope.transientCyclerOptions[item.id] = nextOption
+                    cyclerStates[item.id] = state.copy(
+                        displayedOption = nextOption,
+                        job = coroutineScope.launch {
+                            delay(1000L)
+                            scope.onClickMap[item.id]?.invoke()
+                            cyclerStates[item.id] = cyclerStates[item.id]?.copy(job = null) ?: state
+                        }
+                    )
+                }
+                scope.advancedConfig.onInteraction?.invoke(item.id, item)
+            }
+        }
+
+        Box(modifier = modifier.fillMaxSize()) {
+            // Tap anywhere outside the open dropdown to fold it back up.
+            if (isDropdownOpen) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .pointerInput(Unit) {
+                            detectTapGestures(onTap = {
+                                isDropdownOpen = false
+                                Log.d("AzNavRail", "Dropdown: tap outside, folded up.")
+                            })
+                        }
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .align(dropAlignment)
+                    .padding(AzNavRailDefaults.HeaderPadding),
+                horizontalAlignment = if (visualDockingSide == AzDockingSide.RIGHT) Alignment.End else Alignment.Start
+            ) {
+                // App icon == hamburger trigger.
+                Box(
+                    modifier = Modifier
+                        .size(iconDiameter)
+                        .pointerInput(scope.vibrate) {
+                            detectTapGestures(onTap = {
+                                isDropdownOpen = !isDropdownOpen
+                                if (scope.vibrate) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                Log.d(
+                                    "AzNavRail",
+                                    "Dropdown trigger tapped: ${if (isDropdownOpen) "unfolding" else "folding"} ${scope.dropdownSource} items."
+                                )
+                            })
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (appIcon != null) {
+                        val baseModifier = Modifier.fillMaxSize()
+                        val clipModifier = when (scope.headerIconShape) {
+                            AzHeaderIconShape.CIRCLE -> baseModifier.clip(CircleShape)
+                            AzHeaderIconShape.ROUNDED -> baseModifier.clip(RoundedCornerShape(12.dp))
+                            else -> baseModifier
+                        }
+                        Image(
+                            painter = rememberAsyncImagePainter(appIcon),
+                            contentDescription = "Menu",
+                            modifier = clipModifier
+                        )
+                    } else {
+                        Icon(Icons.Default.Menu, "Menu")
+                    }
+                }
+
+                // The unfolded set — exactly one of the two renderings.
+                if (isDropdownOpen) {
+                    Surface(
+                        color = Color.Transparent,
+                        tonalElevation = 2.dp,
+                        modifier = Modifier.shadow(8.dp, RectangleShape)
+                    ) {
+                        val dropScroll = rememberScrollState()
+                        if (scope.dropdownSource == AzDropdownSource.MENU) {
+                            Column(
+                                modifier = Modifier
+                                    .width(scope.expandedWidth)
+                                    .heightIn(max = maxPanelHeight)
+                                    .verticalScroll(dropScroll)
+                            ) {
+                                scope.navItems.forEach { item ->
+                                    if (!item.isSubItem) {
+                                        MenuItemNode(
+                                            item = item,
+                                            allItems = scope.navItems,
+                                            navController = effectiveNavController,
+                                            currentDestination = actualCurrentDestination,
+                                            scope = scope,
+                                            hostStates = hostStates,
+                                            showHelpOverlay = false,
+                                            onToggleHelp = { },
+                                            onCollapseMenu = { isDropdownOpen = false }
+                                        )
+                                    }
+                                }
+                            }
+                        } else {
+                            Column(
+                                modifier = Modifier
+                                    .heightIn(max = maxPanelHeight)
+                                    .verticalScroll(dropScroll),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                RailItems(
+                                    items = scope.navItems,
+                                    scope = scope,
+                                    navController = effectiveNavController,
+                                    currentDestination = actualCurrentDestination,
+                                    buttonSize = activeButtonSize,
+                                    onRailCyclerClick = onDropdownCyclerClick,
+                                    onItemSelected = { item ->
+                                        if (item.collapseOnClick) isDropdownOpen = false
+                                    },
+                                    hostStates = hostStates,
+                                    packRailButtons = true,
+                                    visualDockingSide = visualDockingSide,
+                                    onItemGloballyPositioned = null,
+                                    helpEnabled = false,
+                                    rotationDegrees = rotationDegrees
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return
+    }
+
     fun toggleExpanded() {
         if (!showHelpOverlay) {
             if (isFloating) {
@@ -610,8 +772,13 @@ fun AzNavRail(
                         )
                     } else {
                         // Reverts to identical App Icon logic
+                        val headerIconDiameter = if (scope.headerIconSize != androidx.compose.ui.unit.Dp.Unspecified) {
+                            scope.headerIconSize
+                        } else {
+                            minOf(100.dp, targetRailWidth)
+                        }
                         Box(
-                            modifier = Modifier.size(minOf(100.dp, targetRailWidth)),
+                            modifier = Modifier.size(headerIconDiameter),
                             contentAlignment = Alignment.Center
                         ) {
                             if (appIcon != null) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -14,6 +14,7 @@ import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
 import com.hereliesaz.aznavrail.model.AzAdvancedConfig
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzDropdownSource
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzItemConfig
 import com.hereliesaz.aznavrail.model.AzNavItem
@@ -66,8 +67,16 @@ interface AzNavRailScope {
      * @param collapsedWidth The width of the rail when collapsed.
      * @param showFooter Whether to show the footer (Privacy, Terms, Help) in the menu.
      * @param appRepositoryUrl The URL of the application's repository to link to in the footer's "About" section. Defaults to the AzNavRail repo.
+     * @param dropdownMenu If true, the rail collapses to a single app-icon trigger anchored at the top
+     *   (the icon replaces the hamburger) and unfolds [dropdownSource] downward like an accordion when
+     *   tapped. `onscreen` content is given the full screen width. This mode runs at the explicit
+     *   exclusion of FAB/dragging, rail-to-menu expansion, swipe gestures, physical docking, the
+     *   footer, nested-rail popups, the bleeding app-name header, and the help overlay.
+     * @param dropdownSource Which set of items the drop-down reveals — [AzDropdownSource.RAIL] (the
+     *   packed rail buttons) or [AzDropdownSource.MENU] (the full drawer rows). Only honoured when
+     *   [dropdownMenu] is true.
      */
-    fun azConfig(dockingSide: AzDockingSide = AzDockingSide.LEFT, packButtons: Boolean = false, noMenu: Boolean = false, vibrate: Boolean = false, displayAppName: Boolean = false, activeClassifiers: Set<String> = emptySet(), usePhysicalDocking: Boolean = false, expandedWidth: Dp = 160.dp, collapsedWidth: Dp = 100.dp, showFooter: Boolean = true, appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail")
+    fun azConfig(dockingSide: AzDockingSide = AzDockingSide.LEFT, packButtons: Boolean = false, noMenu: Boolean = false, vibrate: Boolean = false, displayAppName: Boolean = false, activeClassifiers: Set<String> = emptySet(), usePhysicalDocking: Boolean = false, expandedWidth: Dp = 160.dp, collapsedWidth: Dp = 100.dp, showFooter: Boolean = true, appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail", dropdownMenu: Boolean = false, dropdownSource: AzDropdownSource = AzDropdownSource.RAIL)
 
     /**
      * Configures the visual theme of the rail.
@@ -77,8 +86,10 @@ interface AzNavRailScope {
      * @param headerIconShape The shape of the header icon (Circle, Rounded, None).
      * @param translucentBackground The translucent background color for the rail and popup menus.
      * @param helpLineColors List of colors to use for the connecting lines in the Help overlay.
+     * @param headerIconSize The exact diameter (width and height) of the app icon in the header.
+     *   When [Dp.Unspecified] (the default) the icon sizes itself to the rail width as before.
      */
-    fun azTheme(activeColor: Color = Color.Unspecified, defaultShape: AzButtonShape = AzButtonShape.CIRCLE, headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE, translucentBackground: Color = Color.Unspecified, helpLineColors: List<Color> = emptyList())
+    fun azTheme(activeColor: Color = Color.Unspecified, defaultShape: AzButtonShape = AzButtonShape.CIRCLE, headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE, translucentBackground: Color = Color.Unspecified, helpLineColors: List<Color> = emptyList(), headerIconSize: Dp = Dp.Unspecified)
 
     /**
      * Configures advanced features like loading states, help screens, and overlays.
@@ -113,6 +124,7 @@ interface AzNavRailScope {
         defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
         enableRailDragging: Boolean = false,
         headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
+        headerIconSize: Dp = Dp.Unspecified,
         onUndock: (() -> Unit)? = null,
         overlayService: Class<out android.app.Service>? = null,
         onOverlayDrag: ((Float, Float) -> Unit)? = null,
@@ -129,7 +141,9 @@ interface AzNavRailScope {
         helpList: Map<String, Any> = emptyMap(),
         tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial> = emptyMap(),
         helpLineColors: List<Color> = emptyList(),
-        onInteraction: ((String, com.hereliesaz.aznavrail.model.AzNavItem) -> Unit)? = null
+        onInteraction: ((String, com.hereliesaz.aznavrail.model.AzNavItem) -> Unit)? = null,
+        dropdownMenu: Boolean = false,
+        dropdownSource: AzDropdownSource = AzDropdownSource.RAIL
     )
 
     /**
@@ -609,6 +623,14 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     var packButtons: Boolean = false
     /** If true, the side menu drawer is disabled; the rail operates icon-only. */
     var noMenu: Boolean = false
+    /**
+     * If true, the rail is used as a drop-down menu: it collapses to a single app-icon trigger
+     * anchored at the top of the screen, and unfolds [dropdownSource] downward when tapped. See
+     * [AzNavRailScope.azConfig] for the full list of features this mode disables.
+     */
+    var dropdownMenu: Boolean = false
+    /** Which item set the drop-down reveals when [dropdownMenu] is true. */
+    var dropdownSource: AzDropdownSource = AzDropdownSource.RAIL
     /** If true, haptic feedback is triggered on header tap and drag events. */
     var vibrate: Boolean = false
     /** If true, the header area shows the app name instead of the app icon. */
@@ -625,6 +647,11 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     var defaultShape: AzButtonShape = AzButtonShape.CIRCLE // Restored: default is circle
     /** Shape applied to the app icon in the rail header. */
     var headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE // Default per legacy, overridden in UI
+    /**
+     * Exact diameter (width and height) of the app icon in the header. [Dp.Unspecified] (the
+     * default) keeps the legacy behaviour of sizing the icon to the rail width.
+     */
+    var headerIconSize: Dp = Dp.Unspecified
     /** Background color for popup overlays (nested rails, hidden menus). [Color.Unspecified] uses the surface color. */
     var translucentBackground: Color = Color.Unspecified
     /** Colors used for the connecting lines drawn in the Help overlay. Falls back to a built-in rainbow palette. */
@@ -635,7 +662,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     var advancedConfig: AzAdvancedConfig = AzAdvancedConfig()
 
 
-    override fun azConfig(dockingSide: AzDockingSide, packButtons: Boolean, noMenu: Boolean, vibrate: Boolean, displayAppName: Boolean, activeClassifiers: Set<String>, usePhysicalDocking: Boolean, expandedWidth: Dp, collapsedWidth: Dp, showFooter: Boolean, appRepositoryUrl: String) {
+    override fun azConfig(dockingSide: AzDockingSide, packButtons: Boolean, noMenu: Boolean, vibrate: Boolean, displayAppName: Boolean, activeClassifiers: Set<String>, usePhysicalDocking: Boolean, expandedWidth: Dp, collapsedWidth: Dp, showFooter: Boolean, appRepositoryUrl: String, dropdownMenu: Boolean, dropdownSource: AzDropdownSource) {
         this.dockingSide = dockingSide
         this.packButtons = packButtons
         this.noMenu = noMenu
@@ -647,14 +674,17 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         this.collapsedWidth = collapsedWidth
         this.showFooter = showFooter
         this.appRepositoryUrl = appRepositoryUrl
+        this.dropdownMenu = dropdownMenu
+        this.dropdownSource = dropdownSource
     }
 
-    override fun azTheme(activeColor: Color, defaultShape: AzButtonShape, headerIconShape: AzHeaderIconShape, translucentBackground: Color, helpLineColors: List<Color>) {
+    override fun azTheme(activeColor: Color, defaultShape: AzButtonShape, headerIconShape: AzHeaderIconShape, translucentBackground: Color, helpLineColors: List<Color>, headerIconSize: Dp) {
         this.activeColor = activeColor
         this.defaultShape = defaultShape
         this.headerIconShape = headerIconShape
         this.translucentBackground = translucentBackground
         this.helpLineColors = helpLineColors
+        this.headerIconSize = headerIconSize
     }
 
     override fun azAdvanced(isLoading: Boolean, helpEnabled: Boolean, onDismissHelp: (() -> Unit)?, overlayService: Class<out android.app.Service>?, onUndock: (() -> Unit)?, enableRailDragging: Boolean, onRailDrag: ((Float, Float) -> Unit)?, onOverlayDrag: ((Float, Float) -> Unit)?, onItemGloballyPositioned: ((String, Rect) -> Unit)?, secLoc: String?, secLocPort: Int, helpList: Map<String, Any>, tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial>, onInteraction: ((String, AzNavItem) -> Unit)?) {
@@ -686,6 +716,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         defaultShape: AzButtonShape,
         enableRailDragging: Boolean,
         headerIconShape: AzHeaderIconShape,
+        headerIconSize: Dp,
         onUndock: (() -> Unit)?,
         overlayService: Class<out android.app.Service>?,
         onOverlayDrag: ((Float, Float) -> Unit)?,
@@ -702,16 +733,21 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         helpList: Map<String, Any>,
         tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial>,
         helpLineColors: List<Color>,
-        onInteraction: ((String, AzNavItem) -> Unit)?
+        onInteraction: ((String, AzNavItem) -> Unit)?,
+        dropdownMenu: Boolean,
+        dropdownSource: AzDropdownSource
     ) {
         // Map to internal properties
         this.displayAppName = displayAppNameInHeader
+        this.dropdownMenu = dropdownMenu
+        this.dropdownSource = dropdownSource
         this.packButtons = packRailButtons
         this.expandedWidth = expandedRailWidth
         this.collapsedWidth = collapsedRailWidth
         this.showFooter = showFooter
         this.defaultShape = defaultShape
         this.headerIconShape = headerIconShape
+        this.headerIconSize = headerIconSize
         if (activeColor != null) this.activeColor = activeColor
         this.vibrate = vibrate
         this.dockingSide = dockingSide

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzDropdownSource.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzDropdownSource.kt
@@ -1,0 +1,23 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * Selects which set of items the rail reveals when it is used as a drop-down menu
+ * (see [com.hereliesaz.aznavrail.AzNavRailScope.azConfig]'s `dropdownMenu` flag).
+ *
+ * In drop-down mode there is exactly **one** set of items — the app icon acts as the menu
+ * trigger and tapping it unfolds whichever set this enum names. There is no rail-to-menu
+ * expansion; the developer commits to one of the two renderings.
+ */
+enum class AzDropdownSource {
+    /**
+     * Unfold the **rail** items (everything declared via `azRail*`), rendered as the packed
+     * rail buttons exactly as they would appear on the collapsed rail strip.
+     */
+    RAIL,
+
+    /**
+     * Unfold the **menu** items (the full expandable drawer, including `azRail*` and `azMenu*`
+     * entries), rendered as the menu rows exactly as they would appear in the expanded drawer.
+     */
+    MENU
+}

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailScopeTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailScopeTest.kt
@@ -1,8 +1,11 @@
 package com.hereliesaz.aznavrail
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzDropdownSource
 import com.hereliesaz.aznavrail.model.AzNestedRailAlignment
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -45,6 +48,41 @@ class AzNavRailScopeTest {
 
         assertEquals(Color.Red, scope.activeColor)
         assertEquals(AzButtonShape.SQUARE, scope.defaultShape)
+    }
+
+    @Test
+    fun `dropdownMenu defaults are off`() {
+        assertEquals(false, scope.dropdownMenu)
+        assertEquals(AzDropdownSource.RAIL, scope.dropdownSource)
+        assertEquals(Dp.Unspecified, scope.headerIconSize)
+    }
+
+    @Test
+    fun `azConfig enables dropdown menu mode`() {
+        scope.azConfig(dropdownMenu = true, dropdownSource = AzDropdownSource.MENU)
+
+        assertTrue(scope.dropdownMenu)
+        assertEquals(AzDropdownSource.MENU, scope.dropdownSource)
+    }
+
+    @Test
+    fun `azSettings enables dropdown and header icon size`() {
+        scope.azSettings(
+            dropdownMenu = true,
+            dropdownSource = AzDropdownSource.RAIL,
+            headerIconSize = 56.dp
+        )
+
+        assertTrue(scope.dropdownMenu)
+        assertEquals(AzDropdownSource.RAIL, scope.dropdownSource)
+        assertEquals(56.dp, scope.headerIconSize)
+    }
+
+    @Test
+    fun `azTheme sets header icon size`() {
+        scope.azTheme(headerIconSize = 40.dp)
+
+        assertEquals(40.dp, scope.headerIconSize)
     }
 
     @Test

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,9 +93,36 @@ fun azConfig(
     usePhysicalDocking: Boolean = false,
     expandedWidth: Dp = 130.dp,
     collapsedWidth: Dp = 80.dp,
-    showFooter: Boolean = true
+    showFooter: Boolean = true,
+    appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail",
+    dropdownMenu: Boolean = false,
+    dropdownSource: AzDropdownSource = AzDropdownSource.RAIL
 )
 ~~~
+
+* `dropdownMenu`: `Boolean` — use the rail as a top-anchored drop-down menu. The app icon replaces
+  the hamburger; tapping it unfolds `dropdownSource` like an accordion while `onscreen` content gets
+  the full screen width. Excludes FAB/dragging, rail↔menu expansion, `noMenu`, swipe gestures,
+  physical docking, the footer, nested-rail popups, the bleeding app-name header, and the help overlay.
+* `dropdownSource`: `AzDropdownSource` — `RAIL` (packed rail buttons) or `MENU` (full drawer rows).
+  Only honoured when `dropdownMenu` is true.
+
+### `azTheme`
+Controls the visual style of the rail.
+
+~~~kotlin
+fun azTheme(
+    activeColor: Color = Color.Unspecified,
+    defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
+    headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
+    translucentBackground: Color = Color.Unspecified,
+    helpLineColors: List<Color> = emptyList(),
+    headerIconSize: Dp = Dp.Unspecified
+)
+~~~
+
+* `headerIconSize`: `Dp` — exact diameter of the header app-icon. `Dp.Unspecified` (default) sizes
+  the icon to the rail width (legacy behavior).
 
 ---
 

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -79,7 +79,9 @@ azConfig(
     packButtons = packRailButtons,       // Boolean: Pack items tightly vs spaced
     dockingSide = AzDockingSide.LEFT,    // Enum: LEFT or RIGHT
     noMenu = noMenu,                     // Boolean: Disable the side drawer entirely
-    usePhysicalDocking = usePhysicalDocking // Boolean: Anchor to physical hardware edge vs visual left
+    usePhysicalDocking = usePhysicalDocking, // Boolean: Anchor to physical hardware edge vs visual left
+    dropdownMenu = false,                // Boolean: Use the rail as a top-anchored drop-down menu
+    dropdownSource = AzDropdownSource.RAIL // Enum: which set the drop-down unfolds (RAIL or MENU)
 )
 ```
 
@@ -91,7 +93,8 @@ Controls visual style defaults.
 azTheme(
     defaultShape = AzButtonShape.RECTANGLE, // Default shape for all items
     activeColor = MaterialTheme.colorScheme.primary, // Color for active state
-    translucentBackground = Color.Black.copy(alpha = 0.5f) // Set the background color for menus/overlays!
+    translucentBackground = Color.Black.copy(alpha = 0.5f), // Set the background color for menus/overlays!
+    headerIconSize = 48.dp                  // Exact app-icon diameter (Dp.Unspecified = size to rail width)
 )
 ```
 
@@ -142,6 +145,43 @@ const settings: AzNavRailSettings = {
 
 > **Note on Help Overlay:**
 > The `HelpOverlay` displays a short, truncated entry for each item to conserve space. Tapping a help card expands it to reveal the full description and any extra text provided in `helpList`. Furthermore, `helpList` can be supplied dynamically to `AzNestedRail` components for distinct, localized help data.
+
+
+### D. Drop-down Menu Mode (`dropdownMenu`)
+
+Setting `dropdownMenu = true` turns the rail into a top-anchored **drop-down menu** instead of a
+docked side strip:
+
+- The rail collapses to a single **app-icon trigger** anchored at the top — the app icon takes the
+  place of the hamburger menu icon.
+- `onscreen` content is given the **entire width of the screen** (the rail reserves no horizontal
+  band; it floats above the content).
+- Tapping the icon unfolds the chosen item set **downward like an accordion** (the same fold/unfold
+  mechanism used by FAB mode). Tapping the icon again, tapping an item, or tapping outside folds it
+  back up.
+- `dropdownSource` chooses **one** rendering — there is no rail↔menu expansion:
+  - `AzDropdownSource.RAIL` *(default)* → the packed **rail** buttons.
+  - `AzDropdownSource.MENU` → the full drawer **menu** rows.
+
+```kotlin
+azConfig(dropdownMenu = true, dropdownSource = AzDropdownSource.MENU)
+azTheme(headerIconSize = 56.dp)
+```
+
+```tsx
+const settings: AzNavRailSettings = {
+    dropdownMenu: true,
+    dropdownSource: AzDropdownSource.MENU, // or AzDropdownSource.RAIL
+    headerIconSize: 56,
+};
+```
+
+**Excluded features.** Drop-down mode runs at the explicit exclusion of: FAB mode / draggable rail
+and the overlay service; rail↔menu expansion (`initiallyExpanded`); `noMenu`; all swipe gestures;
+physical docking / rotate-in-place; the footer; nested-rail popups (`azNestedRail`); the rail width
+settings (`RAIL` sizes to content, `MENU` uses `expandedWidth`); the bleeding app-name header
+(`displayAppName`); the rail safe-zone padding; and the help overlay / tutorials. Host items still
+expand inline as an accordion.
 
 ---
 

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -24,9 +24,18 @@ fun azConfig(
     usePhysicalDocking: Boolean = false,
     expandedWidth: Dp = 130.dp,
     collapsedWidth: Dp = 80.dp,
-    showFooter: Boolean = true
+    showFooter: Boolean = true,
+    appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail",
+    dropdownMenu: Boolean = false,
+    dropdownSource: AzDropdownSource = AzDropdownSource.RAIL
 )
 ~~~
+
+`dropdownMenu` turns the rail into a top-anchored drop-down: the app icon replaces the hamburger and
+tapping it unfolds `dropdownSource` (`RAIL` = packed rail buttons, `MENU` = full drawer rows) like an
+accordion, while `onscreen` content spans the full screen width. This mode excludes FAB/dragging,
+rail↔menu expansion, `noMenu`, swipe gestures, physical docking, the footer, nested-rail popups, the
+bleeding app-name header, and the help overlay. See the README's "Drop-down Menu Mode" section.
 
 ### `azTheme`
 Controls the visual style of the rail.
@@ -35,9 +44,15 @@ Controls the visual style of the rail.
 fun azTheme(
     activeColor: Color = Color.Unspecified,
     defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
-    headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE
+    headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
+    translucentBackground: Color = Color.Unspecified,
+    helpLineColors: List<Color> = emptyList(),
+    headerIconSize: Dp = Dp.Unspecified
 )
 ~~~
+
+`headerIconSize` pins the header app-icon to an exact diameter. When left `Dp.Unspecified` the icon
+sizes itself to the rail width (legacy behavior).
 
 ### `azAdvanced`
 Controls system overrides, loading states, and floating window bindings.


### PR DESCRIPTION
## Summary

Adds a new **drop-down menu mode** to the rail, plus a **sizable header icon** option, across Android (Compose), React Native, and React web.

### Drop-down menu mode (`dropdownMenu = true`)
- The rail collapses to a single **app-icon trigger** anchored at the top — the app icon takes the place of the hamburger menu icon.
- `onscreen()` content is given the **entire width of the screen** (the rail reserves no horizontal band; it floats above the content).
- Tapping the icon unfolds the chosen item set **downward like an accordion**, reusing the floating-rail (FAB) fold/unfold mechanism. Tapping the icon again, tapping an item, or tapping outside folds it back up.
- `dropdownSource` selects the one and only set shown — `RAIL` (packed rail buttons) or `MENU` (full drawer rows). There is no rail↔menu expansion.

#### Features intentionally excluded in this mode
FAB/dragging & overlay service, rail↔menu expansion, `noMenu`, all swipe gestures, physical docking/rotate-in-place, the footer, nested-rail popups, the rail width settings, the bleeding app-name header, the rail safe-zone padding, and the help overlay/tutorials. (Host items still expand inline as an accordion.)

### Sizable header icon (`headerIconSize`)
Pins the header app-icon to an exact diameter (`Dp` on Android via `azTheme`/`azSettings`; pixel `number` in React settings). When unset, the icon keeps its legacy behaviour of sizing to the rail width.

## Implementation
- New `AzDropdownSource` enum (Kotlin + TS).
- Android: `AzNavRail.kt` (dedicated early-return render path), `AzNavHost.kt` (full-width onscreen), `AzNavRailScope.kt` (`azConfig`/`azSettings`/`azTheme` params + fields).
- React: `types.ts`, `AzNavRail.tsx` (RN), `web/AzNavRail.jsx` + `web/AzNavRail.css`.

## Docs
README, Complete Guide, DSL/API references, AGENTS.md, and the React migration guide all updated. Added Android scope tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV

---
_Generated by [Claude Code](https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV)_

## Summary by Sourcery

Add a configurable drop-down menu mode and header icon sizing to the navigation rail across Android, React Native, and React web, and document the new options.

New Features:
- Introduce a drop-down menu mode where the rail collapses into a top-anchored app-icon trigger that unfolds either rail or menu items.
- Allow configuring the header app icon to a specific diameter via a new headerIconSize setting on all platforms.

Enhancements:
- Wire dropdownMenu, dropdownSource, and headerIconSize through the Android AzNavRail scope, host layout, and Compose UI.
- Expose dropdownMenu, dropdownSource, and headerIconSize in React Native and React web settings and components for consistent behavior.
- Update styles and layouts so drop-down mode floats above content without reserving rail width.

Documentation:
- Expand README, complete guide, DSL/API docs, AGENTS notes, and React migration guide to describe drop-down menu mode and header icon sizing.
- Note the behavioral exclusions and platform parity for the new drop-down mode and header icon sizing options.

Tests:
- Extend Android scope tests to cover default and configured values for dropdownMenu, dropdownSource, and headerIconSize.