### PR TITLE
Fix drop-down panel background + demo drop-down mode in sample apps

### DIFF
--- a/SampleApp/COVERAGE.md
+++ b/SampleApp/COVERAGE.md
@@ -16,8 +16,9 @@ should be added before shipping.
 
 | DSL | Exercised by |
 | --- | --- |
-| `azConfig` (all params: `vibrate`, `displayAppName`, `activeClassifiers`, `expandedWidth`, `collapsedWidth`, `showFooter`, `appRepositoryUrl`, `packButtons`, `noMenu`, `usePhysicalDocking`, `dockingSide`) | `MainApp.kt`, driven by `CustomizationDemoScreen` + legacy toggles |
-| `azTheme` (`activeColor`, `defaultShape`, `headerIconShape`, `translucentBackground`, `helpLineColors`) | `MainApp.kt`, driven by `CustomizationDemoScreen` |
+| `azConfig` (all params: `vibrate`, `displayAppName`, `activeClassifiers`, `expandedWidth`, `collapsedWidth`, `showFooter`, `appRepositoryUrl`, `packButtons`, `noMenu`, `usePhysicalDocking`, `dockingSide`, `dropdownMenu`, `dropdownSource`) | `MainApp.kt`, driven by `CustomizationDemoScreen` + legacy toggles |
+| `azTheme` (`activeColor`, `defaultShape`, `headerIconShape`, `translucentBackground`, `helpLineColors`, `headerIconSize`) | `MainApp.kt`, driven by `CustomizationDemoScreen` |
+| Drop-down menu mode (`dropdownMenu` + `dropdownSource` RAIL/MENU) and `headerIconSize` | `CustomizationDemoScreen` toggle/cycler/slider |
 | `azAdvanced` (`isLoading`, `helpEnabled`, `onDismissHelp`, `enableRailDragging`, `onRailDrag`, `onOverlayDrag`, `onUndock`, `helpList`, `tutorials`) | `MainApp.kt`, driven by `FabOverlayDemoScreen`, `HelpSystemDemoScreen`, `TutorialDemoScreen` |
 | `azMenuItem` | `MainApp.kt` (10× showcase menu items) |
 | `azRailItem` (Color/ResourceId/ImageVector/AzComposableContent content variants, shape, disabled, classifiers, info) | `MainApp.kt` rail items (`color-item`, `icon-item`, `vector-item`) |

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
@@ -54,6 +54,7 @@ import com.hereliesaz.aznavrail.bottomsheet.rememberAzSheetController
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzComposableContent
 import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzDropdownSource
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzNestedRailAlignment
 import com.hereliesaz.aznavrail.model.AzSheetConfig
