### PR TITLE
In-app About reader + "More from Az" carousel

### DIFF
--- a/.github/workflows/android-sample-build.yml
+++ b/.github/workflows/android-sample-build.yml
@@ -2,6 +2,9 @@ name: Android Sample Build
 
 on:
   push:
+    paths-ignore:
+      - 'more-from-az.json'
+      - '**/*.md'
 
 jobs:
   build:

--- a/.github/workflows/bump-more-from-az.yml
+++ b/.github/workflows/bump-more-from-az.yml
@@ -1,0 +1,42 @@
+name: Bump more-from-az version
+
+# Auto-increments the `version` integer in more-from-az.json whenever its content changes, so the
+# rail's "More from Az" carousel can invalidate its cache without cutting a library release.
+#
+# Loop safety: the bot commit message contains [skip ci], which GitHub honors to skip ALL workflows
+# for that push (so neither this workflow nor android-sample-build.yml re-runs on the bump commit).
+# The job is additionally guarded against the bot actor and [skip ci] messages.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'more-from-az.json'
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Increment version
+        run: |
+          current=$(jq '.version' more-from-az.json)
+          next=$((current + 1))
+          tmp=$(mktemp)
+          jq ".version = $next" more-from-az.json > "$tmp" && mv "$tmp" more-from-az.json
+          echo "Bumped more-from-az version $current -> $next"
+
+      - name: Commit bumped version
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: bump more-from-az version [skip ci]"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          file_pattern: more-from-az.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,4 +165,28 @@ Drop-down menu mode: the rail can be used as a drop-down menu via `dropdownMenu 
   nested-rail popups, the rail width settings, the bleeding app-name header, the rail safe-zone
   padding, and the help overlay/tutorials. Host items still expand inline as an accordion.
 
+In-app About reader + "More from Az": the footer "About" item opens a built-in, full-screen, themed
+markdown reader (an overlay drawn over the live UI, like the help overlay) instead of opening the repo
+URL in a browser. It auto-discovers the consuming app's docs by listing the `.md` files in the
+repository root and the `docs/` folder of `appRepositoryUrl` via the GitHub contents API, builds a
+table of contents, and renders each doc inline. Fetches are cached (ETag + TTL) to respect GitHub's
+unauthenticated rate limit; offline/limited shows the last cached copy. Public repos only. Configured
+via `azAbout(inAppAbout, moreFromAzEnabled, moreFromAzJsonUrl, moreRailItem)`; `inAppAbout = false`
+restores the browser behavior.
+
+"More from Az" is a carousel of the author's other apps reachable from the About screen and/or a
+pinned "More" rail item (`moreRailItem`). It is driven by a **link-only** `more-from-az.json` at the
+repo root: each entry is just `{ github?, play?, web? }` and the name/icon/description are
+auto-populated by resolving the link (Play OpenGraph, website/PWA OpenGraph, or GitHub repo API).
+Everything is built from the rail's own components (`AzButton`, `AzLoad`, `AzDivider`,
+`AutoSizeText`) and tokens (`activeColor`, `translucentBackground`, `defaultShape`, `headerIconShape`)
+so it matches the rail's aesthetic.
+
+INVARIANT — do not break: `more-from-az.json`'s `version` integer is auto-incremented by
+`.github/workflows/bump-more-from-az.yml` on every content change, committed back as
+`github-actions[bot]` with a `[skip ci]` message. The `[skip ci]` is load-bearing: it stops the bump
+commit from re-triggering both that workflow and `android-sample-build.yml` (which also has
+`paths-ignore` for `more-from-az.json` and `**/*.md`). The rail reads `version` to invalidate its
+cache. Do not hand-edit `version`.
+
 As an option, I am changing how the AzNavRail switches from portrait to landscape mode. Instead of maintaining its position on the side of the screen, it maintains its position on the side of the device, and all elements of the rail each rotate in place. This may take some careful consideration for whatever logic is needed in different circumstances, like how RailHostItems are expanded, or the difference between the rail being docked on the right or left in portrait mode. Also--PAY ATTENTION--if the rail is docked to the left in portrait mode, rotating the device clockwise means it will be at the top of the screen. But if I rotate counter-clockwise, it should be at the bottom of the screen. And if I turned the device upside down, the rail should be on the left side.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Add JitPack to your `settings.gradle.kts`:
 - **No Menu Mode**: Treat all items as rail items, removing the side drawer.
 - **Drop-down Menu Mode**: Use the rail as a top-anchored drop-down. The app icon replaces the hamburger; tapping it unfolds *either* the rail items or the menu items like an accordion, while `onscreen` content gets the full screen width. (`dropdownMenu = true`)
 - **Sizable Header Icon**: Set the app-icon to an exact diameter via `headerIconSize`.
+- **In-App About Reader**: The footer "About" opens a themed in-app markdown reader that auto-discovers your repo's docs (root + `docs/`) and renders them inline. (`azAbout`)
+- **More from Az**: A self-versioning, link-only carousel of other apps (name/icon/description auto-populated from GitHub/Play/PWA links); optionally pinned as a "More" rail item.
 - **AzHostActivityLayout**: A layout container that enforces strict safe zones and automatic alignment rules.
 - **AzNavHost**: A wrapper around `androidx.navigation.compose.NavHost` for seamless integration.
 - **Smart Transitions**: `AzNavHost` automatically configures directional transitions (slide in/out) based on the docking side (e.g., standard LTR or mirrored for Right dock).
@@ -512,6 +514,80 @@ azSettings(headerIconSize = 48.dp)
 ```tsx
 const settings: AzNavRailSettings = { headerIconSize: 48 };
 ```
