### PR TITLE
Drop-down mode: no reserved safe zones + dev-chosen icon placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,20 +150,28 @@ that width and height.
 Drop-down menu mode: the rail can be used as a drop-down menu via `dropdownMenu = true` in
 `azConfig`/`azSettings` (a `dropdownMenu` boolean in React settings). In this mode:
 
-- `onscreen()` content is allowed the entire width of the screen (the rail reserves no horizontal
-  band). The rail renders as a floating top-anchored trigger above the content.
-- The app icon takes the place of the hamburger menu icon. The bleeding app-name header is not used
-  here; it is always the icon.
-- Tapping the icon causes either the menu items or the rail items to unfold like an accordion
-  downward, reusing the exact fold/unfold mechanism already programmed for the floating-rail (FAB)
-  feature. Tapping the icon again, tapping an item, or tapping outside folds them back up.
+- `onscreen()` content is allowed the entire screen. The rail reserves **no** horizontal band **and
+  no top/bottom content safe zones** in this mode (`effectiveSafeTop`/`effectiveSafeBottom` are zeroed
+  in `AzNavHost`, and `LocalAzSafeZones` reports zero) — content runs fully edge-to-edge and the
+  floating trigger draws over it.
+- The trigger is placed wherever the dev asks via `dropdownAlignment` (an `AzDropdownAlignment` enum:
+  nine anchors `TOP_START`…`BOTTOM_END`; web/RN use the lowercase string values like `'bottom-end'`)
+  plus a fine `dropdownOffset` (`DpOffset` on Android, `{x,y}` px on React). The docking side no longer
+  dictates the trigger's spot. The shared `parseDropdownAnchor` helper (React) and
+  `AzDropdownAlignment.toAlignment()/toHorizontalAlignment()/isBottom` (Android) drive placement.
+- The app icon takes the place of the hamburger menu icon and behaves exactly like one. The bleeding
+  app-name header is not used here; it is always the icon.
+- Tapping the icon causes either the menu items or the rail items to unfold like an accordion,
+  reusing the exact fold/unfold mechanism already programmed for the floating-rail (FAB) feature. The
+  panel unfolds **downward** for top/centre anchors and **upward** for bottom anchors. Tapping the
+  icon again, tapping an item, or tapping outside folds them back up.
 - The developer selects which set unfolds via `dropdownSource` (`RAIL` or `MENU`). There is no
   collapsing the rail or expanding the menu; whichever they choose is the one and only set the
   drop-down shows.
 - This mode works at the explicit exclusion of: FAB mode/draggable rail and the overlay service,
   rail↔menu expansion, `noMenu`, all swipe gestures, physical docking/rotate-in-place, the footer,
-  nested-rail popups, the rail width settings, the bleeding app-name header, the rail safe-zone
-  padding, and the help overlay/tutorials. Host items still expand inline as an accordion.
+  nested-rail popups, the rail width settings, the bleeding app-name header, the content safe zones,
+  and the help overlay/tutorials. Host items still expand inline as an accordion.
 
 In-app About reader + "More from Az": the footer "About" item opens a built-in, full-screen, themed
 markdown reader (an overlay drawn over the live UI, like the help overlay) instead of opening the repo

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add JitPack to your `settings.gradle.kts`:
 - **Tutorial Framework**: Scripted multi-scene tutorials with spotlights, 4 advance conditions (Button, TapTarget, TapAnywhere, Event), variable-driven branching, TapTarget branching, checklist cards, media cards, and cross-platform read-state persistence.
 - **Left/Right Docking**: Position the rail on the left or right side of the screen.
 - **No Menu Mode**: Treat all items as rail items, removing the side drawer.
-- **Drop-down Menu Mode**: Use the rail as a top-anchored drop-down. The app icon replaces the hamburger; tapping it unfolds *either* the rail items or the menu items like an accordion, while `onscreen` content gets the full screen width. (`dropdownMenu = true`)
+- **Drop-down Menu Mode**: Use the rail as a hamburger-style drop-down you can place anywhere. The app icon replaces the hamburger; tapping it unfolds *either* the rail items or the menu items like an accordion. Position the trigger with `dropdownAlignment` (nine anchors) + `dropdownOffset`, and `onscreen` content gets the **full screen** — no safe zones reserved. (`dropdownMenu = true`)
 - **Sizable Header Icon**: Set the app-icon to an exact diameter via `headerIconSize`.
 - **In-App About Reader**: The footer "About" opens a themed in-app markdown reader that auto-discovers your repo's docs (root + `docs/`) and renders them inline. (`azAbout`)
 - **More from Az**: A self-versioning carousel of other apps — paste GitHub repo links and CI bakes name/icon/description, a verified Play link, and the homepage website/PWA (WIP apps excluded, Play-first); optionally pinned as a "More" rail item.
