### PR TITLE
Make "More from Az" paste-only (repair manifest, auto-derive Play, CI normalize)

### DIFF
--- a/.github/workflows/bump-more-from-az.yml
+++ b/.github/workflows/bump-more-from-az.yml
@@ -1,11 +1,13 @@
-name: Bump more-from-az version
+name: Normalize & bump more-from-az
 
-# Auto-increments the `version` integer in more-from-az.json whenever its content changes, so the
-# rail's "More from Az" carousel can invalidate its cache without cutting a library release.
+# Whenever more-from-az.json changes, normalize it into clean JSON and bump its `version`, so the
+# maintainer can just *paste a list of links* (any shape — bare URLs inside or outside braces, on one
+# line or many) and CI tidies it up. Each app object keeps whatever links it has; URLs are classified
+# by host (github.com -> github, play.google.com -> play, anything else -> web). The Play link is also
+# auto-derived from the GitHub repo at runtime by the rail, so GitHub-only entries are enough.
 #
 # Loop safety: the bot commit message contains [skip ci], which GitHub honors to skip ALL workflows
 # for that push (so neither this workflow nor android-sample-build.yml re-runs on the bump commit).
-# The job is additionally guarded against the bot actor and [skip ci] messages.
 on:
   push:
     branches: [main]
@@ -16,7 +18,7 @@ permissions:
   contents: write
 
 jobs:
-  bump:
+  normalize:
     if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ubuntu-latest
     steps:
@@ -25,18 +27,52 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Increment version
+      - name: Normalize and bump version
         run: |
-          current=$(jq '.version' more-from-az.json)
-          next=$((current + 1))
-          tmp=$(mktemp)
-          jq ".version = $next" more-from-az.json > "$tmp" && mv "$tmp" more-from-az.json
-          echo "Bumped more-from-az version $current -> $next"
+          python3 - <<'PY'
+          import re, json
+          raw = open('more-from-az.json').read()
 
-      - name: Commit bumped version
+          m = re.search(r'"version"\s*:\s*(\d+)', raw)
+          version = (int(m.group(1)) if m else 0) + 1
+
+          def classify(urls):
+              app = {}
+              for u in urls:
+                  u = u.rstrip('.,;')
+                  if 'github.com' in u:
+                      app.setdefault('github', u)
+                  elif 'play.google.com' in u:
+                      app.setdefault('play', u)
+                  else:
+                      app.setdefault('web', u)
+              return app
+
+          url_re = re.compile(r'https?://[^\s"\'<>,}\]]+')
+          apps = []
+          # Prefer grouping by innermost { ... } blocks (one app per block).
+          blocks = re.findall(r'\{[^{}]*\}', raw)
+          for b in blocks:
+              urls = url_re.findall(b)
+              if urls:
+                  apps.append(classify(urls))
+          # Fallback: no usable blocks -> one app per line that contains URL(s).
+          if not apps:
+              for line in raw.splitlines():
+                  urls = url_re.findall(line)
+                  if urls:
+                      apps.append(classify(urls))
+
+          out = {"version": version, "apps": apps}
+          with open('more-from-az.json', 'w') as f:
+              f.write(json.dumps(out, indent=2) + "\n")
+          print(f"Normalized {len(apps)} apps; version -> {version}")
+          PY
+
+      - name: Commit normalized manifest
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore: bump more-from-az version [skip ci]"
+          commit_message: "chore: normalize & bump more-from-az [skip ci]"
           commit_user_name: "github-actions[bot]"
           commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
           file_pattern: more-from-az.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,11 @@ restores the browser behavior.
 pinned "More" rail item (`moreRailItem`). It is driven by a **link-only** `more-from-az.json` at the
 repo root: each entry is just `{ github?, play?, web? }` and the name/icon/description are
 auto-populated by resolving the link (Play OpenGraph, website/PWA OpenGraph, or GitHub repo API).
+The maintainer is meant to **just paste links** — a GitHub link is enough, because the Play URL is
+auto-derived from the repo (`com.<owner>.<repo>`) and used only if that listing resolves. The file
+need not even be valid JSON on paste: the bump workflow normalizes it (URLs classified by host:
+github.com→github, play.google.com→play, else→web; grouped per `{}` block or per line) and the rail
+parsers (`parseLinks`) fall back to the same lenient scan.
 Everything is built from the rail's own components (`AzButton`, `AzLoad`, `AzDivider`,
 `AutoSizeText`) and tokens (`activeColor`, `translucentBackground`, `defaultShape`, `headerIconShape`)
 so it matches the rail's aesthetic.