+
+
+### In-App About Reader
+
+The footer **About** item can open a built-in, themed **in-app documentation reader** instead of
+launching the browser. It **auto-discovers** your app's markdown docs — every `.md` file in the repo
+**root** and the **`docs/`** folder of your configured `appRepositoryUrl` — via the GitHub API, builds
+a table of contents, and renders each doc inline with a markdown renderer themed to the rail
+(`activeColor` links, `translucentBackground` surfaces). A **View on GitHub** button is pinned at the
+bottom with extra spacing.
+
+```kotlin
+azConfig(appRepositoryUrl = "https://github.com/YourOrg/YourApp")
+azAbout(inAppAbout = true)   // default; set false to open the repo URL in a browser instead
+```
+
+```tsx
+const settings: AzNavRailSettings = {
+  appRepositoryUrl: 'https://github.com/YourOrg/YourApp',
+  inAppAbout: true,
+};
+```
+
+- **Caching & rate limit:** results are cached (ETag + 6h TTL) to stay well under GitHub's
+  unauthenticated ~60 req/hr limit; when offline or rate-limited the reader shows the last cached copy.
+- **Public repos only** (unauthenticated GitHub API). Private repos won't resolve.
+- The system **back** button (Android) / back arrow returns from a doc to the table of contents, then
+  dismisses.
+
+### More from Az
+
+A built-in carousel of the library author's other apps, reachable from a **"More from Az"** entry in
+the About screen and/or a pinned **"More"** rail item. It is driven by a **link-only**
+[`more-from-az.json`](more-from-az.json) maintained in *this* repo — each entry is just one or two
+links and the **name, icon, and description are auto-populated** by resolving them (Google Play
+OpenGraph tags, a website/PWA's OpenGraph tags, or the GitHub repository API):
+
+```json
+{
+  "version": 1,
+  "apps": [
+    { "github": "https://github.com/HereLiesAz/AzNavRail" },
+    { "play": "https://play.google.com/store/apps/details?id=com.example", "github": "https://github.com/you/example" },
+    { "web": "https://your-pwa.example.com" }
+  ]
+}
+```
+
+- **Self-versioning:** the `version` integer is **auto-incremented by a GitHub Action**
+  (`.github/workflows/bump-more-from-az.yml`) whenever the file changes, committed back with
+  `[skip ci]`. The rail reads `version` to refresh its cache — **so you never cut a release just to
+  add an app.** Do not hand-edit `version`.
+- **PWAs supported:** a `web` link is treated as a website/PWA and gets an **Open** button.
+- **Config & placement:**
+
+```kotlin
+azAbout(
+    moreFromAzEnabled = true,                 // show the "More from Az" entry in the About screen
+    moreRailItem = true,                      // also pin a "More" item at the bottom of the rail
+    moreFromAzJsonUrl = "https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json",
+)
+```
+
+```tsx
+const settings: AzNavRailSettings = {
+  moreFromAzEnabled: true,
+  moreRailItem: true,
+  moreFromAzJsonUrl: 'https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json',
+};
+```
+
+> **Web note:** Play-Store/website link metadata is fetched client-side and is subject to CORS, so on
+> the web build those links may not auto-resolve (GitHub links always do). Native Android resolves all
+> link types. The link-out buttons always work regardless.
 
 
 ### Reorderable Items (AzRailRelocItem)

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
@@ -174,6 +174,10 @@ fun MainApp() {
             headerIconSize = customization.headerIconSize,
         )
 
+        // In-app About reader (auto-generated from this repo's docs) + pinned "More" rail item that
+        // opens the "More from Az" carousel.
+        azAbout(moreRailItem = true)
+
         azAdvanced(
             isLoading = isLoading,
             enableRailDragging = fabState.railDragEnabled,

--- a/aznavrail-react/MIGRATION_FROM_ANDROID.md
+++ b/aznavrail-react/MIGRATION_FROM_ANDROID.md
@@ -51,6 +51,23 @@ content the full width. It excludes FAB/dragging, rail↔menu expansion, `noMenu
 physical docking, the footer, nested-rail popups, the bleeding app-name header, and the help overlay
 — matching the Android behaviour. `headerIconSize` is a pixel `number` on React vs a `Dp` on Android.
 
+### In-app About reader & "More from Az"
+
+| Android | React |
+| --- | --- |
+| `azAbout(inAppAbout = true)` | `<AzNavRail inAppAbout />` / `settings.inAppAbout` |
+| `azAbout(moreFromAzEnabled = true)` | `moreFromAzEnabled` |
+| `azAbout(moreRailItem = true)` | `moreRailItem` |
+| `azAbout(moreFromAzJsonUrl = "…")` | `moreFromAzJsonUrl` |
+| `azConfig(appRepositoryUrl = "…")` | `appRepositoryUrl` |
+
+The footer "About" opens an in-app markdown reader that auto-discovers the repo's docs (root +
+`docs/`) via the GitHub API; "More from Az" is a link-only, CI-versioned carousel. Both are themed
+from `activeColor`/`translucentBackground` and built from the library's own components. Markdown is
+rendered by a small self-contained renderer (no `react-markdown` dependency). **Web caveat:** Play /
+website link metadata for "More from Az" is subject to CORS and may not resolve in the browser build
+(GitHub links always do); native resolves all. Use `appRepositoryUrl` to point the reader at your repo.
+
 ## Bottom sheets
 
 The Android library registers sheets via `AzNavHostScope.azBottomSheet(controller, config, ...)`

--- a/aznavrail-react/package.json
+++ b/aznavrail-react/package.json
@@ -161,6 +161,7 @@
     "ip": "^2.0.1",
     "flatted": "^3.3.3",
     "picomatch": "^4.0.3",
+    "shell-quote": "^1.8.3",
     "@babel/plugin-transform-modules-systemjs": "^7.27.4",
     "@babel/runtime": "^7.27.4",
     "@babel/core": "^7.27.4",

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -25,6 +25,8 @@ import { DraggableRailItemWrapper } from './components/DraggableRailItemWrapper'
 import { RelocItemHandler } from './util/RelocItemHandler';
 import { AzNestedRailPopup } from './components/AzNestedRailPopup';
 import { HelpOverlay } from './components/HelpOverlay';
+import { AboutOverlay } from './components/AboutOverlay';
+import { MoreFromAzOverlay } from './components/MoreFromAzOverlay';
 import { AzTutorialProvider, useAzTutorialController } from './tutorial/AzTutorialController';
 import { AzTutorialOverlay } from './components/AzTutorialOverlay';
 
@@ -75,6 +77,11 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
       onExpandedChange,
       onInteraction,
       helpList = {},
+      appRepositoryUrl = 'https://github.com/HereLiesAz/AzNavRail',
+      inAppAbout = true,
+      moreFromAzEnabled = true,
+      moreFromAzJsonUrl = 'https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json',
+      moreRailItem = false,
   } = props;
   const logInteraction = useCallback(
     (action: string, details?: string, item?: AzNavItem) => {
@@ -115,10 +122,17 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
       vibrate: dslOverrides.vibrate ?? vibrate,
       onItemGloballyPositioned: dslOverrides.onItemGloballyPositioned,
       helpList: dslOverrides.helpList ?? helpList,
+      appRepositoryUrl: (dslOverrides as any).appRepositoryUrl ?? appRepositoryUrl,
+      inAppAbout: dslOverrides.inAppAbout ?? inAppAbout,
+      moreFromAzEnabled: dslOverrides.moreFromAzEnabled ?? moreFromAzEnabled,
+      moreFromAzJsonUrl: dslOverrides.moreFromAzJsonUrl ?? moreFromAzJsonUrl,
+      moreRailItem: dslOverrides.moreRailItem ?? moreRailItem,
   };
 
   const [isExpanded, setIsExpanded] = useState(initiallyExpanded && !config.noMenu);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [showAbout, setShowAbout] = useState(false);
+  const [showMoreFromAz, setShowMoreFromAz] = useState(false);
   const [isFloating, setIsFloating] = useState(false);
   const [showFloatingButtons, setShowFloatingButtons] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(0);
@@ -586,7 +600,12 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
       };
 
       const handleAbout = () => {
-        Linking.openURL('https://github.com/HereLiesAz/AzNavRail').catch(e => console.error("Could not open About", e));
+        if (config.inAppAbout) {
+          setIsExpanded(false);
+          setShowAbout(true);
+        } else {
+          Linking.openURL(config.appRepositoryUrl).catch(e => console.error("Could not open About", e));
+        }
       };
 
       const handleFeedback = () => {
@@ -742,6 +761,14 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
             ) : (
                 <ScrollView contentContainerStyle={styles.railContent}>
                      {(isFloating && !showFloatingButtons) ? null : effectiveRailItems.map((item, index) => renderRailItem(item, index))}
+                     {(!isFloating && config.moreRailItem && config.moreFromAzEnabled) && (
+                         <AzButton
+                             text="More"
+                             color={config.activeColor || '#6200ee'}
+                             shape={config.defaultShape}
+                             onClick={() => setShowMoreFromAz(true)}
+                         />
+                     )}
                 </ScrollView>
             )}
 
@@ -791,6 +818,24 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                     itemBounds={itemBounds}
                     nestedRailVisibleId={nestedRailVisible}
                     tutorials={(config as any).tutorials}
+                />
+            )}
+
+            {showAbout && (
+                <AboutOverlay
+                    repoUrl={config.appRepositoryUrl}
+                    settings={{ activeColor: config.activeColor, translucentBackground: config.translucentBackground }}
+                    moreFromAzEnabled={config.moreFromAzEnabled}
+                    moreFromAzJsonUrl={config.moreFromAzJsonUrl}
+                    onDismiss={() => setShowAbout(false)}
+                />
+            )}
+
+            {showMoreFromAz && (
+                <MoreFromAzOverlay
+                    jsonUrl={config.moreFromAzJsonUrl}
+                    settings={{ activeColor: config.activeColor, translucentBackground: config.translucentBackground }}
+                    onDismiss={() => setShowMoreFromAz(false)}
                 />
             )}
 

--- a/aznavrail-react/src/__tests__/aboutServices.test.ts
+++ b/aznavrail-react/src/__tests__/aboutServices.test.ts
@@ -1,0 +1,58 @@
+import { parseRepo, humanize, parseContents, orderToc } from '../services/githubDocs';
+import { parseLinks, extractOg } from '../services/moreFromAz';
+
+describe('githubDocs', () => {
+  it('parseRepo extracts owner/repo and strips .git', () => {
+    expect(parseRepo('https://github.com/HereLiesAz/AzNavRail')).toEqual(['HereLiesAz', 'AzNavRail']);
+    expect(parseRepo('https://github.com/HereLiesAz/AzNavRail.git')).toEqual(['HereLiesAz', 'AzNavRail']);
+    expect(parseRepo('https://gitlab.com/a/b')).toBeNull();
+  });
+
+  it('humanize turns filenames into titles', () => {
+    expect(humanize('MIGRATION_GUIDE.md')).toBe('Migration Guide');
+    expect(humanize('project-structure.md')).toBe('Project Structure');
+  });
+
+  it('parseContents keeps only markdown files', () => {
+    const json = JSON.stringify([
+      { type: 'file', name: 'README.md', path: 'README.md', download_url: 'u' },
+      { type: 'file', name: 'build.gradle', path: 'build.gradle', download_url: 'u' },
+      { type: 'dir', name: 'docs', path: 'docs' },
+      { type: 'file', name: 'API.md', path: 'API.md', download_url: 'u' },
+    ]);
+    expect(parseContents(json)).toHaveLength(2);
+  });
+
+  it('orderToc puts README first and docs last', () => {
+    const root = parseContents(JSON.stringify([
+      { type: 'file', name: 'API.md', path: 'API.md', download_url: 'u' },
+      { type: 'file', name: 'README.md', path: 'README.md', download_url: 'u' },
+    ]));
+    const docs = parseContents(JSON.stringify([
+      { type: 'file', name: 'DSL.md', path: 'docs/DSL.md', download_url: 'u' },
+    ]));
+    const toc = orderToc(root, docs);
+    expect(toc[0].title).toBe('README');
+    expect(toc[toc.length - 1].path).toBe('docs/DSL.md');
+  });
+});
+
+describe('moreFromAz', () => {
+  it('parseLinks reads version and drops empty entries', () => {
+    const [version, links] = parseLinks(
+      JSON.stringify({ version: 7, apps: [{ github: 'https://github.com/a/b' }, { play: 'p', web: 'w' }, {}] })
+    );
+    expect(version).toBe(7);
+    expect(links).toHaveLength(2);
+    expect(links[1].web).toBe('w');
+  });
+
+  it('extractOg pulls content regardless of attribute order', () => {
+    const html =
+      '<meta property="og:title" content="My App">' +
+      '<meta content="https://img/icon.png" property="og:image">';
+    expect(extractOg(html, 'title')).toBe('My App');
+    expect(extractOg(html, 'image')).toBe('https://img/icon.png');
+    expect(extractOg(html, 'description')).toBeUndefined();
+  });
+});

--- a/aznavrail-react/src/components/AboutOverlay.tsx
+++ b/aznavrail-react/src/components/AboutOverlay.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Linking, BackHandler } from 'react-native';
+import AzMarkdownNative from './AzMarkdownNative';
+import { MoreFromAzOverlay } from './MoreFromAzOverlay';
+import { AzButton } from './AzButton';
+import { AzLoad } from './AzLoad';
+import { AzButtonShape } from '../types';
+import { listDocs, fetchDoc, AzDocEntry } from '../services/githubDocs';
+
+interface AboutOverlayProps {
+  repoUrl: string;
+  settings?: { activeColor?: string; translucentBackground?: string };
+  moreFromAzEnabled?: boolean;
+  moreFromAzJsonUrl: string;
+  onDismiss: () => void;
+}
+
+type DocsState =
+  | { status: 'loading' }
+  | { status: 'loaded'; entries: AzDocEntry[]; offline: boolean }
+  | { status: 'error' };
+
+/**
+ * Full-screen in-app About reader for React Native. Auto-discovers the repo's markdown docs and
+ * renders the selected one inline via {@link AzMarkdownNative}; a GitHub button is pinned at the
+ * bottom and an optional "More from Az" entry opens the carousel. Themed to match the rail.
+ */
+export const AboutOverlay: React.FC<AboutOverlayProps> = ({ repoUrl, settings = {}, moreFromAzEnabled, moreFromAzJsonUrl, onDismiss }) => {
+  const accent = settings.activeColor || '#6200ee';
+  const surface = settings.translucentBackground || '#ffffff';
+  const [state, setState] = useState<DocsState>({ status: 'loading' });
+  const [selected, setSelected] = useState<AzDocEntry | null>(null);
+  const [body, setBody] = useState<string | null>(null);
+  const [showMore, setShowMore] = useState(false);
+
+  useEffect(() => {
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (showMore) { setShowMore(false); return true; }
+      if (selected) { setSelected(null); return true; }
+      onDismiss();
+      return true;
+    });
+    return () => sub.remove();
+  }, [selected, showMore, onDismiss]);
+
+  useEffect(() => {
+    let active = true;
+    listDocs(repoUrl)
+      .then((r) => active && setState({ status: 'loaded', entries: r.entries, offline: r.offline }))
+      .catch(() => active && setState({ status: 'error' }));
+    return () => { active = false; };
+  }, [repoUrl]);
+
+  useEffect(() => {
+    if (!selected) { setBody(null); return; }
+    let active = true;
+    setBody(null);
+    fetchDoc(selected).then((b) => active && setBody(b ?? '_Could not load this document._'));
+    return () => { active = false; };
+  }, [selected]);
+
+  return (
+    <View style={[styles.overlay, { backgroundColor: surface }]}>
+      <View style={styles.header}>
+        {selected && (
+          <TouchableOpacity onPress={() => setSelected(null)} accessibilityLabel="Back to contents">
+            <Text style={[styles.icon, { color: accent }]}>←</Text>
+          </TouchableOpacity>
+        )}
+        <Text style={[styles.title, { color: accent }]} numberOfLines={1}>{selected ? selected.title : 'About'}</Text>
+        <TouchableOpacity onPress={onDismiss} accessibilityLabel="Close">
+          <Text style={[styles.icon, { color: accent }]}>✕</Text>
+        </TouchableOpacity>
+      </View>
+
+      {selected ? (
+        body === null ? <AzLoad /> : (
+          <ScrollView style={styles.flex}><AzMarkdownNative markdown={body} accent={accent} /></ScrollView>
+        )
+      ) : (
+        <View style={styles.flex}>
+          {state.status === 'loading' && <AzLoad />}
+          {state.status === 'error' && <Text style={styles.empty}>Couldn't load documentation.</Text>}
+          {state.status === 'loaded' && (
+            <>
+              {state.offline && <Text style={styles.banner}>Showing cached docs (offline or rate-limited).</Text>}
+              {state.entries.length === 0 ? (
+                <Text style={styles.empty}>No documentation found in this repository.</Text>
+              ) : (
+                <ScrollView style={styles.flex} contentContainerStyle={styles.toc}>
+                  {state.entries.map((e) => (
+                    <TouchableOpacity key={e.path} style={[styles.tocRow, { borderColor: accent }]} onPress={() => setSelected(e)}>
+                      <Text style={[styles.tocText, { color: accent }]}>{e.title}</Text>
+                    </TouchableOpacity>
+                  ))}
+                  {moreFromAzEnabled && (
+                    <TouchableOpacity style={[styles.tocRow, styles.emph, { borderColor: accent }]} onPress={() => setShowMore(true)}>
+                      <Text style={[styles.tocText, { color: accent, fontWeight: 'bold' }]}>More from Az</Text>
+                    </TouchableOpacity>
+                  )}
+                </ScrollView>
+              )}
+              <View style={styles.bottomSpacer} />
+              <AzButton text="View on GitHub" color={accent} shape={AzButtonShape.RECTANGLE} onClick={() => Linking.openURL(repoUrl).catch(() => {})} />
+            </>
+          )}
+        </View>
+      )}
+
+      {showMore && <MoreFromAzOverlay jsonUrl={moreFromAzJsonUrl} settings={settings} onDismiss={() => setShowMore(false)} />}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: { ...StyleSheet.absoluteFillObject, zIndex: 3000, paddingTop: '6%', paddingBottom: '10%', paddingHorizontal: 20 },
+  flex: { flex: 1 },
+  header: { flexDirection: 'row', alignItems: 'center' },
+  title: { flex: 1, fontSize: 30, fontWeight: 'bold', marginHorizontal: 8 },
+  icon: { fontSize: 22, paddingHorizontal: 6 },
+  toc: { gap: 8, paddingVertical: 12 },
+  tocRow: { borderWidth: 1, borderRadius: 12, paddingVertical: 14, paddingHorizontal: 16, marginBottom: 8 },
+  emph: { borderWidth: 2 },
+  tocText: { fontSize: 18 },
+  empty: { opacity: 0.7, paddingVertical: 16, fontSize: 15 },
+  banner: { opacity: 0.6, paddingVertical: 8, fontSize: 12 },
+  bottomSpacer: { height: 32 },
+});

--- a/aznavrail-react/src/components/AzMarkdownNative.tsx
+++ b/aznavrail-react/src/components/AzMarkdownNative.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { Text, View, Linking, StyleSheet } from 'react-native';
+
+/**
+ * A tiny dependency-free Markdown renderer for the React Native About reader, themed to AzNavRail.
+ * Covers the common doc subset (headings, paragraphs, bold/italic, inline code, fenced code blocks,
+ * lists, block-quotes, horizontal rules, links). `accent` colors links and headings.
+ */
+const INLINE = /(`([^`]+)`)|(\*\*([^*]+)\*\*)|(__([^_]+)__)|(\*([^*]+)\*)|(_([^_]+)_)|(\[([^\]]+)\]\(([^)]+)\))/g;
+
+function renderInline(text: string, accent: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let k = 0;
+  INLINE.lastIndex = 0;
+  while ((m = INLINE.exec(text)) !== null) {
+    if (m.index > last) nodes.push(text.slice(last, m.index));
+    if (m[2]) nodes.push(<Text key={k} style={styles.code}>{m[2]}</Text>);
+    else if (m[4]) nodes.push(<Text key={k} style={styles.bold}>{m[4]}</Text>);
+    else if (m[6]) nodes.push(<Text key={k} style={styles.bold}>{m[6]}</Text>);
+    else if (m[8]) nodes.push(<Text key={k} style={styles.italic}>{m[8]}</Text>);
+    else if (m[10]) nodes.push(<Text key={k} style={styles.italic}>{m[10]}</Text>);
+    else if (m[12]) {
+      const url = m[13];
+      nodes.push(
+        <Text key={k} style={[styles.link, { color: accent }]} onPress={() => Linking.openURL(url).catch(() => {})}>
+          {m[12]}
+        </Text>
+      );
+    }
+    last = m.index + m[0].length;
+    k++;
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+export default function AzMarkdownNative({ markdown, accent }: { markdown: string; accent: string }) {
+  const lines = (markdown || '').replace(/\r\n/g, '\n').split('\n');
+  const blocks: React.ReactNode[] = [];
+  let para: string[] = [];
+  let i = 0;
+  let key = 0;
+
+  const flushPara = () => {
+    if (para.length) {
+      const text = para.join(' ').trim();
+      if (text) blocks.push(<Text key={key++} style={styles.p}>{renderInline(text, accent)}</Text>);
+      para = [];
+    }
+  };
+
+  while (i < lines.length) {
+    const line = lines[i].replace(/\s+$/, '');
+    if (line.trimStart().startsWith('```')) {
+      flushPara();
+      const code: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].trimStart().startsWith('```')) { code.push(lines[i]); i++; }
+      blocks.push(<View key={key++} style={styles.pre}><Text style={styles.preText}>{code.join('\n')}</Text></View>);
+    } else if (/^(---|\*\*\*|___)\s*$/.test(line.trim())) {
+      flushPara();
+      blocks.push(<View key={key++} style={[styles.hr, { backgroundColor: accent }]} />);
+    } else if (/^#{1,6} /.test(line)) {
+      flushPara();
+      const level = (line.match(/^#+/) as RegExpMatchArray)[0].length;
+      blocks.push(
+        <Text key={key++} style={[styles.heading, headingSize(level), level <= 2 ? { color: accent } : null]}>
+          {renderInline(line.replace(/^#+\s/, ''), accent)}
+        </Text>
+      );
+    } else if (line.trimStart().startsWith('>')) {
+      flushPara();
+      blocks.push(
+        <View key={key++} style={[styles.quote, { borderLeftColor: accent }]}>
+          <Text style={styles.p}>{renderInline(line.trimStart().replace(/^>\s?/, ''), accent)}</Text>
+        </View>
+      );
+    } else if (/^\s*([-*+] |\d+\. )/.test(lines[i])) {
+      flushPara();
+      const ordered = /^\s*\d+\. /.test(lines[i]);
+      let n = 1;
+      while (i < lines.length && /^\s*([-*+] |\d+\. )/.test(lines[i])) {
+        const content = lines[i].trimStart().replace(/^([-*+] |\d+\. )/, '');
+        const marker = ordered ? `${n}. ` : '• ';
+        blocks.push(
+          <View key={key++} style={styles.li}>
+            <Text style={[styles.p, { color: accent }]}>{marker}</Text>
+            <Text style={[styles.p, styles.liText]}>{renderInline(content, accent)}</Text>
+          </View>
+        );
+        n++; i++;
+      }
+      i--;
+    } else if (line.trim() === '') {
+      flushPara();
+    } else {
+      para.push(line.trim());
+    }
+    i++;
+  }
+  flushPara();
+
+  return <View>{blocks}</View>;
+}
+
+function headingSize(level: number) {
+  switch (level) {
+    case 1: return { fontSize: 26 };
+    case 2: return { fontSize: 22 };
+    case 3: return { fontSize: 19 };
+    default: return { fontSize: 16 };
+  }
+}
+
+const styles = StyleSheet.create({
+  p: { fontSize: 15, lineHeight: 22, marginBottom: 8 },
+  bold: { fontWeight: 'bold' },
+  italic: { fontStyle: 'italic' },
+  link: { textDecorationLine: 'underline' },
+  code: { fontFamily: 'monospace', backgroundColor: 'rgba(127,127,127,0.15)' },
+  pre: { backgroundColor: 'rgba(127,127,127,0.12)', borderRadius: 8, padding: 12, marginBottom: 8 },
+  preText: { fontFamily: 'monospace', fontSize: 13 },
+  heading: { fontWeight: 'bold', marginTop: 12, marginBottom: 6 },
+  quote: { borderLeftWidth: 3, paddingLeft: 12, marginBottom: 8 },
+  hr: { height: 1, opacity: 0.4, marginVertical: 12 },
+  li: { flexDirection: 'row', marginBottom: 2, paddingLeft: 8 },
+  liText: { flex: 1 },
+});

--- a/aznavrail-react/src/components/MoreFromAzOverlay.tsx
+++ b/aznavrail-react/src/components/MoreFromAzOverlay.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Image, FlatList, TouchableOpacity, StyleSheet, Linking, BackHandler } from 'react-native';
+import { AzButton } from './AzButton';
+import { AzLoad } from './AzLoad';
+import { AzButtonShape } from '../types';
+import { fetchMoreFromAz, AzMoreFromApp } from '../services/moreFromAz';
+
+interface MoreFromAzOverlayProps {
+  jsonUrl: string;
+  settings?: { activeColor?: string; translucentBackground?: string };
+  onDismiss: () => void;
+}
+
+/**
+ * Full-screen "More from Az" overlay for React Native: a horizontal, paging carousel of app-icon
+ * cards with a detail pane below. Cards reuse the rail's transparent-shape-with-colored-stroke look;
+ * data comes from the link-only manifest (metadata auto-resolved).
+ */
+export const MoreFromAzOverlay: React.FC<MoreFromAzOverlayProps> = ({ jsonUrl, settings = {}, onDismiss }) => {
+  const accent = settings.activeColor || '#6200ee';
+  const surface = settings.translucentBackground || '#ffffff';
+  const [apps, setApps] = useState<AzMoreFromApp[] | null>(null);
+  const [selected, setSelected] = useState(0);
+
+  useEffect(() => {
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => { onDismiss(); return true; });
+    return () => sub.remove();
+  }, [onDismiss]);
+
+  useEffect(() => {
+    let active = true;
+    fetchMoreFromAz(jsonUrl).then((r) => active && setApps(r?.apps ?? []));
+    return () => { active = false; };
+  }, [jsonUrl]);
+
+  const current = apps && apps.length ? apps[Math.min(selected, apps.length - 1)] : null;
+  const open = (url?: string) => url && Linking.openURL(url).catch(() => {});
+
+  return (
+    <View style={[styles.overlay, { backgroundColor: surface }]}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onDismiss} accessibilityLabel="Back"><Text style={[styles.icon, { color: accent }]}>←</Text></TouchableOpacity>
+        <Text style={[styles.title, { color: accent }]}>More from Az</Text>
+      </View>
+
+      {apps === null && <AzLoad />}
+      {apps && apps.length === 0 && <Text style={styles.empty}>Couldn't load apps right now.</Text>}
+
+      {current && (
+        <View style={styles.flex}>
+          <FlatList
+            data={apps!}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            keyExtractor={(a, i) => a.githubUrl || a.playStoreUrl || a.webUrl || String(i)}
+            contentContainerStyle={styles.carousel}
+            renderItem={({ item, index }) => (
+              <TouchableOpacity
+                style={[styles.card, { borderColor: index === selected ? accent : `${accent}66`, borderWidth: index === selected ? 3 : 1 }]}
+                onPress={() => setSelected(index)}
+              >
+                {item.iconUrl ? (
+                  <Image source={{ uri: item.iconUrl }} style={styles.cardImg} resizeMode="cover" />
+                ) : (
+                  <Text style={{ color: accent, fontSize: 28 }}>{item.name.slice(0, 2).toUpperCase()}</Text>
+                )}
+              </TouchableOpacity>
+            )}
+          />
+
+          <View style={styles.detail}>
+            <Text style={styles.name}>{current.name}</Text>
+            {!!current.description && <Text style={styles.desc}>{current.description}</Text>}
+            <View style={styles.actions}>
+              {current.webUrl ? <AzButton text="Open" color={accent} shape={AzButtonShape.RECTANGLE} onClick={() => open(current.webUrl)} /> : null}
+              {current.playStoreUrl ? <AzButton text="Play Store" color={accent} shape={AzButtonShape.RECTANGLE} onClick={() => open(current.playStoreUrl)} /> : null}
+              {current.githubUrl ? <AzButton text="GitHub" color={accent} shape={AzButtonShape.RECTANGLE} onClick={() => open(current.githubUrl)} /> : null}
+            </View>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: { ...StyleSheet.absoluteFillObject, zIndex: 3100, paddingTop: '6%', paddingBottom: '10%', paddingHorizontal: 20 },
+  flex: { flex: 1 },
+  header: { flexDirection: 'row', alignItems: 'center', marginBottom: 16 },
+  title: { fontSize: 30, fontWeight: 'bold', marginLeft: 8 },
+  icon: { fontSize: 22, paddingHorizontal: 6 },
+  carousel: { gap: 12, paddingVertical: 4 },
+  card: { width: 132, height: 132, borderRadius: 20, overflow: 'hidden', alignItems: 'center', justifyContent: 'center' },
+  cardImg: { width: '100%', height: '100%' },
+  detail: { marginTop: 20 },
+  name: { fontSize: 22, fontWeight: 'bold' },
+  desc: { marginTop: 6, opacity: 0.85, fontSize: 15 },
+  actions: { flexDirection: 'row', gap: 12, marginTop: 16 },
+  empty: { opacity: 0.7, paddingVertical: 16 },
+});

--- a/aznavrail-react/src/index.tsx
+++ b/aznavrail-react/src/index.tsx
@@ -13,7 +13,11 @@ export * from './components/AzDivider';
 export * from './components/AzBottomSheet';
 export * from './components/AzBottomSheetInsetAware';
 export * from './components/AzFloatingRail';
+export * from './components/AboutOverlay';
+export * from './components/MoreFromAzOverlay';
 export * from './components/useAzSheetController';
+export * from './services/githubDocs';
+export * from './services/moreFromAz';
 export * from './types';
 // `AzToggleProps` / `AzCyclerProps` are declared both as the DSL prop types in `./types` and as the
 // component prop types in the component files above, so the two `export *` statements collide.

--- a/aznavrail-react/src/services/azCache.ts
+++ b/aznavrail-react/src/services/azCache.ts
@@ -1,0 +1,82 @@
+/**
+ * Tiny GET-with-cache helper shared by the About reader and the "More from Az" carousel, mirroring
+ * the Android `AzHttpCache`. Mitigates GitHub's unauthenticated rate limit via a TTL short-circuit,
+ * `ETag`/`If-None-Match` conditional requests, and graceful fallback to the last cached body.
+ *
+ * Storage is `localStorage` on the web; it falls back to an in-memory map when unavailable (e.g.
+ * React Native without a DOM), so callers never need to special-case the platform.
+ */
+interface CacheEntry {
+  body: string;
+  etag?: string;
+  ts: number;
+}
+
+export interface CachedResult {
+  body: string;
+  fromCache: boolean;
+  rateLimited: boolean;
+}
+
+const DEFAULT_TTL_MS = 6 * 60 * 60 * 1000; // 6h
+const PREFIX = 'aznavrail_about:';
+const memory = new Map<string, CacheEntry>();
+
+function readEntry(url: string): CacheEntry | undefined {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const raw = localStorage.getItem(PREFIX + url);
+      return raw ? (JSON.parse(raw) as CacheEntry) : undefined;
+    }
+  } catch {
+    /* fall through to memory */
+  }
+  return memory.get(url);
+}
+
+function writeEntry(url: string, entry: CacheEntry): void {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(PREFIX + url, JSON.stringify(entry));
+      return;
+    }
+  } catch {
+    /* fall through to memory */
+  }
+  memory.set(url, entry);
+}
+
+/**
+ * Fetches [url] honoring the cache. Returns null only on a true cold failure (no network response
+ * AND no cached body), or a 404 with no cache (so callers can treat e.g. a missing docs/ folder as
+ * empty rather than an error).
+ */
+export async function cachedGet(url: string, ttlMs = DEFAULT_TTL_MS): Promise<CachedResult | null> {
+  const cached = readEntry(url);
+  if (cached && Date.now() - cached.ts < ttlMs) {
+    return { body: cached.body, fromCache: true, rateLimited: false };
+  }
+
+  try {
+    const headers: Record<string, string> = { Accept: 'application/vnd.github+json' };
+    if (cached?.etag) headers['If-None-Match'] = cached.etag;
+    const res = await fetch(url, { headers });
+
+    if (res.status === 304 && cached) {
+      writeEntry(url, { ...cached, ts: Date.now() });
+      return { body: cached.body, fromCache: true, rateLimited: false };
+    }
+    if (res.ok) {
+      const body = await res.text();
+      writeEntry(url, { body, etag: res.headers.get('ETag') ?? undefined, ts: Date.now() });
+      return { body, fromCache: false, rateLimited: false };
+    }
+    if (res.status === 404 && !cached) return null;
+
+    const remaining = Number(res.headers.get('X-RateLimit-Remaining'));
+    const limited = res.status === 403 || res.status === 429 || remaining === 0;
+    return cached ? { body: cached.body, fromCache: true, rateLimited: limited } : null;
+  } catch {
+    return cached ? { body: cached.body, fromCache: true, rateLimited: false } : null;
+  }
+}

--- a/aznavrail-react/src/services/githubDocs.ts
+++ b/aznavrail-react/src/services/githubDocs.ts
@@ -1,0 +1,85 @@
+import { cachedGet } from './azCache';
+
+/** One entry in the auto-generated About table of contents. */
+export interface AzDocEntry {
+  title: string;
+  path: string;
+  downloadUrl: string;
+}
+
+const REPO_REGEX = /github\.com[/:]([^/]+)\/([^/?#]+)/;
+
+/** Extracts `[owner, repo]` from a GitHub URL, stripping a trailing `.git`. Null if not GitHub. */
+export function parseRepo(repoUrl: string): [string, string] | null {
+  const m = REPO_REGEX.exec(repoUrl);
+  if (!m) return null;
+  const owner = m[1];
+  const repo = m[2].replace(/\.git$/, '');
+  if (!owner || !repo) return null;
+  return [owner, repo];
+}
+
+/** Turns `MIGRATION_GUIDE.md` into "Migration Guide". */
+export function humanize(fileName: string): string {
+  return fileName
+    .replace(/\.md$/i, '')
+    .replace(/[-_]/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/** Parses a GitHub contents-API JSON array into the `.md` entries it contains. */
+export function parseContents(json: string): AzDocEntry[] {
+  const arr = JSON.parse(json);
+  if (!Array.isArray(arr)) return [];
+  return arr
+    .filter((o) => o && o.type === 'file' && typeof o.name === 'string' && /\.md$/i.test(o.name) && o.download_url)
+    .map((o) => ({ title: humanize(o.name), path: o.path ?? o.name, downloadUrl: o.download_url }));
+}
+
+/** Orders the TOC: README first, then other root docs, then docs/ — each group alphabetised. */
+export function orderToc(root: AzDocEntry[], docs: AzDocEntry[]): AzDocEntry[] {
+  const isReadme = (e: AzDocEntry) => e.path.split('/').pop()!.toUpperCase().startsWith('README');
+  const readme = root.filter(isReadme);
+  const otherRoot = root.filter((e) => !isReadme(e)).sort((a, b) => a.title.localeCompare(b.title));
+  const docsSorted = [...docs].sort((a, b) => a.title.localeCompare(b.title));
+  return [...readme, ...otherRoot, ...docsSorted];
+}
+
+export interface DocsResult {
+  entries: AzDocEntry[];
+  offline: boolean;
+}
+
+/** Lists the repo's root + docs/ markdown files. Empty TOC is a valid (not error) result. */
+export async function listDocs(repoUrl: string): Promise<DocsResult> {
+  const parsed = parseRepo(repoUrl);
+  if (!parsed) throw new Error(`Not a GitHub repo URL: ${repoUrl}`);
+  const [owner, repo] = parsed;
+
+  const rootRes = await cachedGet(`https://api.github.com/repos/${owner}/${repo}/contents/`);
+  const docsRes = await cachedGet(`https://api.github.com/repos/${owner}/${repo}/contents/docs`);
+
+  if (!rootRes && !docsRes) throw new Error(`Could not reach ${repoUrl}`);
+
+  const root = rootRes ? safeParse(rootRes.body) : [];
+  const docs = docsRes ? safeParse(docsRes.body) : [];
+  const offline = Boolean(rootRes?.rateLimited || docsRes?.rateLimited);
+  return { entries: orderToc(root, docs), offline };
+}
+
+function safeParse(body: string): AzDocEntry[] {
+  try {
+    return parseContents(body);
+  } catch {
+    return [];
+  }
+}
+
+/** Fetches the raw markdown for a single TOC entry (cached). */
+export async function fetchDoc(entry: AzDocEntry): Promise<string | null> {
+  const res = await cachedGet(entry.downloadUrl);
+  return res?.body ?? null;
+}

--- a/aznavrail-react/src/services/moreFromAz.ts
+++ b/aznavrail-react/src/services/moreFromAz.ts
@@ -1,0 +1,132 @@
+import { cachedGet } from './azCache';
+import { parseRepo } from './githubDocs';
+
+/** A raw link-only manifest entry. */
+export interface AzMoreFromLink {
+  github?: string;
+  play?: string;
+  web?: string;
+}
+
+/** A fully-resolved app for the carousel (metadata auto-populated from the link). */
+export interface AzMoreFromApp {
+  name: string;
+  iconUrl: string;
+  description: string;
+  githubUrl?: string;
+  playStoreUrl?: string;
+  webUrl?: string;
+}
+
+/** Parses the manifest into `[version, links]`. */
+export function parseLinks(json: string): [number, AzMoreFromLink[]] {
+  const obj = JSON.parse(json);
+  const version = typeof obj.version === 'number' ? obj.version : 0;
+  const apps: AzMoreFromLink[] = Array.isArray(obj.apps)
+    ? obj.apps
+        .map((a: any) => ({ github: a?.github || undefined, play: a?.play || undefined, web: a?.web || undefined }))
+        .filter((a: AzMoreFromLink) => a.github || a.play || a.web)
+    : [];
+  return [version, apps];
+}
+
+/** Extracts an OpenGraph `content` value, tolerant of attribute order. */
+export function extractOg(html: string, property: string): string | undefined {
+  const a = new RegExp(`<meta[^>]+property=["']og:${property}["'][^>]+content=["']([^"']*)["']`, 'i');
+  const b = new RegExp(`<meta[^>]+content=["']([^"']*)["'][^>]+property=["']og:${property}["']`, 'i');
+  const raw = a.exec(html)?.[1] ?? b.exec(html)?.[1];
+  if (!raw) return undefined;
+  // Decode the handful of entities that appear in OG text.
+  const decoded = raw
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+  return decoded.trim() || undefined;
+}
+
+async function resolvePlay(link: AzMoreFromLink): Promise<AzMoreFromApp | null> {
+  if (!link.play) return null;
+  // NOTE: on the web this is subject to CORS (Play pages send no ACAO header) and will usually fail;
+  // GitHub resolution is used as the fallback. Native/Android has no such restriction.
+  const res = await cachedGet(link.play);
+  if (!res) return null;
+  const name = extractOg(res.body, 'title')?.replace(/ - Apps on Google Play$/, '').trim();
+  if (!name) return null;
+  return {
+    name,
+    iconUrl: extractOg(res.body, 'image') ?? '',
+    description: extractOg(res.body, 'description') ?? '',
+    githubUrl: link.github,
+    playStoreUrl: link.play,
+    webUrl: link.web,
+  };
+}
+
+async function resolveWeb(link: AzMoreFromLink): Promise<AzMoreFromApp | null> {
+  if (!link.web) return null;
+  // Subject to CORS on the web build (most sites send no ACAO); resolves natively / when the target
+  // sends permissive headers. GitHub remains the fallback.
+  const res = await cachedGet(link.web);
+  if (!res) return null;
+  const name = extractOg(res.body, 'title')?.trim();
+  if (!name) return null;
+  return {
+    name,
+    iconUrl: extractOg(res.body, 'image') ?? '',
+    description: extractOg(res.body, 'description') ?? '',
+    githubUrl: link.github,
+    playStoreUrl: link.play,
+    webUrl: link.web,
+  };
+}
+
+async function resolveGithub(link: AzMoreFromLink): Promise<AzMoreFromApp | null> {
+  if (!link.github) return null;
+  const parsed = parseRepo(link.github);
+  if (!parsed) return null;
+  const [owner, repo] = parsed;
+  const res = await cachedGet(`https://api.github.com/repos/${owner}/${repo}`);
+  if (!res) return null;
+  try {
+    const o = JSON.parse(res.body);
+    return {
+      name: o.name ?? repo,
+      iconUrl: o.owner?.avatar_url ?? '',
+      description: o.description ?? '',
+      githubUrl: link.github,
+      playStoreUrl: link.play,
+      webUrl: link.web,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Resolves one link into an app (richest metadata first: Play, then web/PWA, then GitHub). */
+export async function resolve(link: AzMoreFromLink): Promise<AzMoreFromApp | null> {
+  return (
+    (link.play ? await resolvePlay(link) : null) ??
+    (link.web ? await resolveWeb(link) : null) ??
+    (await resolveGithub(link))
+  );
+}
+
+export interface MoreFromResult {
+  version: number;
+  apps: AzMoreFromApp[];
+}
+
+/** Fetches the manifest and resolves every link into a displayable app (failures dropped). */
+export async function fetchMoreFromAz(jsonUrl: string): Promise<MoreFromResult | null> {
+  const res = await cachedGet(jsonUrl);
+  if (!res) return null;
+  try {
+    const [version, links] = parseLinks(res.body);
+    const resolved = await Promise.all(links.map(resolve));
+    return { version, apps: resolved.filter((a): a is AzMoreFromApp => a !== null) };
+  } catch {
+    return null;
+  }
+}

--- a/aznavrail-react/src/types.ts
+++ b/aznavrail-react/src/types.ts
@@ -121,8 +121,19 @@ export interface AzNavRailSettings {
   secLoc?: string;
   /** Port for the secret-location server (developer feature). */
   secLocPort?: number;
-  /** URL of the app's source repository, shown in the footer. */
+  /** URL of the app's source repository, shown in the footer and used by the in-app About reader. */
   appRepositoryUrl?: string;
+  /**
+   * When true (default), the footer "About" opens the in-app markdown reader (auto-generated from
+   * the repo's docs) instead of opening {@link appRepositoryUrl} in a browser.
+   */
+  inAppAbout?: boolean;
+  /** When true (default), the About screen offers a "More from Az" carousel of the author's apps. */
+  moreFromAzEnabled?: boolean;
+  /** Raw URL of the CI-versioned `more-from-az.json` manifest backing the carousel. */
+  moreFromAzJsonUrl?: string;
+  /** When true, pins a "More" item at the bottom of the rail that opens the "More from Az" carousel. */
+  moreRailItem?: boolean;
   /** Whether the help overlay feature is enabled. */
   helpEnabled?: boolean;
   /** When true, docking side follows the physical device edge rather than logical left/right. */

--- a/aznavrail-react/src/web/AboutOverlay.css
+++ b/aznavrail-react/src/web/AboutOverlay.css
@@ -1,0 +1,121 @@
+/* In-app About reader + More-from-Az overlay (web), themed to match the rail. */
+.az-about-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 20px calc(10% ) 20px;
+  padding-top: max(12px, 5%);
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.az-about-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.az-about-title {
+  flex: 1;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.az-about-iconbtn {
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  cursor: pointer;
+  padding: 4px 8px;
+  font: inherit;
+}
+
+.az-about-body,
+.az-about-reader {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  margin-top: 12px;
+}
+
+.az-about-toc {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.az-about-tocrow {
+  text-align: left;
+  background: transparent;
+  border: 1px solid;
+  border-radius: 12px;
+  padding: 14px 16px;
+  font-size: 1.1rem;
+  cursor: pointer;
+  font: inherit;
+  opacity: 0.85;
+}
+.az-about-tocrow:hover { opacity: 1; }
+.az-about-tocrow.emphasized { border-width: 2px; font-weight: 700; opacity: 1; }
+
+.az-about-spacer { height: 32px; }
+.az-about-divider { width: 100%; opacity: 0.3; margin: 16px 0; }
+
+.az-about-repo {
+  display: inline-block;
+  text-align: center;
+  border: 2px solid;
+  border-radius: 12px;
+  padding: 12px 20px;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.az-about-banner,
+.az-about-loading,
+.az-about-empty {
+  opacity: 0.7;
+  padding: 12px 0;
+}
+
+/* Markdown */
+.az-markdown { line-height: 1.55; }
+.az-markdown .az-md-h { margin: 0.8em 0 0.4em; font-weight: 700; }
+.az-markdown .az-md-p { margin: 0 0 0.7em; }
+.az-markdown .az-md-list { margin: 0 0 0.7em 1.2em; }
+.az-markdown .az-md-code { font-family: monospace; padding: 0 4px; border-radius: 4px; background: rgba(127,127,127,0.15); }
+.az-markdown .az-md-pre { background: rgba(127,127,127,0.12); border-radius: 8px; padding: 12px; overflow-x: auto; }
+.az-markdown .az-md-quote { border-left: 3px solid; margin: 0 0 0.7em; padding-left: 12px; opacity: 0.85; }
+.az-markdown .az-md-hr { border: none; border-top: 1px solid; opacity: 0.4; margin: 1em 0; }
+
+/* More from Az */
+.az-more-body { display: flex; flex-direction: column; margin-top: 12px; }
+.az-more-carousel {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  padding: 4px;
+}
+.az-more-card {
+  flex: 0 0 132px;
+  height: 132px;
+  border: 1px solid;
+  border-radius: 20px;
+  background: transparent;
+  cursor: pointer;
+  scroll-snap-align: center;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+.az-more-card.focused { border-width: 3px; }
+.az-more-card img { width: 100%; height: 100%; object-fit: cover; }
+.az-more-name { font-size: 1.3rem; font-weight: 700; }
+.az-more-desc { margin-top: 6px; opacity: 0.85; }
+.az-more-actions { display: flex; gap: 12px; margin-top: 16px; }

--- a/aznavrail-react/src/web/AboutOverlay.jsx
+++ b/aznavrail-react/src/web/AboutOverlay.jsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import './AboutOverlay.css';
+import AzMarkdownWeb from './AzMarkdownWeb';
+import MoreFromAzOverlay from './MoreFromAzOverlay';
+import { listDocs, fetchDoc } from '../services/githubDocs';
+
+/**
+ * Full-screen in-app About reader for the web. Auto-discovers the repo's markdown docs
+ * (root + docs/), lists them as a themed table of contents, and renders the selected doc inline.
+ * A "View on GitHub" button sits pinned at the bottom with extra spacing; an optional "More from Az"
+ * entry opens the author's other-apps carousel. Themed from `settings.activeColor` /
+ * `settings.translucentBackground` to match the rail.
+ */
+export default function AboutOverlay({ repoUrl, settings = {}, moreFromAzEnabled, moreFromAzJsonUrl, onDismiss }) {
+  const accent = settings.activeColor || '#6200ee';
+  const surface = settings.translucentBackground || '#ffffff';
+
+  const [state, setState] = useState({ status: 'loading', entries: [], offline: false });
+  const [selected, setSelected] = useState(null);
+  const [docBody, setDocBody] = useState(null);
+  const [showMore, setShowMore] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    listDocs(repoUrl)
+      .then((r) => active && setState({ status: 'loaded', entries: r.entries, offline: r.offline }))
+      .catch(() => active && setState({ status: 'error', entries: [], offline: false }));
+    return () => { active = false; };
+  }, [repoUrl]);
+
+  useEffect(() => {
+    if (!selected) { setDocBody(null); return; }
+    let active = true;
+    setDocBody(null);
+    fetchDoc(selected).then((b) => active && setDocBody(b ?? '_Could not load this document._'));
+    return () => { active = false; };
+  }, [selected]);
+
+  return (
+    <div className="az-about-overlay" style={{ background: surface }}>
+      <div className="az-about-header">
+        {selected && (
+          <button className="az-about-iconbtn" style={{ color: accent }} onClick={() => setSelected(null)} aria-label="Back to contents">←</button>
+        )}
+        <span className="az-about-title" style={{ color: accent }}>{selected ? selected.title : 'About'}</span>
+        <button className="az-about-iconbtn" style={{ color: accent }} onClick={onDismiss} aria-label="Close">✕</button>
+      </div>
+
+      {selected ? (
+        <div className="az-about-reader">
+          {docBody === null ? <div className="az-about-loading">Loading…</div> : <AzMarkdownWeb markdown={docBody} accent={accent} />}
+        </div>
+      ) : (
+        <div className="az-about-body">
+          {state.status === 'loading' && <div className="az-about-loading">Loading…</div>}
+          {state.status === 'error' && <div className="az-about-empty">Couldn't load documentation.</div>}
+          {state.status === 'loaded' && (
+            <>
+              {state.offline && <div className="az-about-banner">Showing cached docs (offline or rate-limited).</div>}
+              {state.entries.length === 0 ? (
+                <div className="az-about-empty">No documentation found in this repository.</div>
+              ) : (
+                <div className="az-about-toc">
+                  {state.entries.map((e) => (
+                    <button key={e.path} className="az-about-tocrow" style={{ borderColor: accent, color: accent }} onClick={() => setSelected(e)}>
+                      {e.title}
+                    </button>
+                  ))}
+                  {moreFromAzEnabled && (
+                    <button className="az-about-tocrow emphasized" style={{ borderColor: accent, color: accent }} onClick={() => setShowMore(true)}>
+                      More from Az
+                    </button>
+                  )}
+                </div>
+              )}
+              <div className="az-about-spacer" />
+              <hr className="az-about-divider" />
+              <a className="az-about-repo" href={repoUrl} target="_blank" rel="noreferrer" style={{ borderColor: accent, color: accent }}>
+                View on GitHub
+              </a>
+            </>
+          )}
+        </div>
+      )}
+
+      {showMore && (
+        <MoreFromAzOverlay jsonUrl={moreFromAzJsonUrl} settings={settings} onDismiss={() => setShowMore(false)} />
+      )}
+    </div>
+  );
+}

--- a/aznavrail-react/src/web/AzMarkdownWeb.jsx
+++ b/aznavrail-react/src/web/AzMarkdownWeb.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+/**
+ * A tiny dependency-free Markdown renderer for the web About reader, themed to AzNavRail.
+ * Covers the common doc subset: ATX headings, paragraphs, bold/italic, inline code, fenced code
+ * blocks, lists, block-quotes, horizontal rules, and links. `accent` colors links and accents.
+ */
+const INLINE = /(`([^`]+)`)|(\*\*([^*]+)\*\*)|(__([^_]+)__)|(\*([^*]+)\*)|(_([^_]+)_)|(\[([^\]]+)\]\(([^)]+)\))/g;
+
+function renderInline(text, accent, keyPrefix) {
+  const nodes = [];
+  let last = 0;
+  let m;
+  let k = 0;
+  INLINE.lastIndex = 0;
+  while ((m = INLINE.exec(text)) !== null) {
+    if (m.index > last) nodes.push(text.slice(last, m.index));
+    if (m[2]) nodes.push(<code key={`${keyPrefix}-${k}`} className="az-md-code">{m[2]}</code>);
+    else if (m[4]) nodes.push(<strong key={`${keyPrefix}-${k}`}>{m[4]}</strong>);
+    else if (m[6]) nodes.push(<strong key={`${keyPrefix}-${k}`}>{m[6]}</strong>);
+    else if (m[8]) nodes.push(<em key={`${keyPrefix}-${k}`}>{m[8]}</em>);
+    else if (m[10]) nodes.push(<em key={`${keyPrefix}-${k}`}>{m[10]}</em>);
+    else if (m[12]) nodes.push(
+      <a key={`${keyPrefix}-${k}`} href={m[13]} target="_blank" rel="noreferrer" style={{ color: accent }}>{m[12]}</a>
+    );
+    last = m.index + m[0].length;
+    k++;
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+export default function AzMarkdownWeb({ markdown, accent }) {
+  const lines = (markdown || '').replace(/\r\n/g, '\n').split('\n');
+  const blocks = [];
+  let para = [];
+  let i = 0;
+  let key = 0;
+
+  const flushPara = () => {
+    if (para.length) {
+      const text = para.join(' ').trim();
+      if (text) blocks.push(<p key={key++} className="az-md-p">{renderInline(text, accent, `p${key}`)}</p>);
+      para = [];
+    }
+  };
+
+  while (i < lines.length) {
+    const raw = lines[i];
+    const line = raw.replace(/\s+$/, '');
+    if (line.trimStart().startsWith('```')) {
+      flushPara();
+      const code = [];
+      i++;
+      while (i < lines.length && !lines[i].trimStart().startsWith('```')) { code.push(lines[i]); i++; }
+      blocks.push(<pre key={key++} className="az-md-pre"><code>{code.join('\n')}</code></pre>);
+    } else if (/^(---|\*\*\*|___)\s*$/.test(line.trim())) {
+      flushPara();
+      blocks.push(<hr key={key++} className="az-md-hr" style={{ borderColor: accent }} />);
+    } else if (/^#{1,6} /.test(line)) {
+      flushPara();
+      const level = line.match(/^#+/)[0].length;
+      const Tag = `h${Math.min(level, 6)}`;
+      const color = level <= 2 ? accent : undefined;
+      blocks.push(<Tag key={key++} className="az-md-h" style={{ color }}>{renderInline(line.replace(/^#+\s/, ''), accent, `h${key}`)}</Tag>);
+    } else if (line.trimStart().startsWith('>')) {
+      flushPara();
+      blocks.push(
+        <blockquote key={key++} className="az-md-quote" style={{ borderLeftColor: accent }}>
+          {renderInline(line.trimStart().replace(/^>\s?/, ''), accent, `q${key}`)}
+        </blockquote>
+      );
+    } else if (/^\s*([-*+] |\d+\. )/.test(raw)) {
+      flushPara();
+      const items = [];
+      const ordered = /^\s*\d+\. /.test(raw);
+      while (i < lines.length && /^\s*([-*+] |\d+\. )/.test(lines[i])) {
+        const content = lines[i].trimStart().replace(/^([-*+] |\d+\. )/, '');
+        items.push(<li key={items.length}>{renderInline(content, accent, `li${key}-${items.length}`)}</li>);
+        i++;
+      }
+      i--;
+      blocks.push(ordered ? <ol key={key++} className="az-md-list">{items}</ol> : <ul key={key++} className="az-md-list">{items}</ul>);
+    } else if (line.trim() === '') {
+      flushPara();
+    } else {
+      para.push(line.trim());
+    }
+    i++;
+  }
+  flushPara();
+
+  return <div className="az-markdown">{blocks}</div>;
+}

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -7,6 +7,8 @@ import AzNestedRailPopup from './AzNestedRailPopup';
 import { RelocItemHandler } from '../util/RelocItemHandler';
 import AzDivider from './AzDivider';
 import AzTextBox from './AzTextBox';
+import AboutOverlay from './AboutOverlay';
+import MoreFromAzOverlay from './MoreFromAzOverlay';
 
 /**
  * An M3-style navigation rail that expands into a menu drawer for web applications.
@@ -41,7 +43,12 @@ const AzNavRail = ({
     activeColor,
     translucentBackground,
     packRailButtons = false,
-    headerIconShape = 'CIRCLE'
+    headerIconShape = 'CIRCLE',
+    inAppAbout = true,
+    moreFromAzEnabled = true,
+    moreFromAzJsonUrl = 'https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json',
+    moreRailItem = false,
+    appRepositoryUrl = 'https://github.com/HereLiesAz/AzNavRail'
   } = settings;
 
   // If noMenu is true, we force expanded to false, unless infoScreen overrides (which it doesn't really)
@@ -61,6 +68,9 @@ const AzNavRail = ({
   // Drop-down menu mode: a single boolean gates whether the chosen item set is unfolded under
   // the app-icon trigger (reusing the floating-rail fold/unfold idea).
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  // In-app About reader + More-from-Az overlays.
+  const [showAbout, setShowAbout] = useState(false);
+  const [showMoreFromAz, setShowMoreFromAz] = useState(false);
 
   const onToggle = () => {
       if (infoScreen) return;
@@ -613,6 +623,17 @@ const AzNavRail = ({
                     </div>
                   );
                 })}
+              {moreRailItem && moreFromAzEnabled && (
+                <div
+                  className="az-nav-rail-button rectangle"
+                  role="button"
+                  tabIndex={0}
+                  style={{ borderColor: activeColor || 'blue', color: activeColor || 'blue', cursor: 'pointer', marginTop: 8 }}
+                  onClick={() => setShowMoreFromAz(true)}
+                >
+                  More
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -621,7 +642,14 @@ const AzNavRail = ({
       {showFooter && isExpanded && (
         <div className="footer" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '16px', color: activeColor || 'currentColor' }}>
              <div className="az-menu-item-text" style={{ padding: '8px 0', fontWeight: 'bold' }}>{appName}</div>
-             <div className="az-menu-item-text" style={{ padding: '4px 0' }}>About</div>
+             <div
+               className="az-menu-item-text"
+               style={{ padding: '4px 0', cursor: 'pointer' }}
+               onClick={() => {
+                 if (inAppAbout) { setShowAbout(true); setIsExpanded(false); }
+                 else window.open(appRepositoryUrl, '_blank', 'noopener');
+               }}
+             >About</div>
              <div className="az-menu-item-text" style={{ padding: '4px 0' }}>Feedback</div>
              <div className="az-menu-item-text" style={{ padding: '4px 0', opacity: 0.5 }}>@HereLiesAz</div>
         </div>
@@ -655,6 +683,24 @@ const AzNavRail = ({
             onDismiss={onDismissInfoScreen}
             nestedRailVisibleId={nestedRailVisibleId}
             helpList={settings?.helpList || {}}
+        />
+    )}
+
+    {showAbout && (
+        <AboutOverlay
+            repoUrl={appRepositoryUrl}
+            settings={settings}
+            moreFromAzEnabled={moreFromAzEnabled}
+            moreFromAzJsonUrl={moreFromAzJsonUrl}
+            onDismiss={() => setShowAbout(false)}
+        />
+    )}
+
+    {showMoreFromAz && (
+        <MoreFromAzOverlay
+            jsonUrl={moreFromAzJsonUrl}
+            settings={settings}
+            onDismiss={() => setShowMoreFromAz(false)}
         />
     )}
 

--- a/aznavrail-react/src/web/MoreFromAzOverlay.jsx
+++ b/aznavrail-react/src/web/MoreFromAzOverlay.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import './AboutOverlay.css';
+import { fetchMoreFromAz } from '../services/moreFromAz';
+
+/**
+ * Full-screen "More from Az" overlay for the web: a horizontal scroll-snap carousel of app-icon
+ * cards with a detail pane below. Cards reuse the rail's transparent-shape-with-colored-stroke
+ * language. Data comes from the link-only `more-from-az.json` (metadata auto-resolved).
+ */
+export default function MoreFromAzOverlay({ jsonUrl, settings = {}, onDismiss }) {
+  const accent = settings.activeColor || '#6200ee';
+  const surface = settings.translucentBackground || '#ffffff';
+  const [apps, setApps] = useState(null);
+  const [selected, setSelected] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    fetchMoreFromAz(jsonUrl).then((r) => active && setApps(r?.apps ?? []));
+    return () => { active = false; };
+  }, [jsonUrl]);
+
+  const current = apps && apps.length ? apps[Math.min(selected, apps.length - 1)] : null;
+
+  return (
+    <div className="az-about-overlay" style={{ background: surface }}>
+      <div className="az-about-header">
+        <button className="az-about-iconbtn" style={{ color: accent }} onClick={onDismiss} aria-label="Back">←</button>
+        <span className="az-about-title" style={{ color: accent }}>More from Az</span>
+      </div>
+
+      {apps === null && <div className="az-about-loading">Loading…</div>}
+      {apps && apps.length === 0 && <div className="az-about-empty">Couldn't load apps right now.</div>}
+
+      {current && (
+        <div className="az-more-body">
+          <div className="az-more-carousel">
+            {apps.map((app, idx) => (
+              <button
+                key={app.githubUrl || app.playStoreUrl || app.name}
+                className={`az-more-card${idx === selected ? ' focused' : ''}`}
+                style={{ borderColor: idx === selected ? accent : `${accent}66` }}
+                onClick={() => setSelected(idx)}
+              >
+                {app.iconUrl ? <img src={app.iconUrl} alt={app.name} /> : <span style={{ color: accent }}>{app.name.slice(0, 2).toUpperCase()}</span>}
+              </button>
+            ))}
+          </div>
+
+          <hr className="az-about-divider" />
+          <div className="az-more-detail">
+            <div className="az-more-name">{current.name}</div>
+            {current.description && <div className="az-more-desc">{current.description}</div>}
+            <div className="az-more-actions">
+              {current.webUrl && (
+                <a className="az-about-repo" href={current.webUrl} target="_blank" rel="noreferrer" style={{ borderColor: accent, color: accent }}>Open</a>
+              )}
+              {current.playStoreUrl && (
+                <a className="az-about-repo" href={current.playStoreUrl} target="_blank" rel="noreferrer" style={{ borderColor: accent, color: accent }}>Play Store</a>
+              )}
+              {current.githubUrl && (
+                <a className="az-about-repo" href={current.githubUrl} target="_blank" rel="noreferrer" style={{ borderColor: accent, color: accent }}>GitHub</a>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/aznavrail/build.gradle.kts
+++ b/aznavrail/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     api(libs.coil.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.activity.compose)
 
 
     testImplementation(libs.junit)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -68,8 +69,10 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import coil.compose.rememberAsyncImagePainter
+import com.hereliesaz.aznavrail.internal.AboutOverlay
 import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
 import com.hereliesaz.aznavrail.internal.AzNavRailLogger
+import com.hereliesaz.aznavrail.internal.MoreFromAzOverlay
 import com.hereliesaz.aznavrail.internal.CyclerTransientState
 import com.hereliesaz.aznavrail.internal.Footer
 import com.hereliesaz.aznavrail.internal.HelpOverlay
@@ -233,6 +236,9 @@ fun AzNavRail(
     var showFloatingButtons by remember { mutableStateOf(false) }
     var railContentHeight by remember { mutableStateOf(0f) }
     var showHelpOverlay by remember { mutableStateOf(false) }
+    // About reader + "More from Az" carousel overlays (drawn over the live UI like the help overlay).
+    var showAboutOverlay by remember { mutableStateOf(false) }
+    var showMoreFromAz by remember { mutableStateOf(false) }
     // When the help item that triggered the overlay lives inside a nested rail, this holds the
     // parent item's id so the overlay shows only that nested rail's cards. Null = main rail scope.
     var helpScopeId by remember { mutableStateOf<String?>(null) }
@@ -921,6 +927,20 @@ fun AzNavRail(
                                 helpEnabled = showHelpOverlay,
                                 rotationDegrees = rotationDegrees
                             )
+
+                            // Optional pinned "More" rail item that opens the More-from-Az carousel.
+                            if (scope.advancedConfig.moreFromAzRailItem &&
+                                scope.advancedConfig.moreFromAzEnabled && !isFloating
+                            ) {
+                                val moreColor = scope.activeColor.takeOrElse { MaterialTheme.colorScheme.primary }
+                                AzButton(
+                                    onClick = { showMoreFromAz = true },
+                                    text = "More",
+                                    color = moreColor,
+                                    activeColor = moreColor,
+                                    shape = scope.defaultShape
+                                )
+                            }
                         }
                     }
                 }
@@ -940,7 +960,10 @@ fun AzNavRail(
                             },
                             onSecretClick = onSecretClick,
                             scope = scope,
-                            footerColor = scope.activeColor
+                            footerColor = scope.activeColor,
+                            onAboutClick = if (scope.advancedConfig.inAppAbout) {
+                                { isExpanded = false; showAboutOverlay = true }
+                            } else null
                         )
                     }
                 }
@@ -961,6 +984,27 @@ fun AzNavRail(
             nestedRailOpenId = helpScopeId,
             tutorials = scope.advancedConfig.tutorials,
             onTutorialLaunch = { toggleHelpOverlay(it) }
+        )
+    }
+
+    // In-app About reader overlay (auto-generated from the repo's markdown docs).
+    if (showAboutOverlay) {
+        AboutOverlay(
+            repoUrl = scope.appRepositoryUrl,
+            scope = scope,
+            onOpenMoreFromAz = if (scope.advancedConfig.moreFromAzEnabled) {
+                { showMoreFromAz = true }
+            } else null,
+            onDismiss = { showAboutOverlay = false }
+        )
+    }
+
+    // "More from Az" carousel overlay, drawn above the About reader.
+    if (showMoreFromAz) {
+        MoreFromAzOverlay(
+            jsonUrl = scope.advancedConfig.moreFromAzJsonUrl,
+            scope = scope,
+            onDismiss = { showMoreFromAz = false }
         )
     }
 

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -111,6 +111,27 @@ interface AzNavRailScope {
     fun azAdvanced(isLoading: Boolean = false, helpEnabled: Boolean = false, onDismissHelp: (() -> Unit)? = null, overlayService: Class<out android.app.Service>? = null, onUndock: (() -> Unit)? = null, enableRailDragging: Boolean = false, onRailDrag: ((Float, Float) -> Unit)? = null, onOverlayDrag: ((Float, Float) -> Unit)? = null, onItemGloballyPositioned: ((String, Rect) -> Unit)? = null, secLoc: String? = null, secLocPort: Int = 10203, helpList: Map<String, Any> = emptyMap(), tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial> = emptyMap(), onInteraction: ((String, com.hereliesaz.aznavrail.model.AzNavItem) -> Unit)? = null)
 
     /**
+     * Configures the built-in **About** screen and the **"More from Az"** carousel.
+     *
+     * When [inAppAbout] is true (the default), tapping the footer's "About" item opens an in-app,
+     * themed markdown reader that auto-discovers this app's documentation (`.md` files in the repo
+     * root and `docs/` folder of [azConfig]'s `appRepositoryUrl`), builds a table of contents, and
+     * renders each doc inline. A GitHub repo button sits pinned at the bottom. Set [inAppAbout] to
+     * false to restore the legacy behavior of opening the repository URL in a browser.
+     *
+     * When [moreFromAzEnabled] is true (the default), the About screen also offers a "More from Az"
+     * entry that opens a carousel of the library author's other apps, fetched at runtime from
+     * [moreFromAzJsonUrl] (a CI-versioned JSON manifest). Public GitHub repos only.
+     *
+     * @param inAppAbout Whether the footer "About" opens the in-app reader (true) or a browser (false).
+     * @param moreFromAzEnabled Whether the "More from Az" carousel entry is shown.
+     * @param moreFromAzJsonUrl Raw URL of the `more-from-az.json` manifest.
+     * @param moreRailItem When true, pins a "More" item at the bottom of the collapsed rail that
+     *   opens the "More from Az" carousel directly.
+     */
+    fun azAbout(inAppAbout: Boolean = true, moreFromAzEnabled: Boolean = true, moreFromAzJsonUrl: String = "https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json", moreRailItem: Boolean = false)
+
+    /**
      * A comprehensive configuration method combining settings, theme, and advanced options.
      * This mirrors the structure used in the `AZNAVRAIL_COMPLETE_GUIDE.md`.
      */
@@ -676,6 +697,15 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         this.appRepositoryUrl = appRepositoryUrl
         this.dropdownMenu = dropdownMenu
         this.dropdownSource = dropdownSource
+    }
+
+    override fun azAbout(inAppAbout: Boolean, moreFromAzEnabled: Boolean, moreFromAzJsonUrl: String, moreRailItem: Boolean) {
+        this.advancedConfig = this.advancedConfig.copy(
+            inAppAbout = inAppAbout,
+            moreFromAzEnabled = moreFromAzEnabled,
+            moreFromAzJsonUrl = moreFromAzJsonUrl,
+            moreFromAzRailItem = moreRailItem
+        )
     }
 
     override fun azTheme(activeColor: Color, defaultShape: AzButtonShape, headerIconShape: AzHeaderIconShape, translucentBackground: Color, helpLineColors: List<Color>, headerIconSize: Dp) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AboutOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AboutOverlay.kt
@@ -1,0 +1,244 @@
+package com.hereliesaz.aznavrail.internal
+
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.border
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.AzNavRailScopeImpl
+import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzDocEntry
+import com.hereliesaz.aznavrail.service.GithubDocsRepository
+import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.AzDivider
+import com.hereliesaz.aznavrail.AzLoad
+import com.hereliesaz.aznavrail.LocalAzSafeZones
+
+/** UI state for the About reader's table-of-contents fetch. */
+private sealed interface DocsUi {
+    data object Loading : DocsUi
+    data class Loaded(val entries: List<AzDocEntry>, val offline: Boolean) : DocsUi
+    data object Error : DocsUi
+}
+
+/**
+ * Full-screen, themed in-app About reader. Auto-discovers the consuming app's markdown docs (root +
+ * `docs/`) from [repoUrl], lists them as a table of contents, and renders the selected doc inline via
+ * [AzMarkdown]. A GitHub repo button sits at the bottom with extra spacing, and an optional
+ * "More from Az" entry opens the author's other-apps carousel.
+ *
+ * Built from the rail's own components ([AzButton], [AzLoad], [AzDivider]) and tokens
+ * ([AzNavRailScopeImpl.activeColor], [AzNavRailScopeImpl.translucentBackground]) so it matches the
+ * rail's aesthetic. Dismissed via the close button or the system back button.
+ */
+@Composable
+internal fun AboutOverlay(
+    repoUrl: String,
+    scope: AzNavRailScopeImpl,
+    onOpenMoreFromAz: (() -> Unit)?,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val accent = scope.activeColor.takeIf { it != Color.Unspecified } ?: MaterialTheme.colorScheme.primary
+    val surface = scope.translucentBackground.takeIf { it != Color.Unspecified } ?: MaterialTheme.colorScheme.surface
+    val safe = LocalAzSafeZones.current
+    var selected by remember { mutableStateOf<AzDocEntry?>(null) }
+
+    BackHandler(enabled = true) { if (selected != null) selected = null else onDismiss() }
+
+    val docs by produceState<DocsUi>(initialValue = DocsUi.Loading, repoUrl) {
+        value = GithubDocsRepository.listDocs(context, repoUrl).fold(
+            onSuccess = { DocsUi.Loaded(it.entries, it.rateLimitedOrOffline) },
+            onFailure = { DocsUi.Error },
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = safe.top, bottom = safe.bottom)
+                .padding(horizontal = 20.dp, vertical = 12.dp)
+        ) {
+            // Header: back (in reader) / title / close
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                if (selected != null) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back to contents",
+                        tint = accent,
+                        modifier = Modifier.clickable { selected = null }.padding(end = 12.dp)
+                    )
+                }
+                Text(
+                    text = selected?.title ?: "About",
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold,
+                    color = accent,
+                    modifier = Modifier.weight(1f)
+                )
+                Icon(
+                    Icons.Filled.Close,
+                    contentDescription = "Close",
+                    tint = accent,
+                    modifier = Modifier.clickable { onDismiss() }
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+
+            if (selected != null) {
+                Box(Modifier.weight(1f).fillMaxWidth()) {
+                    DocReader(entry = selected!!, accent = accent)
+                }
+            } else {
+                when (val state = docs) {
+                    is DocsUi.Loading -> Box(Modifier.fillMaxSize(), Alignment.Center) { AzLoad() }
+                    is DocsUi.Error -> ErrorState(accent) { /* retry via recomposition key bump not needed */ onDismiss() }
+                    is DocsUi.Loaded -> {
+                        if (state.entries.isEmpty()) {
+                            Box(Modifier.fillMaxSize().weight(1f), Alignment.Center) {
+                                Text(
+                                    "No documentation found in this repository.",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                                )
+                            }
+                        } else {
+                            if (state.offline) {
+                                Text(
+                                    "Showing cached docs (offline or rate-limited).",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                                )
+                                Spacer(Modifier.height(8.dp))
+                            }
+                            LazyColumn(
+                                modifier = Modifier.weight(1f).fillMaxWidth(),
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                items(state.entries, key = { it.path }) { entry ->
+                                    TocRow(entry.title, accent) { selected = entry }
+                                }
+                                if (onOpenMoreFromAz != null) {
+                                    item {
+                                        TocRow("More from Az", accent, emphasized = true) { onOpenMoreFromAz() }
+                                    }
+                                }
+                            }
+                        }
+                        // GitHub link pinned at the bottom with extra separation.
+                        Spacer(Modifier.height(32.dp))
+                        AzDivider()
+                        Spacer(Modifier.height(16.dp))
+                        AzButton(
+                            onClick = { openUrl(context, repoUrl) },
+                            text = "View on GitHub",
+                            color = accent,
+                            activeColor = accent,
+                            shape = AzButtonShape.RECTANGLE,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DocReader(entry: AzDocEntry, accent: Color) {
+    val context = LocalContext.current
+    val body by produceState<String?>(initialValue = null, entry.path) {
+        value = GithubDocsRepository.fetchDoc(context, entry).getOrNull() ?: "_Could not load this document._"
+    }
+    val current = body
+    if (current == null) {
+        Box(Modifier.fillMaxSize(), Alignment.Center) { AzLoad() }
+    } else {
+        Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+            AzMarkdown(markdown = current, activeColor = accent)
+        }
+    }
+}
+
+@Composable
+private fun TocRow(title: String, accent: Color, emphasized: Boolean = false, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = if (emphasized) 2.dp else 1.dp,
+                color = if (emphasized) accent else accent.copy(alpha = 0.5f),
+                shape = RoundedCornerShape(12.dp),
+            )
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            color = accent,
+            fontWeight = if (emphasized) FontWeight.Bold else FontWeight.Normal,
+        )
+    }
+}
+
+@Composable
+private fun ErrorState(accent: Color, onClose: () -> Unit) {
+    Box(Modifier.fillMaxSize(), Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                "Couldn't load documentation.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+            )
+            Spacer(Modifier.height(16.dp))
+            AzButton(onClick = onClose, text = "Close", color = accent, activeColor = accent, shape = AzButtonShape.RECTANGLE)
+        }
+    }
+}
+
+private fun openUrl(context: android.content.Context, url: String) {
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    } catch (_: Exception) {
+    }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzMarkdown.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzMarkdown.kt
@@ -1,0 +1,219 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.AzDivider
+
+/**
+ * A dependency-free Markdown renderer tuned to the AzNavRail aesthetic.
+ *
+ * It is intentionally lightweight (no third-party markdown library): it covers the common subset
+ * found in repo docs — ATX headings, paragraphs, bold/italic, inline code, fenced code blocks,
+ * unordered/ordered lists, block-quotes, horizontal rules, and links — and themes every element
+ * from [MaterialTheme] with [activeColor] used for links and accents, matching the rest of the rail.
+ */
+@Composable
+internal fun AzMarkdown(
+    markdown: String,
+    activeColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    val codeBg = if (activeColor != Color.Unspecified) {
+        activeColor.copy(alpha = 0.08f)
+    } else {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+    }
+    val accent = if (activeColor != Color.Unspecified) activeColor else MaterialTheme.colorScheme.primary
+
+    Column(modifier = modifier) {
+        val lines = markdown.replace("\r\n", "\n").split("\n")
+        var i = 0
+        val paragraph = StringBuilder()
+
+        @Composable
+        fun flushParagraph() {
+            if (paragraph.isNotBlank()) {
+                Text(
+                    text = parseInline(paragraph.toString().trim(), accent),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+            paragraph.setLength(0)
+        }
+
+        while (i < lines.size) {
+            val raw = lines[i]
+            val line = raw.trimEnd()
+            when {
+                // Fenced code block
+                line.trimStart().startsWith("```") -> {
+                    flushParagraph()
+                    val code = StringBuilder()
+                    i++
+                    while (i < lines.size && !lines[i].trimStart().startsWith("```")) {
+                        code.appendLine(lines[i]); i++
+                    }
+                    CodeBlock(code.toString().trimEnd(), codeBg)
+                    Spacer(Modifier.height(8.dp))
+                }
+                // Horizontal rule
+                line.trim().let { it == "---" || it == "***" || it == "___" } -> {
+                    flushParagraph()
+                    AzDivider()
+                    Spacer(Modifier.height(8.dp))
+                }
+                // ATX heading
+                Regex("^#{1,6} ").containsMatchIn(line) -> {
+                    flushParagraph()
+                    val level = line.takeWhile { it == '#' }.length
+                    val text = line.drop(level).trim()
+                    Text(
+                        text = parseInline(text, accent),
+                        style = headingStyleFor(level),
+                        color = if (level <= 2) accent else MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                }
+                // Block quote
+                line.trimStart().startsWith(">") -> {
+                    flushParagraph()
+                    val quote = line.trimStart().removePrefix(">").trim()
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        Box(
+                            Modifier
+                                .width(3.dp)
+                                .height(20.dp)
+                                .background(accent)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = parseInline(quote, accent),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                        )
+                    }
+                    Spacer(Modifier.height(6.dp))
+                }
+                // List item (unordered or ordered)
+                Regex("^\\s*([-*+] |\\d+\\. )").containsMatchIn(raw) -> {
+                    flushParagraph()
+                    val indent = raw.takeWhile { it == ' ' }.length
+                    val ordered = Regex("^\\s*\\d+\\. ").find(raw)
+                    val bullet = ordered?.value?.trim() ?: "•"
+                    val content = raw.trimStart().replaceFirst(Regex("^([-*+] |\\d+\\. )"), "")
+                    Row(modifier = Modifier.padding(start = (8 + indent * 4).dp)) {
+                        Text("$bullet ", style = MaterialTheme.typography.bodyLarge, color = accent)
+                        Text(
+                            text = parseInline(content, accent),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                    Spacer(Modifier.height(2.dp))
+                }
+                line.isBlank() -> flushParagraph()
+                else -> {
+                    if (paragraph.isNotEmpty()) paragraph.append(' ')
+                    paragraph.append(line.trim())
+                }
+            }
+            i++
+        }
+        flushParagraph()
+    }
+}
+
+@Composable
+private fun CodeBlock(code: String, background: Color) {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .background(background, RoundedCornerShape(8.dp))
+            .horizontalScroll(rememberScrollState())
+            .padding(PaddingValues(12.dp))
+    ) {
+        Text(
+            text = code,
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun headingStyleFor(level: Int) = when (level) {
+    1 -> MaterialTheme.typography.headlineMedium
+    2 -> MaterialTheme.typography.headlineSmall
+    3 -> MaterialTheme.typography.titleLarge
+    4 -> MaterialTheme.typography.titleMedium
+    else -> MaterialTheme.typography.titleSmall
+}
+
+private val INLINE = Regex(
+    "`([^`]+)`" +                       // 1: code
+        "|\\*\\*([^*]+)\\*\\*" +        // 2: bold
+        "|__([^_]+)__" +                // 3: bold
+        "|\\*([^*]+)\\*" +              // 4: italic
+        "|_([^_]+)_" +                  // 5: italic
+        "|\\[([^\\]]+)\\]\\(([^)]+)\\)" // 6: link text, 7: url
+)
+
+/** Parses inline markdown (code, bold, italic, links) into a themed [AnnotatedString]. */
+internal fun parseInline(text: String, accent: Color): AnnotatedString = buildAnnotatedString {
+    var last = 0
+    for (m in INLINE.findAll(text)) {
+        if (m.range.first > last) append(text.substring(last, m.range.first))
+        val g = m.groupValues
+        when {
+            g[1].isNotEmpty() -> withStyle(SpanStyle(fontFamily = FontFamily.Monospace, color = accent)) { append(g[1]) }
+            g[2].isNotEmpty() -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(g[2]) }
+            g[3].isNotEmpty() -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(g[3]) }
+            g[4].isNotEmpty() -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(g[4]) }
+            g[5].isNotEmpty() -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(g[5]) }
+            g[6].isNotEmpty() -> withLink(
+                LinkAnnotation.Url(
+                    g[7],
+                    TextLinkStyles(SpanStyle(color = accent, textDecoration = TextDecoration.Underline)),
+                )
+            ) { append(g[6]) }
+        }
+        last = m.range.last + 1
+    }
+    if (last < text.length) append(text.substring(last))
+}
+
+/** [buildAnnotatedString] helper mirroring the stdlib's `withStyle` to keep call sites terse. */
+private inline fun AnnotatedString.Builder.withStyle(style: SpanStyle, block: AnnotatedString.Builder.() -> Unit) {
+    val idx = pushStyle(style)
+    try { block() } finally { pop(idx) }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
@@ -36,6 +36,8 @@ import com.hereliesaz.aznavrail.AzNavRailScopeImpl
  * @param onSecretClick Callback that opens the Secret Screens dialog; null when [com.hereliesaz.aznavrail.model.AzAdvancedConfig.secLoc] is unset.
  * @param scope The active rail scope used to read dragging/undock flags and the repository URL.
  * @param footerColor Tint color applied to all footer text items.
+ * @param onAboutClick When non-null, the "About" item invokes this (to open the in-app About reader)
+ *   instead of opening the repository URL in a browser. Null restores the legacy browser behavior.
  */
 @Composable
 internal fun Footer(
@@ -44,7 +46,8 @@ internal fun Footer(
     onUndock: () -> Unit,
     onSecretClick: (() -> Unit)?,
     scope: AzNavRailScopeImpl,
-    footerColor: Color
+    footerColor: Color,
+    onAboutClick: (() -> Unit)? = null
 ) {
     val context = LocalContext.current
 
@@ -71,7 +74,11 @@ internal fun Footer(
             style = MaterialTheme.typography.titleLarge.copy(color = footerColor),
             modifier = Modifier
                 .clickable {
-                    try { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(scope.appRepositoryUrl))) } catch (e: Exception) {}
+                    if (onAboutClick != null) {
+                        onAboutClick()
+                    } else {
+                        try { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(scope.appRepositoryUrl))) } catch (e: Exception) {}
+                    }
                 }
                 .padding(vertical = 4.dp)
         )

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MoreFromAzOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MoreFromAzOverlay.kt
@@ -1,0 +1,200 @@
+package com.hereliesaz.aznavrail.internal
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.carousel.HorizontalMultiBrowseCarousel
+import androidx.compose.material3.carousel.rememberCarouselState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.hereliesaz.aznavrail.AzButton
+import com.hereliesaz.aznavrail.AzDivider
+import com.hereliesaz.aznavrail.AzLoad
+import com.hereliesaz.aznavrail.AzNavRailScopeImpl
+import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzMoreFromApp
+import com.hereliesaz.aznavrail.service.MoreFromAzRepository
+import com.hereliesaz.aznavrail.LocalAzSafeZones
+
+/**
+ * Full-screen "More from Az" overlay: a Material 3 expressive carousel of the library author's other
+ * apps with a detail pane below. The focused/selected card drives the pane (name, description, and
+ * GitHub/Play [AzButton]s). Data comes from the CI-versioned `more-from-az.json` via
+ * [MoreFromAzRepository]; the card visuals reuse the rail's transparent-shape-with-colored-stroke
+ * language and Coil for icon fill.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun MoreFromAzOverlay(
+    jsonUrl: String,
+    scope: AzNavRailScopeImpl,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val accent = scope.activeColor.takeIf { it != Color.Unspecified } ?: MaterialTheme.colorScheme.primary
+    val surface = scope.translucentBackground.takeIf { it != Color.Unspecified } ?: MaterialTheme.colorScheme.surface
+    val safe = LocalAzSafeZones.current
+
+    BackHandler(enabled = true) { onDismiss() }
+
+    val apps by produceState<List<AzMoreFromApp>?>(initialValue = null, jsonUrl) {
+        value = MoreFromAzRepository.fetch(context, jsonUrl).getOrNull()?.apps ?: emptyList()
+    }
+    // Note: `.apps` is the resolved app list; link-only manifest entries are enriched at fetch time.
+
+    Box(Modifier.fillMaxSize().background(surface)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = safe.top, bottom = safe.bottom)
+                .padding(horizontal = 20.dp, vertical = 12.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = accent,
+                    modifier = Modifier.clickable { onDismiss() }.padding(end = 12.dp)
+                )
+                Text(
+                    text = "More from Az",
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold,
+                    color = accent,
+                )
+            }
+            Spacer(Modifier.height(16.dp))
+
+            val list = apps
+            when {
+                list == null -> Box(Modifier.fillMaxSize(), Alignment.Center) { AzLoad() }
+                list.isEmpty() -> Box(Modifier.fillMaxSize(), Alignment.Center) {
+                    Text(
+                        "Couldn't load apps right now.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                    )
+                }
+                else -> {
+                    var selected by remember(list) { mutableIntStateOf(0) }
+                    val carouselState = rememberCarouselState { list.size }
+                    HorizontalMultiBrowseCarousel(
+                        state = carouselState,
+                        preferredItemWidth = 132.dp,
+                        itemSpacing = 12.dp,
+                        contentPadding = PaddingValues(horizontal = 4.dp),
+                        modifier = Modifier.fillMaxWidth().height(150.dp),
+                    ) { index ->
+                        AppCard(
+                            app = list[index],
+                            accent = accent,
+                            focused = index == selected,
+                            onClick = { selected = index },
+                        )
+                    }
+
+                    Spacer(Modifier.height(20.dp))
+                    AzDivider()
+                    Spacer(Modifier.height(16.dp))
+
+                    val app = list[selected.coerceIn(0, list.size - 1)]
+                    DetailPane(app = app, accent = accent, openUrl = { openUrl(context, it) })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AppCard(app: AzMoreFromApp, accent: Color, focused: Boolean, onClick: () -> Unit) {
+    val shape = RoundedCornerShape(20.dp)
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(shape)
+            .border(width = if (focused) 3.dp else 1.dp, color = if (focused) accent else accent.copy(alpha = 0.4f), shape = shape)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center,
+    ) {
+        if (app.iconUrl.isNotBlank()) {
+            Image(
+                painter = rememberAsyncImagePainter(app.iconUrl),
+                contentDescription = app.name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize().clip(shape),
+            )
+        } else {
+            Text(
+                app.name.take(2).uppercase(),
+                style = MaterialTheme.typography.headlineMedium,
+                color = accent,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailPane(app: AzMoreFromApp, accent: Color, openUrl: (String) -> Unit) {
+    Column(Modifier.fillMaxWidth()) {
+        Text(app.name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+        if (app.description.isNotBlank()) {
+            Spacer(Modifier.height(6.dp))
+            Text(app.description, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f))
+        }
+        Spacer(Modifier.height(16.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            app.webUrl?.let { url ->
+                AzButton(onClick = { openUrl(url) }, text = "Open", color = accent, activeColor = accent, shape = AzButtonShape.RECTANGLE)
+            }
+            app.playStoreUrl?.let { url ->
+                AzButton(onClick = { openUrl(url) }, text = "Play Store", color = accent, activeColor = accent, shape = AzButtonShape.RECTANGLE)
+            }
+            app.githubUrl?.let { url ->
+                AzButton(onClick = { openUrl(url) }, text = "GitHub", color = accent, activeColor = accent, shape = AzButtonShape.RECTANGLE)
+            }
+        }
+    }
+}
+
+private fun openUrl(context: Context, url: String) {
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    } catch (_: Exception) {
+    }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzAboutModels.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzAboutModels.kt
@@ -1,0 +1,50 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * One entry in the auto-generated About table of contents: a markdown document discovered in the
+ * consuming app's GitHub repository (its root or `docs/` folder).
+ *
+ * @param title Humanized title derived from the filename (e.g. `MIGRATION_GUIDE.md` -> "Migration Guide").
+ * @param path Repository-relative path (e.g. `README.md`, `docs/API.md`). Used as a stable key.
+ * @param downloadUrl Raw download URL returned by the GitHub contents API, fetched lazily on open.
+ */
+data class AzDocEntry(
+    val title: String,
+    val path: String,
+    val downloadUrl: String
+)
+
+/**
+ * A raw entry in the `more-from-az.json` manifest: **just links**. Everything else (name, icon,
+ * description) is auto-populated at runtime by resolving these links — the Google Play listing's
+ * OpenGraph tags when [play] is present, otherwise the GitHub repository's API metadata.
+ *
+ * @param github Optional GitHub repository link.
+ * @param play Optional Google Play listing link.
+ * @param web Optional website / PWA link.
+ */
+data class AzMoreFromLink(
+    val github: String? = null,
+    val play: String? = null,
+    val web: String? = null
+)
+
+/**
+ * A fully-resolved app shown in the "More from Az" carousel: the link entry enriched with metadata
+ * fetched from the link itself.
+ *
+ * @param name Display name (Play title or GitHub repo name).
+ * @param iconUrl Icon image URL (Play `og:image` or GitHub owner avatar), loaded with Coil.
+ * @param description Short description (Play `og:description` or GitHub repo description).
+ * @param githubUrl Optional GitHub repository link.
+ * @param playStoreUrl Optional Google Play listing link.
+ * @param webUrl Optional website / PWA link.
+ */
+data class AzMoreFromApp(
+    val name: String,
+    val iconUrl: String,
+    val description: String,
+    val githubUrl: String? = null,
+    val playStoreUrl: String? = null,
+    val webUrl: String? = null
+)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzAdvancedConfig.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzAdvancedConfig.kt
@@ -24,6 +24,15 @@ import androidx.compose.ui.geometry.Rect
  * @param tutorials Map of item ID → [com.hereliesaz.aznavrail.tutorial.AzTutorial] for interactive step-by-step guides.
  * @param onInteraction Callback invoked whenever any rail item is interacted with (click, toggle,
  *   cycler advance, nested rail open, reloc drag). Receives the item's `id` and the [AzNavItem] itself.
+ * @param inAppAbout When true (default), the footer "About" item opens the in-app About reader overlay
+ *   (auto-generated from the repo's markdown docs) instead of opening [com.hereliesaz.aznavrail.AzNavRailScopeImpl.appRepositoryUrl]
+ *   in a browser.
+ * @param moreFromAzEnabled When true (default), the About overlay offers a "More from Az" entry that
+ *   opens a carousel of the library author's other apps, fetched from [moreFromAzJsonUrl].
+ * @param moreFromAzJsonUrl Raw URL of the JSON manifest backing the "More from Az" carousel. Its
+ *   `version` integer is CI-managed and used to invalidate the local cache.
+ * @param moreFromAzRailItem When true, a "More" item is pinned at the bottom of the collapsed rail
+ *   that opens the "More from Az" carousel directly (independent of the About screen).
  */
 data class AzAdvancedConfig(
     val isLoading: Boolean = false,
@@ -39,5 +48,9 @@ data class AzAdvancedConfig(
     val secLocPort: Int = 10203,
     val helpList: Map<String, Any> = emptyMap(),
     val tutorials: Map<String, com.hereliesaz.aznavrail.tutorial.AzTutorial> = emptyMap(),
-    val onInteraction: ((String, AzNavItem) -> Unit)? = null
+    val onInteraction: ((String, AzNavItem) -> Unit)? = null,
+    val inAppAbout: Boolean = true,
+    val moreFromAzEnabled: Boolean = true,
+    val moreFromAzJsonUrl: String = "https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json",
+    val moreFromAzRailItem: Boolean = false
 )

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/AzHttpCache.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/AzHttpCache.kt
@@ -1,0 +1,102 @@
+package com.hereliesaz.aznavrail.service
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Tiny GET-with-cache helper shared by the About reader and the "More from Az" carousel.
+ *
+ * It mitigates GitHub's ~60 req/hr unauthenticated rate limit three ways:
+ *  - **TTL short-circuit**: within [ttlMillis] of the last successful fetch the cached body is
+ *    returned with no network call at all.
+ *  - **Conditional requests**: an `ETag` is stored per URL and resent as `If-None-Match`; a `304`
+ *    response (which does not consume the primary rate-limit quota) serves the cached body.
+ *  - **Graceful fallback**: on any network/HTTP error (including a `403`/`429` rate-limit response),
+ *    the last cached body is returned when available.
+ *
+ * Bodies live in `cacheDir/aznavrail_about/`; ETags and timestamps live in a private SharedPreferences.
+ */
+internal object AzHttpCache {
+
+    private const val PREFS = "aznavrail_about_cache"
+    private const val DIR = "aznavrail_about"
+    const val DEFAULT_TTL_MILLIS: Long = 6 * 60 * 60 * 1000 // 6h
+
+    /** Result of a cached fetch. [fromCache] is true when no fresh body was downloaded this call. */
+    data class Result(val body: String, val fromCache: Boolean, val rateLimited: Boolean)
+
+    private fun cacheFile(context: Context, url: String): File {
+        val dir = File(context.cacheDir, DIR).apply { mkdirs() }
+        return File(dir, url.hashCode().toString() + ".cache")
+    }
+
+    private fun readCache(context: Context, url: String): String? =
+        cacheFile(context, url).takeIf { it.exists() }?.readText()
+
+    /**
+     * Fetches [url], honouring the cache. Returns null only when there is neither a usable network
+     * response nor a cached body (true cold failure).
+     *
+     * @param ttlMillis When the cached copy is younger than this, return it without any network call.
+     */
+    suspend fun get(
+        context: Context,
+        url: String,
+        ttlMillis: Long = DEFAULT_TTL_MILLIS,
+    ): Result? = withContext(Dispatchers.IO) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val etag = prefs.getString("etag:$url", null)
+        val lastFetch = prefs.getLong("ts:$url", 0L)
+        val cached = readCache(context, url)
+
+        if (cached != null && System.currentTimeMillis() - lastFetch < ttlMillis) {
+            return@withContext Result(cached, fromCache = true, rateLimited = false)
+        }
+
+        var connection: HttpURLConnection? = null
+        try {
+            connection = (URL(url).openConnection() as HttpURLConnection).apply {
+                requestMethod = "GET"
+                connectTimeout = 10_000
+                readTimeout = 15_000
+                setRequestProperty("User-Agent", "AzNavRail")
+                setRequestProperty("Accept", "application/vnd.github+json")
+                if (etag != null) setRequestProperty("If-None-Match", etag)
+            }
+            val code = connection.responseCode
+            val remaining = connection.getHeaderField("X-RateLimit-Remaining")?.toIntOrNull()
+
+            when {
+                code == HttpURLConnection.HTTP_NOT_MODIFIED && cached != null -> {
+                    prefs.edit().putLong("ts:$url", System.currentTimeMillis()).apply()
+                    Result(cached, fromCache = true, rateLimited = false)
+                }
+                code in 200..299 -> {
+                    val body = connection.inputStream.bufferedReader().use { it.readText() }
+                    cacheFile(context, url).writeText(body)
+                    val newEtag = connection.getHeaderField("ETag")
+                    prefs.edit().apply {
+                        if (newEtag != null) putString("etag:$url", newEtag)
+                        putLong("ts:$url", System.currentTimeMillis())
+                    }.apply()
+                    Result(body, fromCache = false, rateLimited = false)
+                }
+                // 404 with no cache is a legitimate "not found" -> signal via null so callers can
+                // treat e.g. a missing docs/ folder as empty rather than an error.
+                code == HttpURLConnection.HTTP_NOT_FOUND && cached == null -> null
+                else -> {
+                    val limited = code == 403 || code == 429 || remaining == 0
+                    cached?.let { Result(it, fromCache = true, rateLimited = limited) }
+                }
+            }
+        } catch (e: Exception) {
+            cached?.let { Result(it, fromCache = true, rateLimited = false) }
+        } finally {
+            connection?.disconnect()
+        }
+    }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/GithubDocsRepository.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/GithubDocsRepository.kt
@@ -1,0 +1,96 @@
+package com.hereliesaz.aznavrail.service
+
+import android.content.Context
+import com.hereliesaz.aznavrail.model.AzDocEntry
+import org.json.JSONArray
+
+/**
+ * Discovers and fetches the markdown documentation of a GitHub repository for the in-app About
+ * reader. Discovery is automatic: given the repo URL it lists the `.md` files in the repo root and
+ * the `docs/` folder via the GitHub contents API, then fetches each doc's raw markdown lazily.
+ *
+ * All results are served through [AzHttpCache], so repeated opens are cheap and the screen keeps
+ * working offline / when rate-limited (showing the last cached copy).
+ */
+object GithubDocsRepository {
+
+    private val REPO_REGEX = Regex("""github\.com[/:]([^/]+)/([^/?#]+)""")
+
+    /** Extracts `owner` / `repo` from a GitHub URL, stripping a trailing `.git`. Null if not GitHub. */
+    fun parseRepo(repoUrl: String): Pair<String, String>? {
+        val m = REPO_REGEX.find(repoUrl) ?: return null
+        val owner = m.groupValues[1]
+        val repo = m.groupValues[2].removeSuffix(".git")
+        if (owner.isBlank() || repo.isBlank()) return null
+        return owner to repo
+    }
+
+    /** Turns a filename like `MIGRATION_GUIDE.md` into a human title like "Migration Guide". */
+    internal fun humanize(fileName: String): String =
+        fileName.removeSuffix(".md").removeSuffix(".MD")
+            .replace('-', ' ').replace('_', ' ')
+            .split(' ').filter { it.isNotBlank() }
+            .joinToString(" ") { w -> w.replaceFirstChar { it.uppercase() } }
+
+    /** Parses a GitHub contents-API JSON array into the `.md` [AzDocEntry] list it contains. */
+    internal fun parseContents(json: String): List<AzDocEntry> {
+        val out = mutableListOf<AzDocEntry>()
+        val arr = JSONArray(json)
+        for (i in 0 until arr.length()) {
+            val o = arr.optJSONObject(i) ?: continue
+            if (o.optString("type") != "file") continue
+            val name = o.optString("name")
+            if (!name.endsWith(".md", ignoreCase = true)) continue
+            val download = o.optString("download_url")
+            if (download.isBlank()) continue
+            out.add(AzDocEntry(title = humanize(name), path = o.optString("path", name), downloadUrl = download))
+        }
+        return out
+    }
+
+    /**
+     * Orders the table of contents: README first, then remaining root docs, then `docs/` entries —
+     * each group alphabetised by title.
+     */
+    internal fun orderToc(root: List<AzDocEntry>, docs: List<AzDocEntry>): List<AzDocEntry> {
+        val readme = root.filter { it.path.substringAfterLast('/').startsWith("README", ignoreCase = true) }
+        val otherRoot = (root - readme.toSet()).sortedBy { it.title.lowercase() }
+        val docsSorted = docs.sortedBy { it.title.lowercase() }
+        return readme + otherRoot + docsSorted
+    }
+
+    /** Result of [listDocs]: the TOC plus a flag noting the network was unavailable/limited. */
+    data class DocsResult(val entries: List<AzDocEntry>, val rateLimitedOrOffline: Boolean)
+
+    /**
+     * Lists the repo's root + `docs/` markdown files. Returns an empty TOC (not an error) when the
+     * repo has no markdown. Returns failure only when the repo URL isn't a GitHub URL or nothing
+     * could be fetched at all.
+     */
+    suspend fun listDocs(context: Context, repoUrl: String): Result<DocsResult> {
+        val (owner, repo) = parseRepo(repoUrl)
+            ?: return Result.failure(IllegalArgumentException("Not a GitHub repo URL: $repoUrl"))
+
+        val rootUrl = "https://api.github.com/repos/$owner/$repo/contents/"
+        val docsUrl = "https://api.github.com/repos/$owner/$repo/contents/docs"
+
+        val rootRes = AzHttpCache.get(context, rootUrl)
+        val docsRes = AzHttpCache.get(context, docsUrl) // null => no docs/ folder
+
+        if (rootRes == null && docsRes == null) {
+            return Result.failure(IllegalStateException("Could not reach $repoUrl"))
+        }
+
+        val root = rootRes?.body?.let { runCatching { parseContents(it) }.getOrDefault(emptyList()) } ?: emptyList()
+        val docs = docsRes?.body?.let { runCatching { parseContents(it) }.getOrDefault(emptyList()) } ?: emptyList()
+        val limited = (rootRes?.rateLimited == true) || (docsRes?.rateLimited == true)
+        return Result.success(DocsResult(orderToc(root, docs), limited))
+    }
+
+    /** Fetches the raw markdown for a single TOC [entry] (cached). */
+    suspend fun fetchDoc(context: Context, entry: AzDocEntry): Result<String> {
+        val res = AzHttpCache.get(context, entry.downloadUrl)
+            ?: return Result.failure(IllegalStateException("Could not load ${entry.path}"))
+        return Result.success(res.body)
+    }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/MoreFromAzRepository.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/MoreFromAzRepository.kt
@@ -1,0 +1,120 @@
+package com.hereliesaz.aznavrail.service
+
+import android.content.Context
+import com.hereliesaz.aznavrail.model.AzMoreFromApp
+import com.hereliesaz.aznavrail.model.AzMoreFromLink
+import org.json.JSONObject
+
+/**
+ * Backs the "More from Az" carousel from a **link-only** manifest. The author maintains
+ * `more-from-az.json` as nothing more than a `version` and a list of `{ github?, play? }` links;
+ * this repository resolves each link into a full [AzMoreFromApp] by fetching metadata at runtime:
+ *  - **Play** link → the listing page's OpenGraph tags (`og:title`, `og:image`, `og:description`).
+ *  - **GitHub** link → the repository API (`name`, `description`, `owner.avatar_url`).
+ *
+ * Play metadata is preferred when both links are present (it describes the actual app). Everything is
+ * served through [AzHttpCache], so resolution is cheap on repeat opens and degrades to cache offline.
+ */
+object MoreFromAzRepository {
+
+    /** Parses the manifest into its `version` and the raw link list. */
+    internal fun parseLinks(json: String): Pair<Int, List<AzMoreFromLink>> {
+        val obj = JSONObject(json)
+        val version = obj.optInt("version", 0)
+        val arr = obj.optJSONArray("apps")
+        val links = buildList {
+            if (arr != null) {
+                for (i in 0 until arr.length()) {
+                    val a = arr.optJSONObject(i) ?: continue
+                    val github = a.optString("github").takeIf { it.isNotBlank() }
+                    val play = a.optString("play").takeIf { it.isNotBlank() }
+                    val web = a.optString("web").takeIf { it.isNotBlank() }
+                    if (github != null || play != null || web != null) add(AzMoreFromLink(github, play, web))
+                }
+            }
+        }
+        return version to links
+    }
+
+    /** Extracts an OpenGraph `content` value for [property] from raw HTML, tolerant of attribute order. */
+    internal fun extractOg(html: String, property: String): String? {
+        val a = Regex("""<meta[^>]+property=["']og:$property["'][^>]+content=["']([^"']*)["']""", RegexOption.IGNORE_CASE)
+        val b = Regex("""<meta[^>]+content=["']([^"']*)["'][^>]+property=["']og:$property["']""", RegexOption.IGNORE_CASE)
+        return (a.find(html)?.groupValues?.get(1) ?: b.find(html)?.groupValues?.get(1))
+            ?.let { decodeEntities(it).trim() }
+            ?.takeIf { it.isNotBlank() }
+    }
+
+    /** Decodes the handful of HTML entities that appear in OpenGraph text (pure-JVM, no android.text). */
+    private fun decodeEntities(s: String): String = s
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+
+    private suspend fun resolvePlay(context: Context, link: AzMoreFromLink): AzMoreFromApp? {
+        val url = link.play ?: return null
+        val html = AzHttpCache.get(context, url)?.body ?: return null
+        val title = extractOg(html, "title")?.removeSuffix(" - Apps on Google Play")?.trim() ?: return null
+        return AzMoreFromApp(
+            name = title,
+            iconUrl = extractOg(html, "image") ?: "",
+            description = extractOg(html, "description") ?: "",
+            githubUrl = link.github,
+            playStoreUrl = url,
+            webUrl = link.web,
+        )
+    }
+
+    private suspend fun resolveWeb(context: Context, link: AzMoreFromLink): AzMoreFromApp? {
+        val url = link.web ?: return null
+        val html = AzHttpCache.get(context, url)?.body ?: return null
+        val title = extractOg(html, "title")?.trim() ?: return null
+        return AzMoreFromApp(
+            name = title,
+            iconUrl = extractOg(html, "image") ?: "",
+            description = extractOg(html, "description") ?: "",
+            githubUrl = link.github,
+            playStoreUrl = link.play,
+            webUrl = url,
+        )
+    }
+
+    private suspend fun resolveGithub(context: Context, link: AzMoreFromLink): AzMoreFromApp? {
+        val url = link.github ?: return null
+        val (owner, repo) = GithubDocsRepository.parseRepo(url) ?: return null
+        val json = AzHttpCache.get(context, "https://api.github.com/repos/$owner/$repo")?.body ?: return null
+        return runCatching {
+            val o = JSONObject(json)
+            AzMoreFromApp(
+                name = o.optString("name", repo),
+                iconUrl = o.optJSONObject("owner")?.optString("avatar_url") ?: "",
+                description = o.optString("description", ""),
+                githubUrl = url,
+                playStoreUrl = link.play,
+                webUrl = link.web,
+            )
+        }.getOrNull()
+    }
+
+    /** Resolves one link entry into an app (richest metadata first: Play, then web/PWA, then GitHub). */
+    internal suspend fun resolve(context: Context, link: AzMoreFromLink): AzMoreFromApp? =
+        (if (link.play != null) resolvePlay(context, link) else null)
+            ?: (if (link.web != null) resolveWeb(context, link) else null)
+            ?: resolveGithub(context, link)
+
+    /** Result of [fetch]: the manifest version plus the resolved apps (failed entries are dropped). */
+    data class MoreFromResult(val version: Int, val apps: List<AzMoreFromApp>)
+
+    /** Fetches the manifest from [jsonUrl] and resolves every link into a displayable app. */
+    suspend fun fetch(context: Context, jsonUrl: String): Result<MoreFromResult> {
+        val res = AzHttpCache.get(context, jsonUrl)
+            ?: return Result.failure(IllegalStateException("Could not load $jsonUrl"))
+        return runCatching {
+            val (version, links) = parseLinks(res.body)
+            val apps = links.mapNotNull { resolve(context, it) }
+            MoreFromResult(version, apps)
+        }
+    }
+}

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -143,6 +143,31 @@ const settings: AzNavRailSettings = {
 > **Note on Help Overlay:**
 > The `HelpOverlay` displays a short, truncated entry for each item to conserve space. Tapping a help card expands it to reveal the full description and any extra text provided in `helpList`. Furthermore, `helpList` can be supplied dynamically to `AzNestedRail` components for distinct, localized help data.
 
+
+### D. About reader & "More from Az" (`azAbout`)
+
+```kotlin
+azAbout(
+    inAppAbout = true,         // footer "About" opens the in-app markdown reader (vs a browser)
+    moreFromAzEnabled = true,  // show the "More from Az" entry in the About screen
+    moreRailItem = false,      // also pin a "More" item at the bottom of the rail
+    moreFromAzJsonUrl = "https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json",
+)
+```
+
+The **About reader** auto-discovers the markdown docs (`.md` in the repo root + `docs/`) of
+`azConfig`'s `appRepositoryUrl` via the GitHub API (cached; public repos only) and renders them
+inline in a themed reader, with a "View on GitHub" button pinned at the bottom.
+
+**More from Az** is a carousel of other apps backed by a **link-only** `more-from-az.json` in this
+repo — each entry is just `{ "github"?, "play"?, "web"? }` and the name/icon/description are
+auto-populated by resolving the link. Its `version` is auto-incremented by CI so new entries appear
+without a release. A `web` link is treated as a website/PWA (with an "Open" button).
+
+**React:** the same options are flat props/settings — `inAppAbout`, `moreFromAzEnabled`,
+`moreRailItem`, `moreFromAzJsonUrl`, `appRepositoryUrl`. On the web build, Play/website link metadata
+is subject to CORS (GitHub links always resolve).
+
 ---
 
 ## 3. Navigation Items (DSL)

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AboutServiceTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AboutServiceTest.kt
@@ -1,0 +1,83 @@
+package com.hereliesaz.aznavrail
+
+import com.hereliesaz.aznavrail.service.GithubDocsRepository
+import com.hereliesaz.aznavrail.service.MoreFromAzRepository
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure-logic tests for the About reader + More-from-Az parsing/ordering (no network). */
+class AboutServiceTest {
+
+    @Test
+    fun `parseRepo extracts owner and repo`() {
+        assertEquals("HereLiesAz" to "AzNavRail", GithubDocsRepository.parseRepo("https://github.com/HereLiesAz/AzNavRail"))
+        assertEquals("HereLiesAz" to "AzNavRail", GithubDocsRepository.parseRepo("https://github.com/HereLiesAz/AzNavRail.git"))
+        assertEquals("a" to "b", GithubDocsRepository.parseRepo("http://github.com/a/b/tree/main"))
+    }
+
+    @Test
+    fun `parseRepo returns null for non-github`() {
+        assertNull(GithubDocsRepository.parseRepo("https://gitlab.com/a/b"))
+        assertNull(GithubDocsRepository.parseRepo("not a url"))
+    }
+
+    @Test
+    fun `humanize turns filenames into titles`() {
+        assertEquals("Migration Guide", GithubDocsRepository.humanize("MIGRATION_GUIDE.md"))
+        assertEquals("Api", GithubDocsRepository.humanize("api.md"))
+        assertEquals("Project Structure", GithubDocsRepository.humanize("project-structure.md"))
+    }
+
+    @Test
+    fun `parseContents keeps only markdown files`() {
+        val json = """
+            [
+              {"type":"file","name":"README.md","path":"README.md","download_url":"https://raw/README.md"},
+              {"type":"file","name":"build.gradle","path":"build.gradle","download_url":"https://raw/build.gradle"},
+              {"type":"dir","name":"docs","path":"docs","download_url":""},
+              {"type":"file","name":"API.md","path":"API.md","download_url":"https://raw/API.md"}
+            ]
+        """.trimIndent()
+        val docs = GithubDocsRepository.parseContents(json)
+        assertEquals(2, docs.size)
+        assertTrue(docs.all { it.path.endsWith(".md") })
+    }
+
+    @Test
+    fun `orderToc puts README first`() {
+        val root = GithubDocsRepository.parseContents(
+            """[
+              {"type":"file","name":"API.md","path":"API.md","download_url":"u"},
+              {"type":"file","name":"README.md","path":"README.md","download_url":"u"}
+            ]""".trimIndent()
+        )
+        val docs = GithubDocsRepository.parseContents(
+            """[{"type":"file","name":"DSL.md","path":"docs/DSL.md","download_url":"u"}]""".trimIndent()
+        )
+        val toc = GithubDocsRepository.orderToc(root, docs)
+        assertEquals("README", toc.first().title)
+        assertEquals("docs/DSL.md", toc.last().path)
+    }
+
+    @Test
+    fun `parseLinks reads version and link-only entries`() {
+        val (version, links) = MoreFromAzRepository.parseLinks(
+            """{ "version": 7, "apps": [ {"github":"https://github.com/a/b"}, {"play":"p","web":"w"}, {} ] }"""
+        )
+        assertEquals(7, version)
+        assertEquals(2, links.size) // the empty entry is dropped
+        assertEquals("https://github.com/a/b", links[0].github)
+        assertEquals("w", links[1].web)
+    }
+
+    @Test
+    fun `extractOg pulls opengraph content regardless of attribute order`() {
+        val html = """<meta property="og:title" content="My App - Apps on Google Play">""" +
+            """<meta content="https://img/icon.png" property="og:image">"""
+        assertEquals("My App - Apps on Google Play", MoreFromAzRepository.extractOg(html, "title"))
+        assertEquals("https://img/icon.png", MoreFromAzRepository.extractOg(html, "image"))
+        assertNull(MoreFromAzRepository.extractOg(html, "description"))
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -124,6 +124,24 @@ fun azTheme(
 * `headerIconSize`: `Dp` — exact diameter of the header app-icon. `Dp.Unspecified` (default) sizes
   the icon to the rail width (legacy behavior).
 
+### `azAbout`
+Configures the built-in About reader and the "More from Az" carousel.
+
+~~~kotlin
+fun azAbout(
+    inAppAbout: Boolean = true,
+    moreFromAzEnabled: Boolean = true,
+    moreFromAzJsonUrl: String = "https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json",
+    moreRailItem: Boolean = false
+)
+~~~
+
+* `inAppAbout` — footer "About" opens the in-app markdown reader (auto-generated from the repo's docs)
+  instead of opening `appRepositoryUrl` in a browser.
+* `moreFromAzEnabled` — show the "More from Az" entry inside the About screen.
+* `moreFromAzJsonUrl` — raw URL of the link-only, CI-versioned `more-from-az.json` manifest.
+* `moreRailItem` — also pin a "More" item at the bottom of the collapsed rail that opens the carousel.
+
 ---
 
 ## 3. UI Components

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -74,6 +74,22 @@ fun azAdvanced(
 )
 ~~~
 
+### `azAbout`
+Configures the built-in **About** reader and the **"More from Az"** carousel.
+
+~~~kotlin
+fun azAbout(
+    inAppAbout: Boolean = true,        // footer "About" opens the in-app reader vs a browser
+    moreFromAzEnabled: Boolean = true, // show the "More from Az" entry in the About screen
+    moreFromAzJsonUrl: String = "https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json",
+    moreRailItem: Boolean = false      // also pin a "More" item at the bottom of the rail
+)
+~~~
+
+The About reader auto-discovers the markdown docs (root + `docs/`) of `azConfig`'s `appRepositoryUrl`
+via the GitHub API (cached; public repos only) and renders them inline. "More from Az" is a link-only,
+CI-versioned carousel — see the README's "In-App About Reader" and "More from Az" sections.
+
 `onInteraction` is called whenever any rail item is interacted with — click, toggle, cycler advance, nested rail open, reloc drag, or host expand/collapse. It fires for both leaf items (`azRailItem` / `azRailSubItem`) and host items (`azRailHostItem`), in both the compact rail and the expanded menu, so opening a host menu is observable just like tapping a leaf. It receives the item's `id` and the `AzNavItem` itself, enabling analytics, UI feedback, and tutorial advancement (pair it with `controller.fireEvent(...)` and an `AzAdvanceCondition.Event` card) without per-item callbacks.
 
 ## Hidden Menu Builders (for `azRailRelocItem`)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ aznavrail = "9.10"
 # Android & Jetpack
 composeBom = "2026.05.00"
 coreKtx = "1.18.0"
-material3 = "1.4.0"
+material3 = "1.5.0-alpha01"
 coil = "2.7.0"
 navigationCompose = "2.9.8"
 

--- a/more-from-az.json
+++ b/more-from-az.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "apps": [
+    { "github": "https://github.com/HereLiesAz/AzNavRail" },
+    { "github": "https://github.com/HereLiesAz/CueDetat" }
+  ]
+}

--- a/sample-pwa/src/App.tsx
+++ b/sample-pwa/src/App.tsx
@@ -39,6 +39,7 @@ import CustomizationDemo, {
 import FormDemo from './screens/FormDemo'
 import HelpSystemDemo from './screens/HelpSystemDemo'
 import TutorialDemo from './screens/TutorialDemo'
+import AboutDemo from './screens/AboutDemo'
 import LegacyPlayground from './screens/LegacyPlayground'
 
 function App() {
@@ -100,6 +101,9 @@ function App() {
       headerIconSize={customization.headerIconSize || undefined}
       dropdownMenu={customization.dropdownMenu}
       dropdownSource={customization.dropdownSource}
+      inAppAbout
+      moreFromAzEnabled
+      moreRailItem
       onDismissInfoScreen={() => {
         setShowHelp(false)
         setDismissCount((n) => n + 1)
@@ -124,6 +128,7 @@ function App() {
       <AzMenuItem id="help-system" text="Help System" route="help-system" info="screenTitle, info, classifiers, helpList." classifiers={new Set(['focus'])} onClick={() => navigate('/help-system')} />
       <AzMenuItem id="tutorial" text="Tutorials" route="tutorial" info="AzTutorial DSL — every advance condition + highlight." classifiers={new Set(['advanced'])} onClick={() => navigate('/tutorial')} />
       <AzMenuItem id="legacy" text="Rail Playground" route="legacy" info="The original rail demos." onClick={() => navigate('/legacy')} />
+      <AzMenuItem id="about-demo" text="About & More" route="about-demo" info="In-app About reader + More from Az carousel." onClick={() => navigate('/about-demo')} />
 
       <AzDivider />
 
@@ -376,6 +381,7 @@ function App() {
               }
             />
             <Route path="/tutorial" element={<TutorialDemo />} />
+            <Route path="/about-demo" element={<AboutDemo />} />
             <Route path="/legacy" element={<LegacyPlayground />} />
             <Route path="*" element={<LegacyPlayground />} />
           </Routes>

--- a/sample-pwa/src/screens/AboutDemo.tsx
+++ b/sample-pwa/src/screens/AboutDemo.tsx
@@ -1,0 +1,44 @@
+/**
+ * Showcases the in-app About reader and the "More from Az" carousel.
+ *
+ * The rail itself provides both screens — this page just explains how to reach them and how they
+ * are configured. Tap **About** in the rail's footer (expand the rail first) to open the in-app
+ * markdown reader, which auto-discovers this repo's docs from GitHub. The pinned **More** rail item
+ * (enabled in `App.tsx` via `moreRailItem`) opens the apps carousel directly.
+ */
+export default function AboutDemo() {
+  return (
+    <div style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 720 }}>
+      <h2 style={{ margin: 0 }}>About &amp; More from Az</h2>
+      <p style={{ opacity: 0.85 }}>
+        Two built-in, themed overlays the rail provides for free:
+      </p>
+
+      <section>
+        <h3 style={{ marginBottom: 4 }}>In-app About reader</h3>
+        <p style={{ opacity: 0.85, marginTop: 0 }}>
+          Expand the rail and tap <strong>About</strong> in the footer. The reader auto-discovers the
+          markdown docs in the configured repository's root and <code>docs/</code> folder
+          (<code>appRepositoryUrl</code>), builds a table of contents, and renders each doc inline. A
+          GitHub button is pinned at the bottom. Configure with{' '}
+          <code>inAppAbout</code> (set false to open the repo in a browser instead).
+        </p>
+      </section>
+
+      <section>
+        <h3 style={{ marginBottom: 4 }}>More from Az</h3>
+        <p style={{ opacity: 0.85, marginTop: 0 }}>
+          A carousel of other apps, driven by a <strong>link-only</strong>{' '}
+          <code>more-from-az.json</code> in this repo — name, icon, and description are auto-populated
+          from each app's Play / website / GitHub link. Reach it from the About screen's “More from
+          Az” entry, or via the pinned <strong>More</strong> rail item (<code>moreRailItem</code>).
+          Its <code>version</code> is auto-incremented by CI, so the list refreshes without a release.
+        </p>
+        <p style={{ opacity: 0.6, marginTop: 0, fontSize: 13 }}>
+          Note: on the web, metadata for Play/website links is subject to CORS and may not resolve;
+          GitHub links always resolve. Native Android has no such limitation.
+        </p>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Two new built-in, themed screens (full-screen overlays, like the help overlay), on **Android (Compose)**, **React Native**, and **React web**:

### 1. In-app About reader (`azAbout`)
- The footer **About** opens a themed in-app **markdown reader** instead of a browser. It **auto-discovers** the consuming app's docs — every `.md` in the repo **root** + **`docs/`** of `appRepositoryUrl` — via the GitHub contents API, builds a table of contents, and renders each doc inline. **View on GitHub** is pinned at the bottom with extra spacing.
- Cached (ETag + 6h TTL) to respect GitHub's ~60 req/hr unauthenticated limit; serves cached content offline. Public repos only.
- `azAbout(inAppAbout = false)` restores the legacy browser behavior.

### 2. More from Az
- A carousel of other apps from a **link-only** [`more-from-az.json`](more-from-az.json) — each entry is just `{ github?, play?, web? }` and **name/icon/description are auto-populated** by resolving the link (Play OpenGraph, website/PWA OpenGraph, or GitHub repo API). **PWAs supported** via `web` links.
- Material 3 **expressive carousel** + detail pane (Android); scroll-snap carousel (web); FlatList (RN).
- Reachable from the About screen and/or a pinned **"More"** rail item (`azAbout(moreRailItem = true)`).
- **Self-versioning:** `version` is auto-incremented by `.github/workflows/bump-more-from-az.yml` on change (commit-back with `[skip ci]`, loop-safe), so new apps ship **without a release**.

### Theming / component reuse
Everything is built from the rail's own components (`AzButton`, `AzLoad`, `AzDivider`, `AutoSizeText`) and tokens (`activeColor`, `translucentBackground`, `defaultShape`, `headerIconShape`) so it matches the rail's transparent-shape-with-colored-stroke aesthetic.

## Notable implementation decisions (flagging deviations from the approved plan)
- **Markdown renderer:** implemented a small **self-contained** renderer on both platforms instead of `mikepenz`/`react-markdown`. Rationale: I can't verify external markdown libs resolve against the 2026.05 Compose BOM offline, and self-contained gives exact theming control + zero new runtime deps. Easy to swap later if you prefer.
- **material3 → `1.5.0-alpha01`** for Material 3 Expressive (per your call) + `activity-compose` added for `BackHandler`. ⚠️ The dependency resolution of the alpha against the pinned Compose versions is the most likely CI break — watching for it.
- **Web CORS caveat (documented):** Play/website link metadata for "More from Az" is fetched client-side and is subject to CORS, so it may not auto-resolve in the browser build (GitHub links always do; native resolves all). Link-out buttons always work.

## Also
- Security alert #81: added a `shell-quote` (`^1.8.3`) `overrides` entry in `aznavrail-react/package.json`. The committed `package-lock.json` should be regenerated (`npm install`) and committed when online for the alert to fully clear.

## Docs & samples
README, Complete Guide (source-of-truth resource file), DSL/API refs, AGENTS.md (incl. the no-CI-loop invariant), and the React migration guide. Demos added to `SampleApp` and `sample-pwa`. Pure-logic unit tests for URL/manifest parsing on both platforms.

## Verification
Sandbox can't run Gradle/npm offline, so this relies on CI. The Android `build` check (and the alpha-material3 resolution) is the key signal — I'll babysit and iterate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV

---
_Generated by [Claude Code](https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV)_