@@ -443,12 +443,13 @@ const settings: AzNavRailSettings = {
 
 ### Drop-down Menu Mode
 
-Use the rail as a classic **drop-down menu**. Instead of a docked side strip, the rail collapses
-to a single **app-icon trigger anchored at the top of the screen — the app icon takes the place of
-the hamburger menu icon**. Tapping it unfolds the items downward like an accordion (the exact
-fold/unfold behaviour reused from FAB mode); tapping the icon again, tapping an item, or tapping
-outside folds them back up. With this mode enabled, `onscreen` content is given the **entire width
-of the screen** (the rail reserves no horizontal band).
+Use the rail as a classic **drop-down menu**. Instead of a docked side strip, the rail collapses to
+a single **app-icon trigger you place wherever you want — the app icon takes the place of the
+hamburger menu icon and behaves exactly like one**. Tapping it unfolds the items like an accordion;
+tapping the icon again, tapping an item, or tapping outside folds them back up. With this mode
+enabled, `onscreen` content is given the **entire screen** — drop-down mode reserves **no** top/bottom
+content safe zones (and no horizontal band), so your content runs edge-to-edge and the trigger floats
+over it.
 
 Enable it with `dropdownMenu = true` and choose **one** of two renderings with `dropdownSource`:
 
@@ -458,18 +459,24 @@ Enable it with `dropdownMenu = true` and choose **one** of two renderings with `
 There is no rail-to-menu expansion and no menu-to-rail collapse: whichever source you pick is the
 one and only set the drop-down shows.
 
+Place the trigger with `dropdownAlignment` (one of nine anchors, `TOP_START` … `BOTTOM_END`) and nudge
+it with `dropdownOffset` (a `DpOffset`). The panel unfolds **downward** for top/centre anchors and
+**upward** for bottom anchors, so it always opens away from the nearest screen edge.
+
 ```kotlin
 AzHostActivityLayout(navController = navController) {
     azConfig(
         dropdownMenu = true,
         dropdownSource = AzDropdownSource.MENU, // or AzDropdownSource.RAIL
+        dropdownAlignment = AzDropdownAlignment.TOP_END, // place the hamburger top-right
+        dropdownOffset = DpOffset(0.dp, 8.dp),           // nudge it down a touch
     )
     azTheme(headerIconSize = 56.dp)
 
     azRailItem(id = "home", text = "Home", route = "home")
     azMenuItem(id = "settings", text = "Settings", route = "settings")
 
-    onscreen { /* now spans the full screen width */ }
+    onscreen { /* now spans the full screen */ }
 }
 ```
 
@@ -480,21 +487,23 @@ AzHostActivityLayout(navController = navController) {
 > - **Rail ↔ menu expansion** (`initiallyExpanded`, the two-state drawer) — there is only the single drop-down.
 > - **`noMenu`** — superseded by `dropdownSource`.
 > - **Swipe gestures** — both the horizontal swipe-to-open/close and the vertical swipe-to-undock. Only a tap toggles the drop-down.
-> - **Physical docking / rotate-in-place** (`usePhysicalDocking`) — the trigger always anchors to the top.
+> - **Physical docking / rotate-in-place** (`usePhysicalDocking`) — the trigger anchors at `dropdownAlignment`, not a device edge.
 > - **The footer** (`showFooter`) — not shown.
 > - **Nested-rail popups** (`azNestedRail`) — not supported. (Host items still expand inline as an accordion.)
 > - **Rail width settings** (`expandedWidth`/`collapsedWidth`) — ignored for `RAIL`; the panel sizes to its content. (`MENU` uses `expandedWidth` for the panel width.)
 > - **The bleeding app-name header** (`displayAppName`) — the header is always the app icon.
-> - **The rail safe-zone padding** (top/bottom 10%) — the trigger sits at the top edge. Content safe zones still apply to `onscreen`.
+> - **Content safe zones** (top/bottom) — **not reserved** in drop-down mode: `onscreen` content runs fully edge-to-edge, and the trigger floats over it wherever `dropdownAlignment`/`dropdownOffset` place it.
 > - **Help overlay & tutorials** — not driven from the drop-down (their positioning relies on the docked rail).
 
 **React Implementation:**
 ```tsx
-import { AzNavRailSettings, AzDropdownSource } from '@HereLiesAz/aznavrail-react';
+import { AzNavRailSettings, AzDropdownSource, AzDropdownAlignment } from '@HereLiesAz/aznavrail-react';
 
 const settings: AzNavRailSettings = {
     dropdownMenu: true,
     dropdownSource: AzDropdownSource.MENU, // or AzDropdownSource.RAIL
+    dropdownAlignment: AzDropdownAlignment.TOP_END, // place the hamburger top-right
+    dropdownOffset: { x: 0, y: 8 },                 // nudge it down a touch (px)
     headerIconSize: 56,
 };
 // Pass settings to <AzNavRail settings={settings} ... />

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
@@ -163,6 +163,8 @@ fun MainApp() {
             appRepositoryUrl = customization.appRepositoryUrl,
             dropdownMenu = customization.dropdownMenu,
             dropdownSource = customization.dropdownSource,
+            dropdownAlignment = customization.dropdownAlignment,
+            dropdownOffset = customization.dropdownOffset,
         )
 
         azTheme(

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
@@ -16,11 +16,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.AzCycler
 import com.hereliesaz.aznavrail.AzToggle
 import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzDropdownAlignment
 import com.hereliesaz.aznavrail.model.AzDropdownSource
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 
@@ -39,11 +41,14 @@ data class CustomizationState(
     val headerIconSize: Dp = Dp.Unspecified,
     val dropdownMenu: Boolean = false,
     val dropdownSource: AzDropdownSource = AzDropdownSource.RAIL,
+    val dropdownAlignment: AzDropdownAlignment = AzDropdownAlignment.TOP_START,
+    val dropdownOffset: DpOffset = DpOffset.Zero,
 )
 
 private val headerIconShapes = AzHeaderIconShape.values().toList()
 private val defaultShapes = AzButtonShape.values().toList()
 private val dropdownSources = AzDropdownSource.values().toList()
+private val dropdownAlignments = AzDropdownAlignment.values().toList()
 private val translucentChoices = listOf(
     "Unspecified" to Color.Unspecified,
     "Black 40%" to Color.Black.copy(alpha = 0.4f),
@@ -153,6 +158,31 @@ fun CustomizationDemoScreen(
                 onChange(state.copy(dropdownSource = next))
             },
             shape = AzButtonShape.RECTANGLE,
+        )
+
+        SectionLabel("dropdownAlignment (where the hamburger icon sits)")
+        AzCycler(
+            options = dropdownAlignments.map { it.name },
+            selectedOption = state.dropdownAlignment.name,
+            onCycle = {
+                val next = dropdownAlignments[(state.dropdownAlignment.ordinal + 1) % dropdownAlignments.size]
+                onChange(state.copy(dropdownAlignment = next))
+            },
+            shape = AzButtonShape.RECTANGLE,
+        )
+
+        SectionLabel("dropdownOffset.x: ${state.dropdownOffset.x.value.toInt()}dp")
+        Slider(
+            value = state.dropdownOffset.x.value,
+            onValueChange = { onChange(state.copy(dropdownOffset = DpOffset(it.dp, state.dropdownOffset.y))) },
+            valueRange = -64f..64f,
+        )
+
+        SectionLabel("dropdownOffset.y: ${state.dropdownOffset.y.value.toInt()}dp")
+        Slider(
+            value = state.dropdownOffset.y.value,
+            onValueChange = { onChange(state.copy(dropdownOffset = DpOffset(state.dropdownOffset.x, it.dp))) },
+            valueRange = -64f..64f,
         )
 
         SectionLabel("displayAppName")

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -710,7 +710,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
 
                           {isDropdownOpen && (
                               <ScrollView
-                                  style={[styles.dropdownPanel, { maxHeight: screenHeightRef.current * 0.8 }, isBottom ? { marginTop: 0, marginBottom: 4 } : null]}
+                                  style={[styles.dropdownPanel, { maxHeight: screenHeightRef.current * 0.8 }, isBottom ? { marginTop: 0, marginBottom: 4 } : undefined]}
                                   contentContainerStyle={config.dropdownSource === AzDropdownSource.MENU ? { width: config.expandedRailWidth } : { alignItems: 'center' }}
                               >
                                   {config.dropdownSource === AzDropdownSource.MENU

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -14,8 +14,9 @@ import {
   UIManager,
 } from 'react-native';
 import { AzNavRailContext } from './AzNavRailScope';
-import { AzNavItem, AzNavRailSettings, AzButtonShape, AzDockingSide, AzDropdownSource, AzHeaderIconShape, AzNestedRailAlignment } from './types';
+import { AzNavItem, AzNavRailSettings, AzButtonShape, AzDockingSide, AzDropdownSource, AzDropdownAlignment, AzHeaderIconShape, AzNestedRailAlignment } from './types';
 import { AzNavRailDefaults } from './AzNavRailDefaults';
+import { parseDropdownAnchor } from './dropdownPlacement';
 import { AzButton } from './components/AzButton';
 import { AzToggle } from './components/AzToggle';
 import { AzCycler } from './components/AzCycler';
@@ -67,6 +68,8 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
       noMenu = false,
       dropdownMenu = false,
       dropdownSource = AzDropdownSource.RAIL,
+      dropdownAlignment = AzDropdownAlignment.TOP_START,
+      dropdownOffset,
       headerIconSize,
       infoScreen = false,
       onDismissInfoScreen,
@@ -114,6 +117,8 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
       noMenu: dslOverrides.noMenu ?? noMenu,
       dropdownMenu: dslOverrides.dropdownMenu ?? dropdownMenu,
       dropdownSource: dslOverrides.dropdownSource ?? dropdownSource,
+      dropdownAlignment: dslOverrides.dropdownAlignment ?? dropdownAlignment,
+      dropdownOffset: dslOverrides.dropdownOffset ?? dropdownOffset,
       headerIconSize: dslOverrides.headerIconSize ?? headerIconSize,
       infoScreen: dslOverrides.infoScreen ?? infoScreen,
       activeColor: dslOverrides.activeColor ?? activeColor,
@@ -669,7 +674,15 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
   // expansion, swipes, the footer, nested-rail popups and the help overlay are all bypassed here.
   if (config.dropdownMenu) {
       const iconSize = (config as any).headerIconSize ?? AzNavRailDefaults.HeaderIconSize;
-      const isRight = config.dockingSide === AzDockingSide.RIGHT;
+      // The trigger is a plain hamburger button placed wherever the dev asks (nine anchors + a fine
+      // offset), not a docked strip — the docking side no longer dictates its spot.
+      const { vert, horiz, isBottom } = parseDropdownAnchor(config.dropdownAlignment ?? AzDropdownAlignment.TOP_START);
+      const justifyContent: 'flex-start' | 'center' | 'flex-end' =
+          vert === 'top' ? 'flex-start' : vert === 'bottom' ? 'flex-end' : 'center';
+      const alignItems: 'flex-start' | 'center' | 'flex-end' =
+          horiz === 'start' ? 'flex-start' : horiz === 'end' ? 'flex-end' : 'center';
+      const offsetX = config.dropdownOffset?.x ?? 0;
+      const offsetY = config.dropdownOffset?.y ?? 0;
       return (
           <AzNavRailContext.Provider value={{ register, unregister, updateSettings, getDividerId, hasItem }}>
               <View style={{ flex: 1 }}>
@@ -681,27 +694,31 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                       </TouchableWithoutFeedback>
                   )}
 
-                  <View style={{ position: 'absolute', top: 0, left: isRight ? undefined : 0, right: isRight ? 0 : undefined, padding: AzNavRailDefaults.HeaderPadding, alignItems: isRight ? 'flex-end' : 'flex-start', zIndex: 1000 }}>
-                      <TouchableOpacity
-                          onPress={() => { const o = !isDropdownOpen; setIsDropdownOpen(o); logInteraction('Dropdown trigger tapped', o ? `unfolding ${config.dropdownSource}` : 'folding'); }}
-                          accessibilityRole="button"
-                          accessibilityLabel="Menu"
-                      >
-                          <View style={{ width: iconSize, height: iconSize, backgroundColor: 'gray', borderRadius: getHeaderBorderRadius(), alignItems: 'center', justifyContent: 'center' }}>
-                              <Text style={{ color: 'white' }}>Icon</Text>
-                          </View>
-                      </TouchableOpacity>
-
-                      {isDropdownOpen && (
-                          <ScrollView
-                              style={[styles.dropdownPanel, { maxHeight: screenHeightRef.current * 0.8 }]}
-                              contentContainerStyle={config.dropdownSource === AzDropdownSource.MENU ? { width: config.expandedRailWidth } : { alignItems: 'center' }}
+                  {/* Full-screen, touch-transparent positioning layer: the inner column lands at the
+                      chosen anchor; only the icon/panel actually receive touches. */}
+                  <View pointerEvents="box-none" style={[StyleSheet.absoluteFill, { justifyContent, alignItems, padding: AzNavRailDefaults.HeaderPadding, zIndex: 1000 }]}>
+                      <View style={{ flexDirection: isBottom ? 'column-reverse' : 'column', alignItems, transform: [{ translateX: offsetX }, { translateY: offsetY }] }}>
+                          <TouchableOpacity
+                              onPress={() => { const o = !isDropdownOpen; setIsDropdownOpen(o); logInteraction('Dropdown trigger tapped', o ? `unfolding ${config.dropdownSource}` : 'folding'); }}
+                              accessibilityRole="button"
+                              accessibilityLabel="Menu"
                           >
-                              {config.dropdownSource === AzDropdownSource.MENU
-                                  ? menuItems.map(item => item.isDivider ? <View key={item.id} style={styles.divider} /> : renderMenuItem(item))
-                                  : effectiveRailItems.map((item, index) => renderRailItem(item, index))}
-                          </ScrollView>
-                      )}
+                              <View style={{ width: iconSize, height: iconSize, backgroundColor: 'gray', borderRadius: getHeaderBorderRadius(), alignItems: 'center', justifyContent: 'center' }}>
+                                  <Text style={{ color: 'white' }}>Icon</Text>
+                              </View>
+                          </TouchableOpacity>
+
+                          {isDropdownOpen && (
+                              <ScrollView
+                                  style={[styles.dropdownPanel, { maxHeight: screenHeightRef.current * 0.8 }, isBottom ? { marginTop: 0, marginBottom: 4 } : null]}
+                                  contentContainerStyle={config.dropdownSource === AzDropdownSource.MENU ? { width: config.expandedRailWidth } : { alignItems: 'center' }}
+                              >
+                                  {config.dropdownSource === AzDropdownSource.MENU
+                                      ? menuItems.map(item => item.isDivider ? <View key={item.id} style={styles.divider} /> : renderMenuItem(item))
+                                      : effectiveRailItems.map((item, index) => renderRailItem(item, index))}
+                              </ScrollView>
+                          )}
+                      </View>
                   </View>
 
                   {isLoading && (

--- a/aznavrail-react/src/__tests__/dropdownPlacement.test.ts
+++ b/aznavrail-react/src/__tests__/dropdownPlacement.test.ts
@@ -1,0 +1,32 @@
+import { parseDropdownAnchor } from '../dropdownPlacement';
+import { AzDropdownAlignment } from '../types';
+
+describe('parseDropdownAnchor', () => {
+  it('defaults to top-start when no alignment is given', () => {
+    expect(parseDropdownAnchor()).toEqual({ vert: 'top', horiz: 'start', isBottom: false });
+  });
+
+  it('decomposes each anchor into its bands', () => {
+    expect(parseDropdownAnchor(AzDropdownAlignment.TOP_END)).toEqual({
+      vert: 'top', horiz: 'end', isBottom: false,
+    });
+    expect(parseDropdownAnchor(AzDropdownAlignment.CENTER)).toEqual({
+      vert: 'center', horiz: 'center', isBottom: false,
+    });
+    expect(parseDropdownAnchor(AzDropdownAlignment.CENTER_START)).toEqual({
+      vert: 'center', horiz: 'start', isBottom: false,
+    });
+  });
+
+  it('flags only bottom anchors for upward unfolding', () => {
+    expect(parseDropdownAnchor(AzDropdownAlignment.BOTTOM_START).isBottom).toBe(true);
+    expect(parseDropdownAnchor(AzDropdownAlignment.BOTTOM_CENTER).isBottom).toBe(true);
+    expect(parseDropdownAnchor(AzDropdownAlignment.BOTTOM_END).isBottom).toBe(true);
+    expect(parseDropdownAnchor(AzDropdownAlignment.TOP_START).isBottom).toBe(false);
+    expect(parseDropdownAnchor(AzDropdownAlignment.CENTER_END).isBottom).toBe(false);
+  });
+
+  it('accepts raw string alignment values', () => {
+    expect(parseDropdownAnchor('bottom-end')).toEqual({ vert: 'bottom', horiz: 'end', isBottom: true });
+  });
+});

--- a/aznavrail-react/src/dropdownPlacement.ts
+++ b/aznavrail-react/src/dropdownPlacement.ts
@@ -1,0 +1,25 @@
+import { AzDropdownAlignment } from './types';
+
+/** The vertical band a drop-down anchor sits in. */
+export type DropdownVert = 'top' | 'center' | 'bottom';
+/** The horizontal band a drop-down anchor sits in (start/end are LTR-relative). */
+export type DropdownHoriz = 'start' | 'center' | 'end';
+
+export interface DropdownAnchor {
+  vert: DropdownVert;
+  horiz: DropdownHoriz;
+  /** True when anchored to the bottom — the panel then unfolds upward (above the icon). */
+  isBottom: boolean;
+}
+
+/**
+ * Decomposes an {@link AzDropdownAlignment} (e.g. `'bottom-end'`) into its vertical/horizontal
+ * bands and the unfold direction. Shared by the web and React Native drop-down renderers so both
+ * platforms place the hamburger trigger identically. Defaults to `top-start`.
+ */
+export function parseDropdownAnchor(alignment?: AzDropdownAlignment | string): DropdownAnchor {
+  const a = (alignment || 'top-start') as string;
+  const vert: DropdownVert = a.startsWith('top') ? 'top' : a.startsWith('bottom') ? 'bottom' : 'center';
+  const horiz: DropdownHoriz = a.endsWith('start') ? 'start' : a.endsWith('end') ? 'end' : 'center';
+  return { vert, horiz, isBottom: vert === 'bottom' };
+}

--- a/aznavrail-react/src/types.ts
+++ b/aznavrail-react/src/types.ts
@@ -48,6 +48,24 @@ export enum AzDropdownSource {
   MENU = 'MENU',
 }
 
+/**
+ * Where the drop-down trigger icon is anchored on screen (see `AzNavRailSettings.dropdownAlignment`).
+ * In drop-down mode the icon is a plain hamburger button the dev can place anywhere; these are the
+ * nine standard anchor points. The panel unfolds downward for top/centre anchors and upward for the
+ * bottom anchors, so it always grows away from the nearest screen edge.
+ */
+export enum AzDropdownAlignment {
+  TOP_START = 'top-start',
+  TOP_CENTER = 'top-center',
+  TOP_END = 'top-end',
+  CENTER_START = 'center-start',
+  CENTER = 'center',
+  CENTER_END = 'center-end',
+  BOTTOM_START = 'bottom-start',
+  BOTTOM_CENTER = 'bottom-center',
+  BOTTOM_END = 'bottom-end',
+}
+
 /** General orientation flag used by layout helpers. */
 export enum AzOrientation {
   /** Components arranged in a column. */
@@ -103,6 +121,17 @@ export interface AzNavRailSettings {
    * full drawer rows). Only honoured when `dropdownMenu` is true. Defaults to `RAIL`.
    */
   dropdownSource?: AzDropdownSource;
+  /**
+   * Where the drop-down trigger icon is anchored (one of nine standard positions). The panel
+   * unfolds downward for top/centre anchors and upward for bottom anchors. Only honoured when
+   * `dropdownMenu` is true. Defaults to `top-start`.
+   */
+  dropdownAlignment?: AzDropdownAlignment;
+  /**
+   * A fine nudge (px) applied to the drop-down trigger icon from its `dropdownAlignment` anchor.
+   * Only honoured when `dropdownMenu` is true. Defaults to no offset.
+   */
+  dropdownOffset?: { x?: number; y?: number };
   /** Exact diameter (px) of the app icon in the header. When omitted the icon uses its default size. */
   headerIconSize?: number;
   /** When true, the help/info overlay is displayed over the screen. */

--- a/aznavrail-react/src/web/AzNavRail.css
+++ b/aznavrail-react/src/web/AzNavRail.css
@@ -13,24 +13,17 @@
 }
 
 /* ---- Drop-down menu mode ---- */
-/* The rail is a floating top-anchored trigger; it reserves no width so page content can run
-   edge-to-edge underneath it. */
+/* The rail is a floating, dev-placed trigger; it reserves no width so page content can run
+   edge-to-edge underneath it. The exact anchor (top/bottom/left/right + offset) and unfold
+   direction are supplied inline from `dropdownAlignment`/`dropdownOffset`. */
 .az-nav-rail.dropdown {
   position: fixed;
-  top: 0;
-  left: 0;
+  display: flex;
   height: auto;
   width: auto;
   background-color: transparent;
   border: none;
   z-index: 1000;
-  align-items: flex-start;
-}
-
-.az-nav-rail.dropdown.right {
-  left: auto;
-  right: 0;
-  align-items: flex-end;
 }
 
 /* Full-screen invisible layer that folds the panel back up on an outside click. */

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -412,8 +412,8 @@ const AzNavRail = ({
       // The trigger is a plain hamburger button placed wherever the dev asks (nine anchors + a fine
       // offset), not a docked strip — the docking side no longer dictates its spot.
       const { vert, horiz, isBottom } = parseDropdownAnchor(dropdownAlignment);
-      const offX = (dropdownOffset && dropdownOffset.x) || 0;
-      const offY = (dropdownOffset && dropdownOffset.y) || 0;
+      const offX = dropdownOffset?.x ?? 0;
+      const offY = dropdownOffset?.y ?? 0;
       const txCenter = horiz === 'center' ? '-50%' : '0px';
       const tyCenter = vert === 'center' ? '-50%' : '0px';
       const placementStyle = {

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -9,6 +9,7 @@ import AzDivider from './AzDivider';
 import AzTextBox from './AzTextBox';
 import AboutOverlay from './AboutOverlay';
 import MoreFromAzOverlay from './MoreFromAzOverlay';
+import { parseDropdownAnchor } from '../dropdownPlacement';
 
 /**
  * An M3-style navigation rail that expands into a menu drawer for web applications.
@@ -38,6 +39,8 @@ const AzNavRail = ({
     noMenu = false,
     dropdownMenu = false,
     dropdownSource = 'RAIL',
+    dropdownAlignment = 'top-start',
+    dropdownOffset,
     headerIconSize,
     activeClassifiers = new Set(), // Set of strings
     activeColor,
@@ -406,6 +409,23 @@ const AzNavRail = ({
 
   if (dropdownMenu) {
       const iconStyle = headerIconSize ? { width: headerIconSize, height: headerIconSize } : undefined;
+      // The trigger is a plain hamburger button placed wherever the dev asks (nine anchors + a fine
+      // offset), not a docked strip — the docking side no longer dictates its spot.
+      const { vert, horiz, isBottom } = parseDropdownAnchor(dropdownAlignment);
+      const offX = (dropdownOffset && dropdownOffset.x) || 0;
+      const offY = (dropdownOffset && dropdownOffset.y) || 0;
+      const txCenter = horiz === 'center' ? '-50%' : '0px';
+      const tyCenter = vert === 'center' ? '-50%' : '0px';
+      const placementStyle = {
+          top: vert === 'bottom' ? 'auto' : vert === 'center' ? '50%' : 0,
+          bottom: vert === 'bottom' ? 0 : 'auto',
+          left: horiz === 'end' ? 'auto' : horiz === 'center' ? '50%' : 0,
+          right: horiz === 'end' ? 0 : 'auto',
+          alignItems: horiz === 'end' ? 'flex-end' : horiz === 'center' ? 'center' : 'flex-start',
+          flexDirection: isBottom ? 'column-reverse' : 'column',
+          transform: `translate(calc(${txCenter} + ${offX}px), calc(${tyCenter} + ${offY}px))`,
+      };
+      const panelBaseStyle = isBottom ? { marginTop: 0, marginBottom: 4 } : {};
       return (
           <>
               {isDropdownOpen && (
@@ -414,14 +434,16 @@ const AzNavRail = ({
                       onClick={() => setIsDropdownOpen(false)}
                   />
               )}
-              <div className={`az-nav-rail dropdown ${dockingSide === 'RIGHT' ? 'right' : ''} ${isDropdownOpen ? 'open' : ''}`}>
+              <div className={`az-nav-rail dropdown ${isDropdownOpen ? 'open' : ''}`} style={placementStyle}>
                   <div className="header" onClick={() => setIsDropdownOpen(o => !o)}>
                       <img src="/app-icon.png" alt="Menu" className={getHeaderIconClass()} style={iconStyle} />
                   </div>
                   {isDropdownOpen && (
                       <div
                           className={`az-dropdown-panel ${dropdownSource === 'MENU' ? 'menu' : 'rail'} ${packRailButtons ? 'packed' : ''}`}
-                          style={dropdownSource === 'MENU' ? { width: expandedRailWidth, backgroundColor: translucentBackground || undefined } : { backgroundColor: translucentBackground || undefined }}
+                          style={dropdownSource === 'MENU'
+                              ? { ...panelBaseStyle, width: expandedRailWidth, backgroundColor: translucentBackground || undefined }
+                              : { ...panelBaseStyle, backgroundColor: translucentBackground || undefined }}
                       >
                           {dropdownSource === 'MENU'
                               ? menuItems.map(item => renderMenuItem(item))

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavHost.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavHost.kt
@@ -360,13 +360,17 @@ fun AzHostActivityLayout(
             Box(modifier = Modifier.fillMaxSize()) { item.content() }
         }
 
-        // In drop-down mode the rail is a floating top-anchored trigger, not a docked side-strip,
-        // so it reserves no horizontal/vertical band: onscreen content spans the full screen width.
+        // In drop-down mode the rail is a floating, dev-placed trigger, not a docked side-strip, so
+        // it reserves no horizontal/vertical band: onscreen content spans the full screen width. It
+        // also reserves NO top/bottom content safe zones — the icon is a plain hamburger button, so
+        // content runs edge-to-edge and the dev is free to place the trigger over it.
         val isDropdown = railScope.dropdownMenu
         val startPadding = if (!isDropdown && visualSide == AzVisualSide.LEFT) railWidth else 0.dp
         val endPadding = if (!isDropdown && visualSide == AzVisualSide.RIGHT) railWidth else 0.dp
         val topPadding = if (!isDropdown && visualSide == AzVisualSide.TOP) railWidth else 0.dp
         val bottomPadding = if (!isDropdown && visualSide == AzVisualSide.BOTTOM) railWidth else 0.dp
+        val effectiveSafeTop = if (isDropdown) 0.dp else safeTop
+        val effectiveSafeBottom = if (isDropdown) 0.dp else safeBottom
 
         // Identify active item and pull actual transient states
         val railScopeImpl = scope.getRailScopeImpl()
@@ -414,8 +418,8 @@ fun AzHostActivityLayout(
             LocalAzTutorialController provides tutorialController
         ) {
             AzHostFragmentLayout(
-                safeTop = safeTop,
-                safeBottom = safeBottom,
+                safeTop = effectiveSafeTop,
+                safeBottom = effectiveSafeBottom,
                 startPadding = startPadding,
                 endPadding = endPadding,
                 topPadding = topPadding,
@@ -427,7 +431,7 @@ fun AzHostActivityLayout(
 
         CompositionLocalProvider(
             LocalAzNavHostPresent provides true,
-            LocalAzSafeZones provides AzSafeZones(safeTop, safeBottom),
+            LocalAzSafeZones provides AzSafeZones(effectiveSafeTop, effectiveSafeBottom),
             LocalAzTutorialController provides tutorialController
         ) {
             AzNavRail(

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -80,6 +80,7 @@ import com.hereliesaz.aznavrail.internal.MenuItem
 import com.hereliesaz.aznavrail.internal.RailItems
 import com.hereliesaz.aznavrail.internal.SecretScreens
 import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzDropdownAlignment
 import com.hereliesaz.aznavrail.model.AzDropdownSource
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzNavItem
@@ -375,7 +376,13 @@ fun AzNavRail(
     // screen by AzHostActivityLayout (it zeroes the rail-offset padding in this mode).
     if (scope.dropdownMenu) {
         var isDropdownOpen by remember { mutableStateOf(false) }
-        val dropAlignment = if (visualDockingSide == AzDockingSide.RIGHT) Alignment.TopEnd else Alignment.TopStart
+        // The trigger icon is placed wherever the dev asks (nine anchors + a fine offset) — it is a
+        // plain hamburger button, not a docked strip, so the docking side no longer dictates its spot.
+        val dropAlignment = scope.dropdownAlignment.toAlignment()
+        val dropHorizontalAlignment = scope.dropdownAlignment.toHorizontalAlignment()
+        // Bottom-anchored triggers unfold the panel upward (panel above the icon) so it grows away
+        // from the bottom edge; every other anchor unfolds downward as before.
+        val unfoldUpward = scope.dropdownAlignment.isBottom
         val iconDiameter = if (scope.headerIconSize != androidx.compose.ui.unit.Dp.Unspecified) {
             scope.headerIconSize
         } else {
@@ -407,6 +414,68 @@ fun AzNavRail(
             }
         }
 
+        // The unfolded set — exactly one of the two renderings. Extracted so it can be ordered above
+        // or below the trigger icon depending on whether the anchor unfolds upward or downward.
+        val dropdownPanel: @Composable () -> Unit = {
+            Surface(
+                color = if (scope.translucentBackground != Color.Unspecified) scope.translucentBackground else MaterialTheme.colorScheme.surface,
+                shape = RoundedCornerShape(12.dp),
+                tonalElevation = 2.dp,
+                shadowElevation = 8.dp
+            ) {
+                val dropScroll = rememberScrollState()
+                if (scope.dropdownSource == AzDropdownSource.MENU) {
+                    Column(
+                        modifier = Modifier
+                            .width(scope.expandedWidth)
+                            .heightIn(max = maxPanelHeight)
+                            .verticalScroll(dropScroll)
+                    ) {
+                        scope.navItems.forEach { item ->
+                            if (!item.isSubItem) {
+                                MenuItemNode(
+                                    item = item,
+                                    allItems = scope.navItems,
+                                    navController = effectiveNavController,
+                                    currentDestination = actualCurrentDestination,
+                                    scope = scope,
+                                    hostStates = hostStates,
+                                    showHelpOverlay = false,
+                                    onToggleHelp = { },
+                                    onCollapseMenu = { isDropdownOpen = false }
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    Column(
+                        modifier = Modifier
+                            .heightIn(max = maxPanelHeight)
+                            .verticalScroll(dropScroll),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        RailItems(
+                            items = scope.navItems,
+                            scope = scope,
+                            navController = effectiveNavController,
+                            currentDestination = actualCurrentDestination,
+                            buttonSize = activeButtonSize,
+                            onRailCyclerClick = onDropdownCyclerClick,
+                            onItemSelected = { item ->
+                                if (item.collapseOnClick) isDropdownOpen = false
+                            },
+                            hostStates = hostStates,
+                            packRailButtons = true,
+                            visualDockingSide = visualDockingSide,
+                            onItemGloballyPositioned = null,
+                            helpEnabled = false,
+                            rotationDegrees = rotationDegrees
+                        )
+                    }
+                }
+            }
+        }
+
         Box(modifier = modifier.fillMaxSize()) {
             // Tap anywhere outside the open dropdown to fold it back up.
             if (isDropdownOpen) {
@@ -425,9 +494,15 @@ fun AzNavRail(
             Column(
                 modifier = Modifier
                     .align(dropAlignment)
+                    .offset(x = scope.dropdownOffset.x, y = scope.dropdownOffset.y)
                     .padding(AzNavRailDefaults.HeaderPadding),
-                horizontalAlignment = if (visualDockingSide == AzDockingSide.RIGHT) Alignment.End else Alignment.Start
+                horizontalAlignment = dropHorizontalAlignment
             ) {
+                // Bottom anchors render the panel above the icon so it unfolds upward.
+                if (unfoldUpward && isDropdownOpen) {
+                    dropdownPanel()
+                }
+
                 // App icon == hamburger trigger.
                 Box(
                     modifier = Modifier
@@ -461,65 +536,9 @@ fun AzNavRail(
                     }
                 }
 
-                // The unfolded set — exactly one of the two renderings.
-                if (isDropdownOpen) {
-                    Surface(
-                        color = if (scope.translucentBackground != Color.Unspecified) scope.translucentBackground else MaterialTheme.colorScheme.surface,
-                        shape = RoundedCornerShape(12.dp),
-                        tonalElevation = 2.dp,
-                        shadowElevation = 8.dp
-                    ) {
-                        val dropScroll = rememberScrollState()
-                        if (scope.dropdownSource == AzDropdownSource.MENU) {
-                            Column(
-                                modifier = Modifier
-                                    .width(scope.expandedWidth)
-                                    .heightIn(max = maxPanelHeight)
-                                    .verticalScroll(dropScroll)
-                            ) {
-                                scope.navItems.forEach { item ->
-                                    if (!item.isSubItem) {
-                                        MenuItemNode(
-                                            item = item,
-                                            allItems = scope.navItems,
-                                            navController = effectiveNavController,
-                                            currentDestination = actualCurrentDestination,
-                                            scope = scope,
-                                            hostStates = hostStates,
-                                            showHelpOverlay = false,
-                                            onToggleHelp = { },
-                                            onCollapseMenu = { isDropdownOpen = false }
-                                        )
-                                    }
-                                }
-                            }
-                        } else {
-                            Column(
-                                modifier = Modifier
-                                    .heightIn(max = maxPanelHeight)
-                                    .verticalScroll(dropScroll),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                RailItems(
-                                    items = scope.navItems,
-                                    scope = scope,
-                                    navController = effectiveNavController,
-                                    currentDestination = actualCurrentDestination,
-                                    buttonSize = activeButtonSize,
-                                    onRailCyclerClick = onDropdownCyclerClick,
-                                    onItemSelected = { item ->
-                                        if (item.collapseOnClick) isDropdownOpen = false
-                                    },
-                                    hostStates = hostStates,
-                                    packRailButtons = true,
-                                    visualDockingSide = visualDockingSide,
-                                    onItemGloballyPositioned = null,
-                                    helpEnabled = false,
-                                    rotationDegrees = rotationDegrees
-                                )
-                            }
-                        }
-                    }
+                // Top/centre anchors render the panel below the icon so it unfolds downward.
+                if (!unfoldUpward && isDropdownOpen) {
+                    dropdownPanel()
                 }
             }
         }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -418,7 +418,7 @@ fun AzNavRail(
         // or below the trigger icon depending on whether the anchor unfolds upward or downward.
         val dropdownPanel: @Composable () -> Unit = {
             Surface(
-                color = if (scope.translucentBackground != Color.Unspecified) scope.translucentBackground else MaterialTheme.colorScheme.surface,
+                color = scope.translucentBackground.takeOrElse { MaterialTheme.colorScheme.surface },
                 shape = RoundedCornerShape(12.dp),
                 tonalElevation = 2.dp,
                 shadowElevation = 8.dp

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -8,12 +8,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
 import com.hereliesaz.aznavrail.model.AzAdvancedConfig
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzDropdownAlignment
 import com.hereliesaz.aznavrail.model.AzDropdownSource
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzItemConfig
@@ -67,16 +69,23 @@ interface AzNavRailScope {
      * @param collapsedWidth The width of the rail when collapsed.
      * @param showFooter Whether to show the footer (Privacy, Terms, Help) in the menu.
      * @param appRepositoryUrl The URL of the application's repository to link to in the footer's "About" section. Defaults to the AzNavRail repo.
-     * @param dropdownMenu If true, the rail collapses to a single app-icon trigger anchored at the top
-     *   (the icon replaces the hamburger) and unfolds [dropdownSource] downward like an accordion when
-     *   tapped. `onscreen` content is given the full screen width. This mode runs at the explicit
-     *   exclusion of FAB/dragging, rail-to-menu expansion, swipe gestures, physical docking, the
-     *   footer, nested-rail popups, the bleeding app-name header, and the help overlay.
+     * @param dropdownMenu If true, the rail collapses to a single app-icon trigger placed at
+     *   [dropdownAlignment] (the icon replaces the hamburger) and unfolds [dropdownSource] like an
+     *   accordion when tapped. `onscreen` content is given the full screen — drop-down mode reserves
+     *   **no** top/bottom content safe zones, so the icon behaves like a plain hamburger button you
+     *   can drop anywhere. This mode runs at the explicit exclusion of FAB/dragging, rail-to-menu
+     *   expansion, swipe gestures, physical docking, the footer, nested-rail popups, the bleeding
+     *   app-name header, and the help overlay.
      * @param dropdownSource Which set of items the drop-down reveals — [AzDropdownSource.RAIL] (the
      *   packed rail buttons) or [AzDropdownSource.MENU] (the full drawer rows). Only honoured when
      *   [dropdownMenu] is true.
+     * @param dropdownAlignment Where the drop-down trigger icon is anchored on screen (one of nine
+     *   standard positions). The panel unfolds downward for top/centre anchors and upward for bottom
+     *   anchors. Only honoured when [dropdownMenu] is true. Defaults to [AzDropdownAlignment.TOP_START].
+     * @param dropdownOffset A fine nudge applied to the trigger icon from its [dropdownAlignment]
+     *   anchor. Only honoured when [dropdownMenu] is true. Defaults to no offset.
      */
-    fun azConfig(dockingSide: AzDockingSide = AzDockingSide.LEFT, packButtons: Boolean = false, noMenu: Boolean = false, vibrate: Boolean = false, displayAppName: Boolean = false, activeClassifiers: Set<String> = emptySet(), usePhysicalDocking: Boolean = false, expandedWidth: Dp = 160.dp, collapsedWidth: Dp = 100.dp, showFooter: Boolean = true, appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail", dropdownMenu: Boolean = false, dropdownSource: AzDropdownSource = AzDropdownSource.RAIL)
+    fun azConfig(dockingSide: AzDockingSide = AzDockingSide.LEFT, packButtons: Boolean = false, noMenu: Boolean = false, vibrate: Boolean = false, displayAppName: Boolean = false, activeClassifiers: Set<String> = emptySet(), usePhysicalDocking: Boolean = false, expandedWidth: Dp = 160.dp, collapsedWidth: Dp = 100.dp, showFooter: Boolean = true, appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail", dropdownMenu: Boolean = false, dropdownSource: AzDropdownSource = AzDropdownSource.RAIL, dropdownAlignment: AzDropdownAlignment = AzDropdownAlignment.TOP_START, dropdownOffset: DpOffset = DpOffset.Zero)
 
     /**
      * Configures the visual theme of the rail.
@@ -164,7 +173,9 @@ interface AzNavRailScope {
         helpLineColors: List<Color> = emptyList(),
         onInteraction: ((String, com.hereliesaz.aznavrail.model.AzNavItem) -> Unit)? = null,
         dropdownMenu: Boolean = false,
-        dropdownSource: AzDropdownSource = AzDropdownSource.RAIL
+        dropdownSource: AzDropdownSource = AzDropdownSource.RAIL,
+        dropdownAlignment: AzDropdownAlignment = AzDropdownAlignment.TOP_START,
+        dropdownOffset: DpOffset = DpOffset.Zero
     )
 
     /**
@@ -652,6 +663,10 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     var dropdownMenu: Boolean = false
     /** Which item set the drop-down reveals when [dropdownMenu] is true. */
     var dropdownSource: AzDropdownSource = AzDropdownSource.RAIL
+    /** Where the drop-down trigger icon is anchored when [dropdownMenu] is true. */
+    var dropdownAlignment: AzDropdownAlignment = AzDropdownAlignment.TOP_START
+    /** Fine nudge applied to the drop-down trigger icon from its [dropdownAlignment] anchor. */
+    var dropdownOffset: DpOffset = DpOffset.Zero
     /** If true, haptic feedback is triggered on header tap and drag events. */
     var vibrate: Boolean = false
     /** If true, the header area shows the app name instead of the app icon. */
@@ -683,7 +698,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     var advancedConfig: AzAdvancedConfig = AzAdvancedConfig()
 
 
-    override fun azConfig(dockingSide: AzDockingSide, packButtons: Boolean, noMenu: Boolean, vibrate: Boolean, displayAppName: Boolean, activeClassifiers: Set<String>, usePhysicalDocking: Boolean, expandedWidth: Dp, collapsedWidth: Dp, showFooter: Boolean, appRepositoryUrl: String, dropdownMenu: Boolean, dropdownSource: AzDropdownSource) {
+    override fun azConfig(dockingSide: AzDockingSide, packButtons: Boolean, noMenu: Boolean, vibrate: Boolean, displayAppName: Boolean, activeClassifiers: Set<String>, usePhysicalDocking: Boolean, expandedWidth: Dp, collapsedWidth: Dp, showFooter: Boolean, appRepositoryUrl: String, dropdownMenu: Boolean, dropdownSource: AzDropdownSource, dropdownAlignment: AzDropdownAlignment, dropdownOffset: DpOffset) {
         this.dockingSide = dockingSide
         this.packButtons = packButtons
         this.noMenu = noMenu
@@ -697,6 +712,8 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         this.appRepositoryUrl = appRepositoryUrl
         this.dropdownMenu = dropdownMenu
         this.dropdownSource = dropdownSource
+        this.dropdownAlignment = dropdownAlignment
+        this.dropdownOffset = dropdownOffset
     }
 
     override fun azAbout(inAppAbout: Boolean, moreFromAzEnabled: Boolean, moreFromAzJsonUrl: String, moreRailItem: Boolean) {
@@ -765,12 +782,16 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         helpLineColors: List<Color>,
         onInteraction: ((String, AzNavItem) -> Unit)?,
         dropdownMenu: Boolean,
-        dropdownSource: AzDropdownSource
+        dropdownSource: AzDropdownSource,
+        dropdownAlignment: AzDropdownAlignment,
+        dropdownOffset: DpOffset
     ) {
         // Map to internal properties
         this.displayAppName = displayAppNameInHeader
         this.dropdownMenu = dropdownMenu
         this.dropdownSource = dropdownSource
+        this.dropdownAlignment = dropdownAlignment
+        this.dropdownOffset = dropdownOffset
         this.packButtons = packRailButtons
         this.expandedWidth = expandedRailWidth
         this.collapsedWidth = collapsedRailWidth

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzDropdownAlignment.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzDropdownAlignment.kt
@@ -1,0 +1,52 @@
+package com.hereliesaz.aznavrail.model
+
+import androidx.compose.ui.Alignment
+
+/**
+ * Where the drop-down menu's trigger icon is anchored on screen
+ * (see [com.hereliesaz.aznavrail.AzNavRailScope.azConfig]'s `dropdownMenu` flag).
+ *
+ * In drop-down mode the rail is **not** a docked side-strip — it is a single hamburger-style icon
+ * the developer can place anywhere, exactly like a plain menu button. This enum names the nine
+ * standard anchor points; a fine `dropdownOffset` (a [androidx.compose.ui.unit.DpOffset]) nudges
+ * the icon from that anchor. The unfolded panel opens **downward** for top/centre anchors and
+ * **upward** for the bottom anchors, so it always grows away from the nearest screen edge.
+ */
+enum class AzDropdownAlignment {
+    TOP_START,
+    TOP_CENTER,
+    TOP_END,
+    CENTER_START,
+    CENTER,
+    CENTER_END,
+    BOTTOM_START,
+    BOTTOM_CENTER,
+    BOTTOM_END;
+
+    /** The Compose [Alignment] this anchor maps to within the full-screen drop-down container. */
+    fun toAlignment(): Alignment = when (this) {
+        TOP_START -> Alignment.TopStart
+        TOP_CENTER -> Alignment.TopCenter
+        TOP_END -> Alignment.TopEnd
+        CENTER_START -> Alignment.CenterStart
+        CENTER -> Alignment.Center
+        CENTER_END -> Alignment.CenterEnd
+        BOTTOM_START -> Alignment.BottomStart
+        BOTTOM_CENTER -> Alignment.BottomCenter
+        BOTTOM_END -> Alignment.BottomEnd
+    }
+
+    /** Horizontal alignment for the trigger/panel column derived from the anchor. */
+    fun toHorizontalAlignment(): Alignment.Horizontal = when (this) {
+        TOP_START, CENTER_START, BOTTOM_START -> Alignment.Start
+        TOP_CENTER, CENTER, BOTTOM_CENTER -> Alignment.CenterHorizontally
+        TOP_END, CENTER_END, BOTTOM_END -> Alignment.End
+    }
+
+    /**
+     * True when the icon is anchored to the bottom of the screen, in which case the unfolded panel
+     * is rendered **above** the icon so it opens upward (away from the bottom edge).
+     */
+    val isBottom: Boolean
+        get() = this == BOTTOM_START || this == BOTTOM_CENTER || this == BOTTOM_END
+}

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzDropdownAlignmentTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzDropdownAlignmentTest.kt
@@ -1,0 +1,48 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.ui.Alignment
+import com.hereliesaz.aznavrail.model.AzDropdownAlignment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure mapping checks for [AzDropdownAlignment] — no Compose runtime, just the enum→alignment and
+ * unfold-direction helpers that drive drop-down placement.
+ */
+class AzDropdownAlignmentTest {
+
+    @Test
+    fun `toAlignment maps every anchor to the matching Compose alignment`() {
+        assertEquals(Alignment.TopStart, AzDropdownAlignment.TOP_START.toAlignment())
+        assertEquals(Alignment.TopCenter, AzDropdownAlignment.TOP_CENTER.toAlignment())
+        assertEquals(Alignment.TopEnd, AzDropdownAlignment.TOP_END.toAlignment())
+        assertEquals(Alignment.CenterStart, AzDropdownAlignment.CENTER_START.toAlignment())
+        assertEquals(Alignment.Center, AzDropdownAlignment.CENTER.toAlignment())
+        assertEquals(Alignment.CenterEnd, AzDropdownAlignment.CENTER_END.toAlignment())
+        assertEquals(Alignment.BottomStart, AzDropdownAlignment.BOTTOM_START.toAlignment())
+        assertEquals(Alignment.BottomCenter, AzDropdownAlignment.BOTTOM_CENTER.toAlignment())
+        assertEquals(Alignment.BottomEnd, AzDropdownAlignment.BOTTOM_END.toAlignment())
+    }
+
+    @Test
+    fun `horizontal alignment follows the start-center-end column`() {
+        assertEquals(Alignment.Start, AzDropdownAlignment.TOP_START.toHorizontalAlignment())
+        assertEquals(Alignment.Start, AzDropdownAlignment.BOTTOM_START.toHorizontalAlignment())
+        assertEquals(Alignment.CenterHorizontally, AzDropdownAlignment.CENTER.toHorizontalAlignment())
+        assertEquals(Alignment.CenterHorizontally, AzDropdownAlignment.TOP_CENTER.toHorizontalAlignment())
+        assertEquals(Alignment.End, AzDropdownAlignment.TOP_END.toHorizontalAlignment())
+        assertEquals(Alignment.End, AzDropdownAlignment.CENTER_END.toHorizontalAlignment())
+    }
+
+    @Test
+    fun `only bottom anchors unfold upward`() {
+        assertTrue(AzDropdownAlignment.BOTTOM_START.isBottom)
+        assertTrue(AzDropdownAlignment.BOTTOM_CENTER.isBottom)
+        assertTrue(AzDropdownAlignment.BOTTOM_END.isBottom)
+        assertFalse(AzDropdownAlignment.TOP_START.isBottom)
+        assertFalse(AzDropdownAlignment.CENTER.isBottom)
+        assertFalse(AzDropdownAlignment.CENTER_END.isBottom)
+    }
+}

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailScopeTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzNavRailScopeTest.kt
@@ -2,9 +2,11 @@ package com.hereliesaz.aznavrail
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzDropdownAlignment
 import com.hereliesaz.aznavrail.model.AzDropdownSource
 import com.hereliesaz.aznavrail.model.AzNestedRailAlignment
 import org.junit.Assert.assertEquals
@@ -54,7 +56,33 @@ class AzNavRailScopeTest {
     fun `dropdownMenu defaults are off`() {
         assertEquals(false, scope.dropdownMenu)
         assertEquals(AzDropdownSource.RAIL, scope.dropdownSource)
+        assertEquals(AzDropdownAlignment.TOP_START, scope.dropdownAlignment)
+        assertEquals(DpOffset.Zero, scope.dropdownOffset)
         assertEquals(Dp.Unspecified, scope.headerIconSize)
+    }
+
+    @Test
+    fun `azConfig sets dropdown alignment and offset`() {
+        scope.azConfig(
+            dropdownMenu = true,
+            dropdownAlignment = AzDropdownAlignment.BOTTOM_END,
+            dropdownOffset = DpOffset(8.dp, (-12).dp)
+        )
+
+        assertEquals(AzDropdownAlignment.BOTTOM_END, scope.dropdownAlignment)
+        assertEquals(DpOffset(8.dp, (-12).dp), scope.dropdownOffset)
+    }
+
+    @Test
+    fun `azSettings sets dropdown alignment and offset`() {
+        scope.azSettings(
+            dropdownMenu = true,
+            dropdownAlignment = AzDropdownAlignment.TOP_END,
+            dropdownOffset = DpOffset(4.dp, 4.dp)
+        )
+
+        assertEquals(AzDropdownAlignment.TOP_END, scope.dropdownAlignment)
+        assertEquals(DpOffset(4.dp, 4.dp), scope.dropdownOffset)
     }
 
     @Test

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -27,15 +27,24 @@ fun azConfig(
     showFooter: Boolean = true,
     appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail",
     dropdownMenu: Boolean = false,
-    dropdownSource: AzDropdownSource = AzDropdownSource.RAIL
+    dropdownSource: AzDropdownSource = AzDropdownSource.RAIL,
+    dropdownAlignment: AzDropdownAlignment = AzDropdownAlignment.TOP_START,
+    dropdownOffset: DpOffset = DpOffset.Zero
 )
 ~~~
 
-`dropdownMenu` turns the rail into a top-anchored drop-down: the app icon replaces the hamburger and
-tapping it unfolds `dropdownSource` (`RAIL` = packed rail buttons, `MENU` = full drawer rows) like an
-accordion, while `onscreen` content spans the full screen width. This mode excludes FAB/dragging,
-rail↔menu expansion, `noMenu`, swipe gestures, physical docking, the footer, nested-rail popups, the
-bleeding app-name header, and the help overlay. See the README's "Drop-down Menu Mode" section.
+`dropdownMenu` turns the rail into a drop-down whose trigger behaves like a plain hamburger button:
+the app icon replaces the hamburger and tapping it unfolds `dropdownSource` (`RAIL` = packed rail
+buttons, `MENU` = full drawer rows) like an accordion. `onscreen` content spans the **full screen** —
+drop-down mode reserves **no** top/bottom content safe zones, so content runs edge-to-edge and the
+trigger floats over it. This mode excludes FAB/dragging, rail↔menu expansion, `noMenu`, swipe
+gestures, physical docking, the footer, nested-rail popups, the bleeding app-name header, and the
+help overlay.
+
+`dropdownAlignment` places the trigger icon at one of nine standard anchors (`TOP_START` … `BOTTOM_END`);
+`dropdownOffset` is a fine `DpOffset` nudge from that anchor. The panel unfolds downward for
+top/centre anchors and upward for bottom anchors, so it always grows away from the nearest edge. See
+the README's "Drop-down Menu Mode" section.
 
 ### `azTheme`
 Controls the visual style of the rail.

--- a/sample-pwa/src/App.tsx
+++ b/sample-pwa/src/App.tsx
@@ -6,6 +6,7 @@ import {
   AzAlignment,
   AzButtonShape,
   AzDockingSide,
+  AzDropdownAlignment,
   AzDropdownSource,
   AzHeaderIconShape,
   AzNestedRailAlignment,
@@ -74,6 +75,9 @@ function App() {
     headerIconSize: 0,
     dropdownMenu: false,
     dropdownSource: AzDropdownSource.RAIL,
+    dropdownAlignment: AzDropdownAlignment.TOP_START,
+    dropdownOffsetX: 0,
+    dropdownOffsetY: 0,
   })
 
   const themeColor = '#6200EE'
@@ -101,6 +105,8 @@ function App() {
       headerIconSize={customization.headerIconSize || undefined}
       dropdownMenu={customization.dropdownMenu}
       dropdownSource={customization.dropdownSource}
+      dropdownAlignment={customization.dropdownAlignment}
+      dropdownOffset={{ x: customization.dropdownOffsetX, y: customization.dropdownOffsetY }}
       inAppAbout
       moreFromAzEnabled
       moreRailItem

--- a/sample-pwa/src/screens/CustomizationDemo.tsx
+++ b/sample-pwa/src/screens/CustomizationDemo.tsx
@@ -1,5 +1,6 @@
 import {
   AzButtonShape,
+  AzDropdownAlignment,
   AzDropdownSource,
   AzHeaderIconShape,
 } from '@HereLiesAz/aznavrail-react'
@@ -17,11 +18,15 @@ export interface CustomizationState {
   headerIconSize: number
   dropdownMenu: boolean
   dropdownSource: AzDropdownSource
+  dropdownAlignment: AzDropdownAlignment
+  dropdownOffsetX: number
+  dropdownOffsetY: number
 }
 
 const headerShapes = Object.values(AzHeaderIconShape) as AzHeaderIconShape[]
 const buttonShapes = Object.values(AzButtonShape) as AzButtonShape[]
 const dropdownSources = Object.values(AzDropdownSource) as AzDropdownSource[]
+const dropdownAlignments = Object.values(AzDropdownAlignment) as AzDropdownAlignment[]
 const repoChoices: { label: string; url: string }[] = [
   { label: 'AzNavRail', url: 'https://github.com/HereLiesAz/AzNavRail' },
   { label: 'Anthropic', url: 'https://github.com/anthropics' },
@@ -96,6 +101,29 @@ export default function CustomizationDemo({
         >
           {dropdownSources.map((s) => <option key={s} value={s}>{s}</option>)}
         </select>
+      </Block>
+
+      <Block label={`dropdownAlignment: ${state.dropdownAlignment} (where the hamburger sits — only in dropdown mode)`}>
+        <select
+          value={state.dropdownAlignment}
+          onChange={(e) => onChange({ ...state, dropdownAlignment: e.target.value as AzDropdownAlignment })}
+        >
+          {dropdownAlignments.map((s) => <option key={s} value={s}>{s}</option>)}
+        </select>
+      </Block>
+
+      <Block label={`dropdownOffset.x: ${state.dropdownOffsetX}px`}>
+        <input
+          type="range" min={-64} max={64} value={state.dropdownOffsetX}
+          onChange={(e) => onChange({ ...state, dropdownOffsetX: Number(e.target.value) })}
+        />
+      </Block>
+
+      <Block label={`dropdownOffset.y: ${state.dropdownOffsetY}px`}>
+        <input
+          type="range" min={-64} max={64} value={state.dropdownOffsetY}
+          onChange={(e) => onChange({ ...state, dropdownOffsetY: Number(e.target.value) })}
+        />
       </Block>
 
       <Toggle


### PR DESCRIPTION
## What & why

Drop-down menu mode (`dropdownMenu = true`) was built by reusing the docked-rail machinery: the trigger icon was hard-anchored to the top corner (from the docking side) and `AzNavHost` still reserved the top/bottom **content safe zones** (~20% / 10%) even though nothing is docked there.

That's wrong for a drop-down — it should behave like a plain hamburger button the dev can drop anywhere. Per the request:

1. **No reserved safe zones** in drop-down mode — `onscreen` content runs the full screen, edge-to-edge.
2. **Dev-chosen placement** — alignment + offset.

## Changes

**Android (`aznavrail`)**
- `AzNavHost.kt`: when `isDropdown`, `effectiveSafeTop`/`effectiveSafeBottom` are zeroed and fed to both `AzHostFragmentLayout` and `LocalAzSafeZones` — content is fully edge-to-edge.
- New `AzDropdownAlignment` enum (nine anchors `TOP_START`…`BOTTOM_END`) with `toAlignment()` / `toHorizontalAlignment()` / `isBottom` helpers.
- New `dropdownAlignment` (default `TOP_START`) + `dropdownOffset` (`DpOffset`) params on `azConfig`/`azSettings` (+ `AzNavRailScopeImpl` fields).
- `AzNavRail.kt`: the drop-down trigger is placed from the configured alignment + offset; the panel unfolds **downward** for top/centre anchors and **upward** for bottom anchors (rendered above the icon).

**React (`aznavrail-react`)**
- `AzDropdownAlignment` string enum + `dropdownAlignment`/`dropdownOffset` settings.
- Shared pure helper `parseDropdownAnchor` drives placement on both RN (absolute positioning + `column-reverse` for bottom) and web (inline `top/bottom/left/right` + `transform` translate; CSS no longer hardcodes `top:0; left:0`).

**Samples & docs**
- `sample-pwa` and Android `SampleApp` Customization demos get alignment + offset controls.
- `README.md`, `docs/DSL.md`, `AGENTS.md` updated.

## Tests
- Android: `AzDropdownAlignmentTest` (pure mapper) + extended `AzNavRailScopeTest`.
- React: `dropdownPlacement.test.ts` (passes); package `tsc --noEmit` clean.
- Android unit tests / assemble run in CI (no Android SDK in this environment).

Default (`TOP_START`, zero offset) reproduces prior behaviour aside from the intended edge-to-edge content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV

---
_Generated by [Claude Code](https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV)_