--- a/README.md
+++ b/README.md
@@ -547,25 +547,36 @@ const settings: AzNavRailSettings = {
 
 A built-in carousel of the library author's other apps, reachable from a **"More from Az"** entry in
 the About screen and/or a pinned **"More"** rail item. It is driven by a **link-only**
-[`more-from-az.json`](more-from-az.json) maintained in *this* repo — each entry is just one or two
-links and the **name, icon, and description are auto-populated** by resolving them (Google Play
-OpenGraph tags, a website/PWA's OpenGraph tags, or the GitHub repository API):
+[`more-from-az.json`](more-from-az.json) maintained in *this* repo — **just paste links**; the
+**name, icon, and description are auto-populated** by resolving them (Google Play OpenGraph tags, a
+website/PWA's OpenGraph tags, or the GitHub repository API).
+
+In the common case you only paste a **GitHub** link: the Play Store URL is **auto-derived** from the
+repo as `com.<owner>.<repo>` (e.g. `HereLiesAz/CueDetat` → `…?id=com.hereliesaz.cuedetat`) and used
+only if that listing actually exists. Add an explicit `play` (e.g. an internal-test link) or `web`
+(PWA) only when the convention doesn't apply:
 
 ```json
 {
   "version": 1,
   "apps": [
     { "github": "https://github.com/HereLiesAz/AzNavRail" },
-    { "play": "https://play.google.com/store/apps/details?id=com.example", "github": "https://github.com/you/example" },
+    { "github": "https://github.com/HereLiesAz/CueDetat" },
+    { "github": "https://github.com/you/example", "play": "https://play.google.com/apps/internaltest/123" },
     { "web": "https://your-pwa.example.com" }
   ]
 }
 ```
 
-- **Self-versioning:** the `version` integer is **auto-incremented by a GitHub Action**
-  (`.github/workflows/bump-more-from-az.yml`) whenever the file changes, committed back with
-  `[skip ci]`. The rail reads `version` to refresh its cache — **so you never cut a release just to
-  add an app.** Do not hand-edit `version`.
+You don't even have to write valid JSON: paste bare URLs (one app per line, or inside `{ }` blocks)
+and the **normalize workflow** (`.github/workflows/bump-more-from-az.yml`) tidies the file into clean
+JSON and bumps `version` on commit. The rail parser is also lenient, so a half-formatted manifest
+still renders.
+
+- **Self-versioning & self-normalizing:** the same GitHub Action normalizes your paste into clean
+  JSON and **auto-increments `version`** whenever the file changes, committed back with `[skip ci]`
+  — **so you never cut a release just to add an app**, and never hand-format JSON. Do not hand-edit
+  `version`.
 - **PWAs supported:** a `web` link is treated as a website/PWA and gets an **Open** button.
 - **Config & placement:**
 

--- a/aznavrail-react/src/__tests__/aboutServices.test.ts
+++ b/aznavrail-react/src/__tests__/aboutServices.test.ts
@@ -1,5 +1,5 @@
 import { parseRepo, humanize, parseContents, orderToc } from '../services/githubDocs';
-import { parseLinks, extractOg } from '../services/moreFromAz';
+import { parseLinks, extractOg, derivePlayUrl } from '../services/moreFromAz';
 
 describe('githubDocs', () => {
   it('parseRepo extracts owner/repo and strips .git', () => {
@@ -45,6 +45,29 @@ describe('moreFromAz', () => {
     expect(version).toBe(7);
     expect(links).toHaveLength(2);
     expect(links[1].web).toBe('w');
+  });
+
+  it('derivePlayUrl builds the conventional package id from a github repo', () => {
+    expect(derivePlayUrl('https://github.com/HereLiesAz/CueDetat')).toBe(
+      'https://play.google.com/store/apps/details?id=com.hereliesaz.cuedetat'
+    );
+    expect(derivePlayUrl('https://gitlab.com/a/b')).toBeUndefined();
+  });
+
+  it('parseLinks tolerates pasted bare-URL manifests', () => {
+    const messy = `{ "version": 5, "apps": [
+      { https://github.com/HereLiesAz/AzNavRail }
+      {
+        https://github.com/HereLiesAz/CueDetat
+        https://play.google.com/store/apps/details?id=com.hereliesaz.cuedetat
+      }
+      { }
+    ] }`;
+    const [version, links] = parseLinks(messy);
+    expect(version).toBe(5);
+    expect(links).toHaveLength(2);
+    expect(links[0].github).toBe('https://github.com/HereLiesAz/AzNavRail');
+    expect(links[1].play).toContain('id=com.hereliesaz.cuedetat');
   });
 
   it('extractOg pulls content regardless of attribute order', () => {

--- a/aznavrail-react/src/services/moreFromAz.ts
+++ b/aznavrail-react/src/services/moreFromAz.ts
@@ -18,16 +18,54 @@ export interface AzMoreFromApp {
   webUrl?: string;
 }
 
-/** Parses the manifest into `[version, links]`. */
+const URL_RE = /https?:\/\/[^\s"'<>,}\]]+/g;
+
+function classifyUrls(urls: string[]): AzMoreFromLink | null {
+  const app: AzMoreFromLink = {};
+  for (const raw of urls) {
+    const u = raw.replace(/[.,;]+$/, '');
+    if (u.includes('github.com')) app.github ??= u;
+    else if (u.includes('play.google.com')) app.play ??= u;
+    else app.web ??= u;
+  }
+  return app.github || app.play || app.web ? app : null;
+}
+
+/** Lenient fallback: pull URLs out of a not-quite-JSON manifest, grouping by `{}` block or line. */
+export function parseLinksLoose(raw: string): [number, AzMoreFromLink[]] {
+  const version = Number(/"version"\s*:\s*(\d+)/.exec(raw)?.[1]) || 0;
+  const links: AzMoreFromLink[] = [];
+  const blocks = raw.match(/\{[^{}]*\}/g) || [];
+  for (const b of blocks) {
+    const app = classifyUrls(b.match(URL_RE) || []);
+    if (app) links.push(app);
+  }
+  if (links.length === 0) {
+    for (const line of raw.split('\n')) {
+      const app = classifyUrls(line.match(URL_RE) || []);
+      if (app) links.push(app);
+    }
+  }
+  return [version, links];
+}
+
+/**
+ * Parses the manifest into `[version, links]`. Tries strict JSON first; on failure (e.g. bare URLs
+ * pasted before CI normalized the file) falls back to a lenient URL scan so the carousel still works.
+ */
 export function parseLinks(json: string): [number, AzMoreFromLink[]] {
-  const obj = JSON.parse(json);
-  const version = typeof obj.version === 'number' ? obj.version : 0;
-  const apps: AzMoreFromLink[] = Array.isArray(obj.apps)
-    ? obj.apps
-        .map((a: any) => ({ github: a?.github || undefined, play: a?.play || undefined, web: a?.web || undefined }))
-        .filter((a: AzMoreFromLink) => a.github || a.play || a.web)
-    : [];
-  return [version, apps];
+  try {
+    const obj = JSON.parse(json);
+    const version = typeof obj.version === 'number' ? obj.version : 0;
+    const apps: AzMoreFromLink[] = Array.isArray(obj.apps)
+      ? obj.apps
+          .map((a: any) => ({ github: a?.github || undefined, play: a?.play || undefined, web: a?.web || undefined }))
+          .filter((a: AzMoreFromLink) => a.github || a.play || a.web)
+      : [];
+    return [version, apps];
+  } catch {
+    return parseLinksLoose(json);
+  }
 }
 
 /** Extracts an OpenGraph `content` value, tolerant of attribute order. */
@@ -104,13 +142,38 @@ async function resolveGithub(link: AzMoreFromLink): Promise<AzMoreFromApp | null
   }
 }
 
-/** Resolves one link into an app (richest metadata first: Play, then web/PWA, then GitHub). */
+/**
+ * Derives the conventional Play Store URL for a GitHub repo (`com.<owner>.<repo>`, lower-cased).
+ * Only used if it actually resolves to a real listing (see {@link resolve}).
+ */
+export function derivePlayUrl(githubUrl: string): string | undefined {
+  const parsed = parseRepo(githubUrl);
+  if (!parsed) return undefined;
+  const [owner, repo] = parsed;
+  return `https://play.google.com/store/apps/details?id=com.${owner.toLowerCase()}.${repo.toLowerCase()}`;
+}
+
+/**
+ * Resolves one link into an app. Order: explicit Play, derived Play (verified by fetch), web/PWA,
+ * then GitHub. (On the web, Play/website fetches are CORS-limited, so GitHub is the usual resolver.)
+ */
 export async function resolve(link: AzMoreFromLink): Promise<AzMoreFromApp | null> {
-  return (
-    (link.play ? await resolvePlay(link) : null) ??
-    (link.web ? await resolveWeb(link) : null) ??
-    (await resolveGithub(link))
-  );
+  if (link.play) {
+    const viaPlay = await resolvePlay(link);
+    if (viaPlay) return viaPlay;
+  }
+  if (!link.play && link.github) {
+    const derived = derivePlayUrl(link.github);
+    if (derived) {
+      const viaDerived = await resolvePlay({ ...link, play: derived });
+      if (viaDerived) return viaDerived;
+    }
+  }
+  if (link.web) {
+    const viaWeb = await resolveWeb(link);
+    if (viaWeb) return viaWeb;
+  }
+  return resolveGithub(link);
 }
 
 export interface MoreFromResult {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/MoreFromAzRepository.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/MoreFromAzRepository.kt
@@ -17,8 +17,13 @@ import org.json.JSONObject
  */
 object MoreFromAzRepository {
 
-    /** Parses the manifest into its `version` and the raw link list. */
-    internal fun parseLinks(json: String): Pair<Int, List<AzMoreFromLink>> {
+    /**
+     * Parses the manifest into its `version` and the raw link list. Tries strict JSON first; if that
+     * fails (e.g. a maintainer pasted bare URLs and CI hasn't normalized the file yet), falls back to
+     * a lenient scan that extracts URLs from `{ ... }` blocks (or, failing that, per line) so the
+     * carousel still works.
+     */
+    internal fun parseLinks(json: String): Pair<Int, List<AzMoreFromLink>> = try {
         val obj = JSONObject(json)
         val version = obj.optInt("version", 0)
         val arr = obj.optJSONArray("apps")
@@ -31,6 +36,39 @@ object MoreFromAzRepository {
                     val web = a.optString("web").takeIf { it.isNotBlank() }
                     if (github != null || play != null || web != null) add(AzMoreFromLink(github, play, web))
                 }
+            }
+        }
+        version to links
+    } catch (e: Exception) {
+        parseLinksLoose(json)
+    }
+
+    private val URL_RE = Regex("""https?://[^\s"'<>,}\]]+""")
+
+    private fun classifyUrls(urls: List<String>): AzMoreFromLink? {
+        var gh: String? = null; var play: String? = null; var web: String? = null
+        for (raw in urls) {
+            val u = raw.trimEnd('.', ',', ';')
+            when {
+                u.contains("github.com") -> if (gh == null) gh = u
+                u.contains("play.google.com") -> if (play == null) play = u
+                else -> if (web == null) web = u
+            }
+        }
+        return if (gh != null || play != null || web != null) AzMoreFromLink(gh, play, web) else null
+    }
+
+    /** Lenient fallback: pull URLs out of a not-quite-JSON manifest, grouping by `{}` block or line. */
+    internal fun parseLinksLoose(raw: String): Pair<Int, List<AzMoreFromLink>> {
+        val version = Regex("""\"version\"\s*:\s*(\d+)""").find(raw)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+        val links = mutableListOf<AzMoreFromLink>()
+        Regex("""\{[^{}]*\}""").findAll(raw).forEach { block ->
+            classifyUrls(URL_RE.findAll(block.value).map { it.value }.toList())?.let { links.add(it) }
+        }
+        if (links.isEmpty()) {
+            raw.lineSequence().forEach { line ->
+                val urls = URL_RE.findAll(line).map { it.value }.toList()
+                if (urls.isNotEmpty()) classifyUrls(urls)?.let { links.add(it) }
             }
         }
         return version to links
@@ -98,11 +136,34 @@ object MoreFromAzRepository {
         }.getOrNull()
     }
 
-    /** Resolves one link entry into an app (richest metadata first: Play, then web/PWA, then GitHub). */
-    internal suspend fun resolve(context: Context, link: AzMoreFromLink): AzMoreFromApp? =
-        (if (link.play != null) resolvePlay(context, link) else null)
-            ?: (if (link.web != null) resolveWeb(context, link) else null)
-            ?: resolveGithub(context, link)
+    /**
+     * Derives the conventional Play Store URL for a GitHub repo (`com.<owner>.<repo>`, lower-cased),
+     * e.g. `HereLiesAz/CueDetat` -> `…?id=com.hereliesaz.cuedetat`. The candidate is only used if it
+     * actually resolves to a real listing (see [resolve]), so a wrong guess for an unpublished app is
+     * silently dropped.
+     */
+    internal fun derivePlayUrl(githubUrl: String): String? {
+        val (owner, repo) = GithubDocsRepository.parseRepo(githubUrl) ?: return null
+        val pkg = "com.${owner.lowercase()}.${repo.lowercase()}"
+        return "https://play.google.com/store/apps/details?id=$pkg"
+    }
+
+    /**
+     * Resolves one link entry into an app. Order (richest metadata first):
+     *  1. explicit Play link, 2. **derived** Play link from the GitHub repo (verified by fetch),
+     *  3. website/PWA link, 4. GitHub repo API.
+     * Resolving via Play also avoids a GitHub API call (saving the rate-limit budget) for published apps.
+     */
+    internal suspend fun resolve(context: Context, link: AzMoreFromLink): AzMoreFromApp? {
+        if (link.play != null) resolvePlay(context, link)?.let { return it }
+        if (link.play == null && link.github != null) {
+            derivePlayUrl(link.github)?.let { derived ->
+                resolvePlay(context, link.copy(play = derived))?.let { return it }
+            }
+        }
+        if (link.web != null) resolveWeb(context, link)?.let { return it }
+        return resolveGithub(context, link)
+    }
 
     /** Result of [fetch]: the manifest version plus the resolved apps (failed entries are dropped). */
     data class MoreFromResult(val version: Int, val apps: List<AzMoreFromApp>)

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AboutServiceTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AboutServiceTest.kt
@@ -73,6 +73,36 @@ class AboutServiceTest {
     }
 
     @Test
+    fun `derivePlayUrl builds the conventional package id from a github repo`() {
+        assertEquals(
+            "https://play.google.com/store/apps/details?id=com.hereliesaz.cuedetat",
+            MoreFromAzRepository.derivePlayUrl("https://github.com/HereLiesAz/CueDetat")
+        )
+        assertNull(MoreFromAzRepository.derivePlayUrl("https://gitlab.com/a/b"))
+    }
+
+    @Test
+    fun `parseLinks tolerates pasted bare-URL manifests`() {
+        // A maintainer paste: bare URLs inside braces, no keys/quotes/commas, plus an empty block.
+        val messy = """
+            { "version": 5, "apps": [
+              { https://github.com/HereLiesAz/AzNavRail }
+              {
+                https://github.com/HereLiesAz/CueDetat
+                https://play.google.com/store/apps/details?id=com.hereliesaz.cuedetat
+              }
+              { }
+            ] }
+        """.trimIndent()
+        val (version, links) = MoreFromAzRepository.parseLinks(messy)
+        assertEquals(5, version)
+        assertEquals(2, links.size) // empty block dropped
+        assertEquals("https://github.com/HereLiesAz/AzNavRail", links[0].github)
+        assertEquals("https://github.com/HereLiesAz/CueDetat", links[1].github)
+        assertTrue(links[1].play!!.contains("id=com.hereliesaz.cuedetat"))
+    }
+
+    @Test
     fun `extractOg pulls opengraph content regardless of attribute order`() {
         val html = """<meta property="og:title" content="My App - Apps on Google Play">""" +
             """<meta content="https://img/icon.png" property="og:image">"""

--- a/more-from-az.json
+++ b/more-from-az.json
@@ -1,88 +1,29 @@
 {
   "version": 2,
   "apps": [
-    {
-      "github": "https://github.com/HereLiesAz/AzNavRail"
-    },
-    {
-      "github": "https://github.com/HereLiesAz/CueDetat"
-      https://play.google.com/store/apps/details?id=com.hereliesaz.cuedetat
-    }
-    {
-https://github.com/HereLiesAz/GraffitiXR
-    https://play.google.com/store/apps/details?id=com.hereliesaz.graffitixr
-    }
-    {
-https://github.com/HereLiesAz/BarBacker
-    }
-    {
-https://github.com/HereLiesAz/IDEaz
-    }
-{
-https://github.com/HereLiesAz/TheLexorcist
-      }
-    {
-      https://github.com/HereLiesAz/BluSnu
-      }
-    {
-      https://github.com/HereLiesAz/Liperty
-      https://play.google.com/apps/internaltest/4701511429095710682
-      }
-    {
-      https://github.com/HereLiesAz/LogKitty
-      }
-    {
-      https://github.com/HereLiesAz/RedBlightDistrict
-      }
-    {
-https://github.com/HereLiesAz/HalfHashedKitty
-
-    }
-    {
-https://github.com/HereLiesAz/QaRd
-    }
-    {
-https://github.com/HereLiesAz/BarCodeNcrypt
-    }
-    {
-https://github.com/HereLiesAz/CleanUnderwear
-      https://play.google.com/apps/internaltest/4701485263411403388
-    }
-    {
-https://github.com/HereLiesAz/QuicLoc
-    }
-    {
-https://github.com/HereLiesAz/Guillotine
-    }
-    {
-https://github.com/HereLiesAz/MagNom
-    }
-    {
-https://github.com/HereLiesAz/pwnagotchiOnAndroid
-    }
-    {
-https://github.com/HereLiesAz/ReUp
-    }
-    {
-https://github.com/HereLiesAz/Et2Brutus
-    }
- {
-https://github.com/HereLiesAz/LeFauxPass
-    }
- {
-https://github.com/HereLiesAz/MadeMeDance
-    }
- {
-https://github.com/HereLiesAz/Click
-    }
- {
-https://github.com/HereLiesAz/WifiHaqueur
-    }
- {
-
-    }
- {
-
-    }
+    { "github": "https://github.com/HereLiesAz/AzNavRail" },
+    { "github": "https://github.com/HereLiesAz/CueDetat" },
+    { "github": "https://github.com/HereLiesAz/GraffitiXR" },
+    { "github": "https://github.com/HereLiesAz/BarBacker" },
+    { "github": "https://github.com/HereLiesAz/IDEaz" },
+    { "github": "https://github.com/HereLiesAz/TheLexorcist" },
+    { "github": "https://github.com/HereLiesAz/BluSnu" },
+    { "github": "https://github.com/HereLiesAz/Liperty", "play": "https://play.google.com/apps/internaltest/4701511429095710682" },
+    { "github": "https://github.com/HereLiesAz/LogKitty" },
+    { "github": "https://github.com/HereLiesAz/RedBlightDistrict" },
+    { "github": "https://github.com/HereLiesAz/HalfHashedKitty" },
+    { "github": "https://github.com/HereLiesAz/QaRd" },
+    { "github": "https://github.com/HereLiesAz/BarCodeNcrypt" },
+    { "github": "https://github.com/HereLiesAz/CleanUnderwear", "play": "https://play.google.com/apps/internaltest/4701485263411403388" },
+    { "github": "https://github.com/HereLiesAz/QuicLoc" },
+    { "github": "https://github.com/HereLiesAz/Guillotine" },
+    { "github": "https://github.com/HereLiesAz/MagNom" },
+    { "github": "https://github.com/HereLiesAz/pwnagotchiOnAndroid" },
+    { "github": "https://github.com/HereLiesAz/ReUp" },
+    { "github": "https://github.com/HereLiesAz/Et2Brutus" },
+    { "github": "https://github.com/HereLiesAz/LeFauxPass" },
+    { "github": "https://github.com/HereLiesAz/MadeMeDance" },
+    { "github": "https://github.com/HereLiesAz/Click" },
+    { "github": "https://github.com/HereLiesAz/WifiHaqueur" }
   ]
 }


### PR DESCRIPTION
## Summary

`more-from-az.json` on `main` was pasted as invalid JSON (bare URLs in braces), which broke the "More from Az" carousel. Beyond repairing it, this makes the whole flow **"just paste links"** — addressing the feedback that even formatting JSON is a hassle.

### Changes
- **Repaired `more-from-az.json`** → valid JSON, all 24 apps. GitHub-only entries, plus the two internal-test Play links that can't be derived.
- **Auto-derive the Play URL from a GitHub link** as `com.<owner>.<repo>` (e.g. `HereLiesAz/CueDetat` → `…?id=com.hereliesaz.cuedetat`), used **only if the listing actually resolves**. So a GitHub link alone produces a Play button for published apps — and resolving via Play skips a GitHub API call (saves rate-limit budget). Implemented on Android + React.
- **CI normalizes any paste** — the `bump-more-from-az.yml` workflow now parses a messy manifest (bare URLs inside/outside `{}`, one line or many), classifies URLs by host (github/play/web), writes clean JSON, and bumps `version`, committed back with `[skip ci]`.
- **Lenient rail parsers** — `parseLinks` (Android + TS) fall back to the same URL scan, so a half-formatted manifest still renders before CI tidies it.
- Docs (README, AGENTS) updated; tests added for `derivePlayUrl` and lenient `parseLinks` on both platforms; JSON validated (24 apps).

### Net effect for the maintainer
Paste a list of GitHub repo URLs (any shape). CI cleans + versions it; the rail derives Play links and auto-fills name/icon/description. No JSON formatting, no manual Play links (except internal-test/PWA edge cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV

---
_Generated by [Claude Code](https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV)_