@@ -160,6 +161,8 @@ fun MainApp() {
             collapsedWidth = customization.collapsedWidth,
             showFooter = customization.showFooter,
             appRepositoryUrl = customization.appRepositoryUrl,
+            dropdownMenu = customization.dropdownMenu,
+            dropdownSource = customization.dropdownSource,
         )
 
         azTheme(
@@ -168,6 +171,7 @@ fun MainApp() {
             headerIconShape = customization.headerIconShape,
             translucentBackground = customization.translucentBackground,
             helpLineColors = customization.helpLineColors,
+            headerIconSize = customization.headerIconSize,
         )
 
         azAdvanced(

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
@@ -21,6 +21,7 @@ import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.AzCycler
 import com.hereliesaz.aznavrail.AzToggle
 import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzDropdownSource
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 
 /** Live theme/config state surfaced from MainApp so the rail can re-key on each change. */
@@ -35,10 +36,14 @@ data class CustomizationState(
     val appRepositoryUrl: String,
     val helpLineColors: List<Color>,
     val vibrate: Boolean,
+    val headerIconSize: Dp = Dp.Unspecified,
+    val dropdownMenu: Boolean = false,
+    val dropdownSource: AzDropdownSource = AzDropdownSource.RAIL,
 )
 
 private val headerIconShapes = AzHeaderIconShape.values().toList()
 private val defaultShapes = AzButtonShape.values().toList()
+private val dropdownSources = AzDropdownSource.values().toList()
 private val translucentChoices = listOf(
     "Unspecified" to Color.Unspecified,
     "Black 40%" to Color.Black.copy(alpha = 0.4f),
@@ -121,6 +126,33 @@ fun CustomizationDemoScreen(
             value = state.collapsedWidth.value,
             onValueChange = { onChange(state.copy(collapsedWidth = it.dp)) },
             valueRange = 60f..160f,
+        )
+
+        SectionLabel("headerIconSize: ${if (state.headerIconSize == Dp.Unspecified) "auto (rail width)" else "${state.headerIconSize.value.toInt()} dp"}")
+        Slider(
+            value = if (state.headerIconSize == Dp.Unspecified) 0f else state.headerIconSize.value,
+            onValueChange = { onChange(state.copy(headerIconSize = if (it < 1f) Dp.Unspecified else it.dp)) },
+            valueRange = 0f..120f,
+        )
+
+        SectionLabel("dropdownMenu — use the rail as a drop-down (app icon = hamburger)")
+        AzToggle(
+            isChecked = state.dropdownMenu,
+            onToggle = { onChange(state.copy(dropdownMenu = !state.dropdownMenu)) },
+            toggleOnText = "Dropdown On",
+            toggleOffText = "Dropdown Off",
+            shape = AzButtonShape.RECTANGLE,
+        )
+
+        SectionLabel("dropdownSource (which set the drop-down unfolds)")
+        AzCycler(
+            options = dropdownSources.map { it.name },
+            selectedOption = state.dropdownSource.name,
+            onCycle = {
+                val next = dropdownSources[(dropdownSources.indexOf(state.dropdownSource) + 1) % dropdownSources.size]
+                onChange(state.copy(dropdownSource = next))
+            },
+            shape = AzButtonShape.RECTANGLE,
         )
 
         SectionLabel("displayAppName")

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -458,9 +458,10 @@ fun AzNavRail(
                 // The unfolded set — exactly one of the two renderings.
                 if (isDropdownOpen) {
                     Surface(
-                        color = Color.Transparent,
+                        color = if (scope.translucentBackground != Color.Unspecified) scope.translucentBackground else MaterialTheme.colorScheme.surface,
+                        shape = RoundedCornerShape(12.dp),
                         tonalElevation = 2.dp,
-                        modifier = Modifier.shadow(8.dp, RectangleShape)
+                        modifier = Modifier.shadow(8.dp, RoundedCornerShape(12.dp))
                     ) {
                         val dropScroll = rememberScrollState()
                         if (scope.dropdownSource == AzDropdownSource.MENU) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -461,7 +461,7 @@ fun AzNavRail(
                         color = if (scope.translucentBackground != Color.Unspecified) scope.translucentBackground else MaterialTheme.colorScheme.surface,
                         shape = RoundedCornerShape(12.dp),
                         tonalElevation = 2.dp,
-                        modifier = Modifier.shadow(8.dp, RoundedCornerShape(12.dp))
+                        shadowElevation = 8.dp
                     ) {
                         val dropScroll = rememberScrollState()
                         if (scope.dropdownSource == AzDropdownSource.MENU) {

--- a/sample-pwa/README.md
+++ b/sample-pwa/README.md
@@ -13,8 +13,9 @@ this Vite PWA, not Jekyll).
   and the `AzBottomSheetInsetAware` variant.
 - **Standalone Widgets** — `AzButton`, `AzToggle`, `AzCycler` at every `AzButtonShape`,
   plus `AzRoller`, `AzDivider`, `AzLoad`.
-- **Customization** — live header icon shape, default shape, rail widths, footer, repo URL,
-  haptics, and `activeClassifiers` chips.
+- **Customization** — live header icon shape, header icon size, default shape, rail widths,
+  footer, repo URL, haptics, `activeClassifiers` chips, and **drop-down menu mode**
+  (`dropdownMenu` + `dropdownSource` RAIL/MENU).
 - **Forms** — `AzForm` + `AzTextBox` showcase.
 - **Rail Playground** — toggles, cyclers, host items, reloc items with hidden menus, and both
   vertical/horizontal nested rails (each with its own Help item that scopes the help overlay).

--- a/sample-pwa/src/App.tsx
+++ b/sample-pwa/src/App.tsx
@@ -6,6 +6,7 @@ import {
   AzAlignment,
   AzButtonShape,
   AzDockingSide,
+  AzDropdownSource,
   AzHeaderIconShape,
   AzNestedRailAlignment,
   AzRailItem,
@@ -69,6 +70,9 @@ function App() {
     appRepositoryUrl: 'https://github.com/HereLiesAz/AzNavRail',
     vibrate: false,
     activeClassifiers: new Set<string>(),
+    headerIconSize: 0,
+    dropdownMenu: false,
+    dropdownSource: AzDropdownSource.RAIL,
   })
 
   const themeColor = '#6200EE'
@@ -93,6 +97,9 @@ function App() {
       appRepositoryUrl={customization.appRepositoryUrl}
       vibrate={customization.vibrate}
       activeClassifiers={customization.activeClassifiers}
+      headerIconSize={customization.headerIconSize || undefined}
+      dropdownMenu={customization.dropdownMenu}
+      dropdownSource={customization.dropdownSource}
       onDismissInfoScreen={() => {
         setShowHelp(false)
         setDismissCount((n) => n + 1)

--- a/sample-pwa/src/screens/CustomizationDemo.tsx
+++ b/sample-pwa/src/screens/CustomizationDemo.tsx
@@ -1,5 +1,6 @@
 import {
   AzButtonShape,
+  AzDropdownSource,
   AzHeaderIconShape,
 } from '@HereLiesAz/aznavrail-react'
 
@@ -13,10 +14,14 @@ export interface CustomizationState {
   appRepositoryUrl: string
   vibrate: boolean
   activeClassifiers: Set<string>
+  headerIconSize: number
+  dropdownMenu: boolean
+  dropdownSource: AzDropdownSource
 }
 
 const headerShapes = Object.values(AzHeaderIconShape) as AzHeaderIconShape[]
 const buttonShapes = Object.values(AzButtonShape) as AzButtonShape[]
+const dropdownSources = Object.values(AzDropdownSource) as AzDropdownSource[]
 const repoChoices: { label: string; url: string }[] = [
   { label: 'AzNavRail', url: 'https://github.com/HereLiesAz/AzNavRail' },
   { label: 'Anthropic', url: 'https://github.com/anthropics' },
@@ -69,6 +74,28 @@ export default function CustomizationDemo({
           type="range" min={80} max={200} value={state.collapsedRailWidth}
           onChange={(e) => onChange({ ...state, collapsedRailWidth: Number(e.target.value) })}
         />
+      </Block>
+
+      <Block label={`headerIconSize: ${state.headerIconSize ? `${state.headerIconSize}px` : 'auto (default)'}`}>
+        <input
+          type="range" min={0} max={96} value={state.headerIconSize}
+          onChange={(e) => onChange({ ...state, headerIconSize: Number(e.target.value) })}
+        />
+      </Block>
+
+      <Toggle
+        label="dropdownMenu — use the rail as a drop-down (app icon = hamburger)"
+        value={state.dropdownMenu}
+        onChange={(v) => onChange({ ...state, dropdownMenu: v })}
+      />
+
+      <Block label={`dropdownSource: ${state.dropdownSource}`}>
+        <select
+          value={state.dropdownSource}
+          onChange={(e) => onChange({ ...state, dropdownSource: e.target.value as AzDropdownSource })}
+        >
+          {dropdownSources.map((s) => <option key={s} value={s}>{s}</option>)}
+        </select>
       </Block>
 
       <Toggle


### PR DESCRIPTION
## Summary

Follow-up to #460. Three things:

### 1. Fix transparent drop-down panel (the reported bug)
The drop-down panel's `Surface` used `color = Color.Transparent`, so menu/rail items blended into the screen content and were unreadable. The panel now gets a solid, theme-aware background (`scope.translucentBackground` when set, else `MaterialTheme.colorScheme.surface`) and a `RoundedCornerShape(12.dp)`, matching the React Native and Web panels.

### 2. Use `Surface.shadowElevation` (addressing Gemini review)
Replaced the manual `Modifier.shadow(8.dp, RoundedCornerShape(12.dp))` with `Surface`'s `shadowElevation = 8.dp`, so the shadow is drawn with the Surface's own shape — no duplicate shape, no future mismatch.

### 3. Demo the feature in both sample apps
- **SampleApp (Android):** `headerIconSize` slider, `dropdownMenu` toggle, and `dropdownSource` (RAIL/MENU) cycler in the Customization screen, wired through `azConfig`/`azTheme`.
- **sample-pwa (React web):** the same controls in the Customization screen, forwarded to `AzHostActivityLayout`.
- Updated `SampleApp/COVERAGE.md` and the `sample-pwa` README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV