### PR TITLE
feat(dropdown): make the app-icon trigger's shape and size configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,17 +149,18 @@ that width and height.
 
 Drop-down menu (`AzDropdownMenu`): a standalone widget declared with the **same opinionated DSL as the
 rail**. In AzNavRail tradition it accepts only sanctioned config — it does **not** expose arbitrary
-icon styling, panel background, offsets, `menuWidth`, or a free `azCustom` escape hatch. The trigger is
-the **app icon** (auto-drawn exactly like the rail's header — `getApplicationIcon` on Android, gray
-placeholder on RN, `/app-icon.png` on web — not customizable), placed inline; only the dropped list is
-an overlay.
+icon tint/source, panel background, offsets, `menuWidth`, or a free `azCustom` escape hatch. The
+trigger is the **app icon** (auto-drawn exactly like the rail's header — `getApplicationIcon` on
+Android, gray placeholder on RN, `/app-icon.png` on web), placed inline; its shape/size are
+configurable (mirroring the rail's `azTheme`). Only the dropped list is an overlay.
 
 - File: `aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt` (Android),
   `aznavrail-react/src/components/AzDropdownMenu.tsx` (RN) and `src/web/AzDropdownMenu.jsx` (web).
 - DSL like the rail (collect-then-render): the `content` is a plain `AzDropdownMenuScope.() -> Unit`
-  builder. `azConfig(design, dockingSide, vibrate, expandedWidth, collapsedWidth)` mirrors the rail's
-  `azConfig`/`azTheme`; items are `azItem`/`azToggle`/`azCycler`/`azDivider` accepting only the rail's
-  per-item knobs (`color`/`textColor`/`fillColor`/`shape`/`enabled`/`closeOnClick`) plus a `route`.
+  builder. `azConfig(design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape,
+  headerIconSize)` mirrors the rail's `azConfig`/`azTheme` (RN/web take `headerIconShape`/
+  `headerIconSize` props); items are `azItem`/`azToggle`/`azCycler`/`azDivider` accepting only the
+  rail's per-item knobs (`color`/`textColor`/`fillColor`/`shape`/`enabled`/`closeOnClick`) plus a `route`.
 - `design` (`AzDropdownDesign { RAIL, MENU }`, default `MENU`) styles the panel as the collapsed rail
   (compact buttons, `collapsedWidth` ≈100dp) or the expanded menu (full-width labeled rows,
   `expandedWidth` ≈160dp). `dockingSide` (`AzDockingSide { LEFT, RIGHT }`) **pins the panel to that

--- a/README.md
+++ b/README.md
@@ -445,16 +445,17 @@ const settings: AzNavRailSettings = {
 
 A drop-down menu is a **standalone widget** declared with the same opinionated DSL as the rail. In
 AzNavRail tradition it accepts **only** what the rest of the library sanctions — no arbitrary panel
-background, offsets, icon styling, or free composable escape hatch. Its trigger is the **app icon**
-(auto-drawn exactly like the rail's header — not customizable), dropped inline like any widget.
-Tapping it unfolds an **overlay panel** of the items you declare; tapping outside, pressing back, or
-tapping an item folds it up.
+background, offsets, icon tint/source, or free composable escape hatch. Its trigger is the **app
+icon** (auto-drawn exactly like the rail's header), dropped inline like any widget. Tapping it unfolds
+an **overlay panel** of the items you declare; tapping outside, pressing back, or tapping an item
+folds it up.
 
 Configure it through `azConfig` (mirroring the rail): **`design`** picks `AzDropdownDesign.RAIL`
 (compact rail buttons at the **collapsed width**, ≈100dp) or `AzDropdownDesign.MENU` (the default;
 full-width labeled rows at the **expanded width**, ≈160dp); **`dockingSide`** pins the panel to the
-`LEFT` or `RIGHT` screen edge; `vibrate`/`expandedWidth`/`collapsedWidth` round out the config. The
-panel **drops from the trigger** automatically (downward when it fits, otherwise upward).
+`LEFT` or `RIGHT` screen edge; the app-icon **`headerIconShape`/`headerIconSize`** (mirroring the
+rail's `azTheme`) and `vibrate`/`expandedWidth`/`collapsedWidth` round out the config. The panel
+**drops from the trigger** automatically (downward when it fits, otherwise upward).
 
 Items are declared with `azItem` / `azToggle` / `azCycler` / `azDivider`, accepting only the rail's
 sanctioned per-item knobs (`color`/`textColor`/`fillColor`/`shape`/`enabled`/`closeOnClick`). Each may

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
@@ -249,7 +249,12 @@ private fun AzDropdownMenuDemo() {
 
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         AzDropdownMenu {
-            azConfig(design = design, dockingSide = dockingSide)
+            azConfig(
+                design = design,
+                dockingSide = dockingSide,
+                headerIconShape = AzHeaderIconShape.ROUNDED,
+                headerIconSize = 56.dp,
+            )
             azItem("Profile") { lastAction = "Profile" }
             azItem("Settings") { lastAction = "Settings" }
             azToggle(

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Added
 - **`AzDropdownMenu` (+ `AzDropdownItem`).** A standalone, **app-icon** drop-down declared with the
   rail's opinionated surface — it accepts only what the rest of the library sanctions (no arbitrary
-  icon styling, panel background, offsets, or `menuWidth`). The trigger is the app icon (gray
-  placeholder on RN, `/app-icon.png` on web), dropped inline. Configured by `design`
+  icon tint/source, panel background, offsets, or `menuWidth`). The trigger is the app icon (gray
+  placeholder on RN, `/app-icon.png` on web), dropped inline, with configurable `headerIconShape`/
+  `headerIconSize` (mirroring the rail's `azTheme`). Configured by `design`
   (`AzDropdownDesign` RAIL/MENU → panel width) and `dockingSide` (`AzDockingSide` LEFT/RIGHT screen
   edge); the panel drops from the trigger (RN `Modal` overlay; web fixed panel). `<AzDropdownItem>`
   entries accept the sanctioned per-item knobs plus a `route` dispatched through the menu's

--- a/aznavrail-react/src/__tests__/AzDropdownMenu.test.tsx
+++ b/aznavrail-react/src/__tests__/AzDropdownMenu.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import { AzDropdownMenu, AzDropdownItem } from '../components/AzDropdownMenu';
-import { AzDockingSide, AzDropdownDesign } from '../types';
+import { AzDockingSide, AzDropdownDesign, AzHeaderIconShape } from '../types';
 
 describe('AzDropdownMenu', () => {
   it('is closed initially and opens when the app-icon trigger is pressed', () => {
@@ -102,6 +102,18 @@ describe('AzDropdownMenu', () => {
     // Default mocked window width is 375; right edge = 375 - 160 = 215.
     const rightStyle = right.getByTestId('az-dropdown-panel').props.style.flat();
     expect(rightStyle).toEqual(expect.arrayContaining([expect.objectContaining({ left: 375 - 160 })]));
+  });
+
+  it('applies a configurable app-icon size and shape to the trigger', () => {
+    const { getByTestId } = render(
+      <AzDropdownMenu headerIconSize={72} headerIconShape={AzHeaderIconShape.ROUNDED}>
+        <AzDropdownItem text="Profile" onClick={() => {}} />
+      </AzDropdownMenu>
+    );
+    const style = getByTestId('az-dropdown-trigger').props.style;
+    expect(style.width).toBe(72);
+    expect(style.height).toBe(72);
+    expect(style.borderRadius).toBe(8); // ROUNDED → 8
   });
 
   it('dispatches an item route through onNavigate before the callback', () => {

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -13,7 +13,7 @@ import {
   LayoutChangeEvent,
 } from 'react-native';
 import { AzButton } from './AzButton';
-import { AzButtonShape, AzDockingSide, AzDropdownDesign } from '../types';
+import { AzButtonShape, AzDockingSide, AzDropdownDesign, AzHeaderIconShape } from '../types';
 import { AzNavRailDefaults } from '../AzNavRailDefaults';
 
 /** Context the menu provides so item components can navigate, fold the menu, and match its design. */
@@ -37,6 +37,10 @@ export interface AzDropdownMenuProps {
   expandedWidth?: number;
   /** Panel width (px) in the RAIL design. */
   collapsedWidth?: number;
+  /** Clip shape for the app-icon trigger (mirrors the rail's `headerIconShape`). */
+  headerIconShape?: AzHeaderIconShape;
+  /** Diameter (px) of the app-icon trigger (mirrors the rail's `headerIconSize`). */
+  headerIconSize?: number;
   /** Optional controlled open-state. When omitted the menu manages its own. */
   expanded?: boolean;
   /** Called whenever the open-state changes. */
@@ -119,7 +123,8 @@ interface Anchor { x: number; y: number; width: number; height: number; }
 
 /**
  * A standalone, hamburger-style drop-down menu, declared with the same opinionated surface as the
- * rail. The trigger is the **app icon** (drawn like the rail's header — not customizable); the panel
+ * rail. The trigger is the **app icon** (drawn like the rail's header; its shape/size set via
+ * `headerIconShape`/`headerIconSize`); the panel
  * is configured by `design` + `dockingSide`, width-constrained to match, pinned to the chosen screen
  * edge, and dropped from the trigger. Items may carry a `route` dispatched through `onNavigate`.
  *
@@ -137,6 +142,8 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
   vibrate = false,
   expandedWidth = AzNavRailDefaults.ExpandedRailWidth,
   collapsedWidth = AzNavRailDefaults.CollapsedRailWidth,
+  headerIconShape = AzHeaderIconShape.CIRCLE,
+  headerIconSize = AzNavRailDefaults.HeaderIconSize,
   expanded,
   onExpandedChange,
   onNavigate,
@@ -169,7 +176,12 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
   // Reactive so the panel re-positions on orientation / split-screen changes.
   const screen = useWindowDimensions();
   const panelWidth = design === AzDropdownDesign.RAIL ? collapsedWidth : expandedWidth;
-  const triggerSize = AzNavRailDefaults.HeaderIconSize;
+  const triggerSize = headerIconSize;
+  // Clip radius mirrors the rail's header icon: circle = half, rounded = 8, square = 0.
+  const triggerRadius =
+    headerIconShape === AzHeaderIconShape.ROUNDED ? 8 :
+    headerIconShape === AzHeaderIconShape.SQUARE ? 0 :
+    triggerSize / 2;
 
   const panelPosition: ViewStyle = { position: 'absolute' };
   // Horizontal: pin to the physical docking-side edge.
@@ -185,7 +197,8 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
 
   return (
     <View style={style}>
-      {/* The app-icon trigger — drawn like the rail's header icon (gray placeholder), no styling knobs. */}
+      {/* The app-icon trigger — drawn like the rail's header icon (gray placeholder), clipped to the
+          configured shape/size. */}
       <TouchableOpacity
         ref={triggerRef as React.RefObject<any>}
         onPress={() => (isOpen ? setOpen(false) : openMenu())}
@@ -193,10 +206,11 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
         accessibilityLabel="Menu"
       >
         <View
+          testID="az-dropdown-trigger"
           style={{
             width: triggerSize,
             height: triggerSize,
-            borderRadius: triggerSize / 2,
+            borderRadius: triggerRadius,
             backgroundColor: 'gray',
             alignItems: 'center',
             justifyContent: 'center',

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -177,11 +177,11 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
   const screen = useWindowDimensions();
   const panelWidth = design === AzDropdownDesign.RAIL ? collapsedWidth : expandedWidth;
   const triggerSize = headerIconSize;
-  // Clip radius mirrors the rail's header icon: circle = half, rounded = 8, square = 0.
+  // Clip radius mirrors the rail's header icon: circle = half, rounded = 8, anything else = 0.
   const triggerRadius =
     headerIconShape === AzHeaderIconShape.ROUNDED ? 8 :
-    headerIconShape === AzHeaderIconShape.SQUARE ? 0 :
-    triggerSize / 2;
+    headerIconShape === AzHeaderIconShape.CIRCLE ? triggerSize / 2 :
+    0;
 
   const panelPosition: ViewStyle = { position: 'absolute' };
   // Horizontal: pin to the physical docking-side edge.

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -51,10 +51,10 @@ export const AzDropdownItem = ({ text, onClick, route, shape = 'RECTANGLE', enab
 
 /**
  * A standalone, hamburger-style drop-down menu (web), declared with the same opinionated surface as
- * the rail. The trigger is the **app icon** (`/app-icon.png`, like the rail header — not
- * customizable); the panel is configured by `design` + `dockingSide`, width-constrained to match,
- * pinned to the chosen screen edge, and dropped from the trigger. Items may carry a `route`
- * dispatched through `onNavigate`. Clicking outside folds it up.
+ * the rail. The trigger is the **app icon** (`/app-icon.png`, like the rail header; its shape/size
+ * set via `headerIconShape`/`headerIconSize`); the panel is configured by `design` + `dockingSide`,
+ * width-constrained to match, pinned to the chosen screen edge, and dropped from the trigger. Items
+ * may carry a `route` dispatched through `onNavigate`. Clicking outside folds it up.
  *
  * @param {object} props
  * @param {'rail'|'menu'} [props.design='menu'] - Rail look (rail width) or menu look (menu width).
@@ -62,6 +62,8 @@ export const AzDropdownItem = ({ text, onClick, route, shape = 'RECTANGLE', enab
  * @param {boolean} [props.vibrate=false] - Haptic feedback on tap (where supported).
  * @param {number} [props.expandedWidth=160] - Panel width in the menu design.
  * @param {number} [props.collapsedWidth=100] - Panel width in the rail design.
+ * @param {'CIRCLE'|'ROUNDED'|'SQUARE'} [props.headerIconShape='CIRCLE'] - App-icon clip shape.
+ * @param {number} [props.headerIconSize=48] - App-icon trigger diameter (px).
  * @param {boolean} [props.expanded] - Optional controlled open-state.
  * @param {function} [props.onExpandedChange]
  * @param {function} [props.onNavigate] - Called with an item's `route` before its callback.
@@ -73,6 +75,8 @@ const AzDropdownMenu = ({
   vibrate = false,
   expandedWidth = 160,
   collapsedWidth = 100,
+  headerIconShape = 'CIRCLE',
+  headerIconSize = 48,
   expanded,
   onExpandedChange,
   onNavigate,
@@ -147,19 +151,26 @@ const AzDropdownMenu = ({
     }
   }
 
+  // Clip radius mirrors the rail's header icon: circle = half, rounded = 8, square = 0.
+  const triggerRadius =
+    headerIconShape === 'ROUNDED' ? 8 :
+    headerIconShape === 'SQUARE' ? 0 :
+    headerIconSize / 2;
+
   return (
     <div className="az-dropdown-menu" ref={rootRef}>
       <button
         type="button"
         ref={triggerRef}
-        className="az-dropdown-menu-trigger circle"
+        className="az-dropdown-menu-trigger"
+        style={{ width: headerIconSize, height: headerIconSize, borderRadius: triggerRadius }}
         aria-label="Menu"
         aria-haspopup="menu"
         aria-expanded={isOpen}
         onClick={toggle}
       >
-        {/* The app icon — drawn like the rail header, not customizable. */}
-        <img src="/app-icon.png" alt="App Icon" className="az-dropdown-menu-app-icon" />
+        {/* The app icon — drawn like the rail header, clipped to the configured shape/size. */}
+        <img src="/app-icon.png" alt="App Icon" className="az-dropdown-menu-app-icon" style={{ borderRadius: triggerRadius }} />
       </button>
       {isOpen && (
         <div className={`az-dropdown-menu-panel ${design === 'menu' ? 'menu' : 'rail'}`} style={panelStyle} role="menu">

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -151,11 +151,11 @@ const AzDropdownMenu = ({
     }
   }
 
-  // Clip radius mirrors the rail's header icon: circle = half, rounded = 8, square = 0.
+  // Clip radius mirrors the rail's header icon: circle = half, rounded = 8, anything else = 0.
   const triggerRadius =
     headerIconShape === 'ROUNDED' ? 8 :
-    headerIconShape === 'SQUARE' ? 0 :
-    headerIconSize / 2;
+    headerIconShape === 'CIRCLE' ? headerIconSize / 2 :
+    0;
 
   return (
     <div className="az-dropdown-menu" ref={rootRef}>

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -150,8 +150,9 @@ const settings: AzNavRailSettings = {
 A hamburger drop-down is **not** a rail mode — it is a standalone widget, `AzDropdownMenu`, declared
 with the **same opinionated DSL as the rail**. In AzNavRail tradition it accepts only the
 configuration the rest of the library sanctions (no arbitrary panel background, offsets, icon
-styling, or free composable escape hatch). Its trigger is the **app icon** (auto-drawn like the
-rail's header — not customizable), dropped inline like any widget. Tapping it unfolds an **overlay
+tint/source, or free composable escape hatch). Its trigger is the **app icon** (auto-drawn like the
+rail's header; its shape/size set via `azConfig`'s `headerIconShape`/`headerIconSize`), dropped
+inline like any widget. Tapping it unfolds an **overlay
 panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `design` picks
 `AzDropdownDesign.RAIL` (compact rail buttons at the collapsed width ≈100dp) or `AzDropdownDesign.MENU`
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalConfiguration
@@ -54,19 +55,18 @@ import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzDockingSide
 import com.hereliesaz.aznavrail.model.AzDropdownDesign
-
-/** Fixed diameter of the drop-down's app-icon trigger. Not customizable, in the AzNavRail tradition. */
-private val AzDropdownTriggerSize = 48.dp
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 
 /**
  * DSL builder scope for an [AzDropdownMenu] — declared the same way as the rail
  * (`AzDropdownMenu { azConfig(...); azItem(...) { } }`).
  *
  * In keeping with AzNavRail's opinionated tradition, the drop-down only accepts configuration the
- * rest of the library sanctions: [azConfig] mirrors the rail's `azConfig` (design, docking side,
- * vibration, the collapsed/expanded widths) and the item builders accept only the per-item knobs the
- * rail's items accept (`color`/`textColor`/`fillColor`/`shape`/`enabled`, plus a navigation `route`).
- * There is no arbitrary panel background, offset, icon styling, or free composable escape hatch.
+ * rest of the library sanctions: [azConfig] mirrors the rail's `azConfig`/`azTheme` (design, docking
+ * side, vibration, the collapsed/expanded widths, and the app-icon shape/size) and the item builders
+ * accept only the per-item knobs the rail's items accept (`color`/`textColor`/`fillColor`/`shape`/
+ * `enabled`, plus a navigation `route`). There is no arbitrary panel background, offset, or free
+ * composable escape hatch.
  */
 interface AzDropdownMenuScope {
     /**
@@ -79,13 +79,19 @@ interface AzDropdownMenuScope {
      * @param vibrate Haptic feedback when the trigger is tapped.
      * @param expandedWidth Panel width in the [AzDropdownDesign.MENU] design.
      * @param collapsedWidth Panel width in the [AzDropdownDesign.RAIL] design.
+     * @param headerIconShape Clip shape for the app-icon trigger (mirrors the rail's
+     *   `azTheme(headerIconShape = …)`).
+     * @param headerIconSize Diameter of the app-icon trigger (mirrors the rail's
+     *   `azTheme(headerIconSize = …)`).
      */
     fun azConfig(
         design: AzDropdownDesign = AzDropdownDesign.MENU,
         dockingSide: AzDockingSide = AzDockingSide.LEFT,
         vibrate: Boolean = false,
         expandedWidth: Dp = 160.dp,
-        collapsedWidth: Dp = 100.dp
+        collapsedWidth: Dp = 100.dp,
+        headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
+        headerIconSize: Dp = 48.dp
     )
 
     /**
@@ -143,7 +149,9 @@ internal data class AzDropdownConfig(
     val dockingSide: AzDockingSide = AzDockingSide.LEFT,
     val vibrate: Boolean = false,
     val expandedWidth: Dp = 160.dp,
-    val collapsedWidth: Dp = 100.dp
+    val collapsedWidth: Dp = 100.dp,
+    val headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
+    val headerIconSize: Dp = 48.dp
 )
 
 /** One declared entry, collected by the builder and rendered by the composable. */
@@ -209,9 +217,13 @@ private class AzDropdownMenuScopeImpl : AzDropdownMenuScope {
         dockingSide: AzDockingSide,
         vibrate: Boolean,
         expandedWidth: Dp,
-        collapsedWidth: Dp
+        collapsedWidth: Dp,
+        headerIconShape: AzHeaderIconShape,
+        headerIconSize: Dp
     ) {
-        config = AzDropdownConfig(design, dockingSide, vibrate, expandedWidth, collapsedWidth)
+        config = AzDropdownConfig(
+            design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape, headerIconSize
+        )
     }
 
     override fun azItem(
@@ -439,8 +451,9 @@ private class AzDropdownEdgePositionProvider(
 /**
  * A standalone, hamburger-style drop-down menu, declared with the same opinionated DSL as the rail.
  *
- * The trigger is the **app icon** (auto-drawn, exactly like the rail's header — not customizable),
- * dropped inline like any widget. Tapping it unfolds a [Popup] panel of the items you declare in
+ * The trigger is the **app icon** (auto-drawn exactly like the rail's header; its shape/size are set
+ * via [AzDropdownMenuScope.azConfig], mirroring the rail's `azTheme`), dropped inline like any
+ * widget. Tapping it unfolds a [Popup] panel of the items you declare in
  * [content]; the panel is presented as a slice of the rail ([AzDropdownDesign.RAIL]) or menu
  * ([AzDropdownDesign.MENU]), width-constrained to match, pinned to the [AzDockingSide] screen edge,
  * and dropping from the trigger. Tapping outside or pressing back folds it up.
@@ -501,12 +514,18 @@ fun AzDropdownMenu(
     }
 
     Box(modifier = modifier) {
-        // The inline app-icon trigger — fixed shape/size, no styling knobs. The icon itself is
-        // decorative; the box carries the "Menu" accessibility label.
+        // The inline app-icon trigger — the app icon, clipped to the configured shape/size. The icon
+        // itself is decorative; the box carries the "Menu" accessibility label.
+        val iconClipShape: Shape? = when (config.headerIconShape) {
+            AzHeaderIconShape.CIRCLE -> CircleShape
+            AzHeaderIconShape.ROUNDED -> RoundedCornerShape(12.dp)
+            else -> null
+        }
+        val clipModifier = if (iconClipShape != null) Modifier.clip(iconClipShape) else Modifier
         Box(
             modifier = Modifier
-                .size(AzDropdownTriggerSize)
-                .clip(CircleShape)
+                .size(config.headerIconSize)
+                .then(clipModifier)
                 .clickable {
                     setOpen(!isOpen)
                     if (config.vibrate) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -518,7 +537,7 @@ fun AzDropdownMenu(
                 Image(
                     painter = rememberAsyncImagePainter(appIcon),
                     contentDescription = null,
-                    modifier = Modifier.fillMaxSize().clip(CircleShape)
+                    modifier = Modifier.fillMaxSize().then(clipModifier)
                 )
             } else {
                 Icon(imageVector = Icons.Default.Menu, contentDescription = null)

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -150,8 +150,9 @@ const settings: AzNavRailSettings = {
 A hamburger drop-down is **not** a rail mode — it is a standalone widget, `AzDropdownMenu`, declared
 with the **same opinionated DSL as the rail**. In AzNavRail tradition it accepts only the
 configuration the rest of the library sanctions (no arbitrary panel background, offsets, icon
-styling, or free composable escape hatch). Its trigger is the **app icon** (auto-drawn like the
-rail's header — not customizable), dropped inline like any widget. Tapping it unfolds an **overlay
+tint/source, or free composable escape hatch). Its trigger is the **app icon** (auto-drawn like the
+rail's header; its shape/size set via `azConfig`'s `headerIconShape`/`headerIconSize`), dropped
+inline like any widget. Tapping it unfolds an **overlay
 panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `design` picks
 `AzDropdownDesign.RAIL` (compact rail buttons at the collapsed width ≈100dp) or `AzDropdownDesign.MENU`
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzDropdownMenuTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzDropdownMenuTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.model.AzDropdownDesign
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -95,6 +96,23 @@ class AzDropdownMenuTest {
         composeTestRule.onNodeWithText("Home").assertIsDisplayed()
         composeTestRule.onNodeWithText("Home").performClick()
         assertTrue(clicked)
+    }
+
+    @Test
+    fun configurable_app_icon_shape_and_size_still_open_the_panel() {
+        composeTestRule.setContent {
+            AzDropdownMenu {
+                azConfig(
+                    headerIconShape = com.hereliesaz.aznavrail.model.AzHeaderIconShape.SQUARE,
+                    headerIconSize = 72.dp
+                )
+                azItem("Settings") { }
+            }
+        }
+
+        composeTestRule.onNodeWithText("Settings").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Menu").performClick()
+        composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
     }
 
     @Test

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -150,8 +150,9 @@ const settings: AzNavRailSettings = {
 A hamburger drop-down is **not** a rail mode — it is a standalone widget, `AzDropdownMenu`, declared
 with the **same opinionated DSL as the rail**. In AzNavRail tradition it accepts only the
 configuration the rest of the library sanctions (no arbitrary panel background, offsets, icon
-styling, or free composable escape hatch). Its trigger is the **app icon** (auto-drawn like the
-rail's header — not customizable), dropped inline like any widget. Tapping it unfolds an **overlay
+tint/source, or free composable escape hatch). Its trigger is the **app icon** (auto-drawn like the
+rail's header; its shape/size set via `azConfig`'s `headerIconShape`/`headerIconSize`), dropped
+inline like any widget. Tapping it unfolds an **overlay
 panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `design` picks
 `AzDropdownDesign.RAIL` (compact rail buttons at the collapsed width ≈100dp) or `AzDropdownDesign.MENU`
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -92,9 +92,10 @@ CI-versioned carousel — see the README's "In-App About Reader" and "More from 
 
 A drop-down menu is a standalone widget declared with the **same opinionated DSL as the rail**: it
 accepts only the configuration the rest of the library sanctions (no arbitrary panel background,
-offsets, icon styling, or free composable escape hatch). Its trigger is the **app icon** (auto-drawn
-like the rail's header — not customizable), dropped inline like any widget. Tapping it unfolds an
-**overlay panel** (a `Popup`) of the items you declare; tapping outside or pressing back folds it up.
+offsets, icon tint/source, or free composable escape hatch). Its trigger is the **app icon**
+(auto-drawn like the rail's header; shape/size set via `azConfig`), dropped inline like any widget.
+Tapping it unfolds an **overlay panel** (a `Popup`) of the items you declare; tapping outside or
+pressing back folds it up.
 
 ~~~kotlin
 @Composable
@@ -113,7 +114,9 @@ interface AzDropdownMenuScope {
         dockingSide: AzDockingSide = AzDockingSide.LEFT,    // which screen edge the panel pins to
         vibrate: Boolean = false,
         expandedWidth: Dp = 160.dp,
-        collapsedWidth: Dp = 100.dp
+        collapsedWidth: Dp = 100.dp,
+        headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,  // app-icon clip, like azTheme
+        headerIconSize: Dp = 48.dp                          // app-icon diameter, like azTheme
     )
     fun azItem(text, route = null, color, textColor, fillColor, shape, enabled, closeOnClick = true, onClick)
     fun azToggle(isChecked, toggleOnText, toggleOffText, route = null, …, onToggle)
@@ -124,9 +127,11 @@ interface AzDropdownMenuScope {
 
 `azConfig` mirrors the rail's `azConfig`/`azTheme`: `design` sets the look + width
 (`AzDropdownDesign.RAIL` = compact rail buttons at `collapsedWidth` ≈100dp; `AzDropdownDesign.MENU`
-= full-width labeled rows at `expandedWidth` ≈160dp), and `dockingSide` pins the panel to the `LEFT`
-or `RIGHT` screen edge. The panel drops from the trigger automatically (downward when it fits, else
-upward). Items accept only the rail's sanctioned per-item knobs, plus a navigation `route`: when set,
+= full-width labeled rows at `expandedWidth` ≈160dp), `dockingSide` pins the panel to the `LEFT`
+or `RIGHT` screen edge, and `headerIconShape`/`headerIconSize` set the app-icon trigger's clip and
+diameter (the same knobs the rail exposes via `azTheme`). The panel drops from the trigger
+automatically (downward when it fits, else upward). Items accept only the rail's sanctioned per-item
+knobs, plus a navigation `route`: when set,
 tapping navigates the `navController` (so the drop-down can drive an `AzNavHost`), then runs the
 callback, then folds up if `closeOnClick`.
 

--- a/sample-pwa/src/screens/CustomizationDemo.tsx
+++ b/sample-pwa/src/screens/CustomizationDemo.tsx
@@ -160,7 +160,7 @@ function AzDropdownMenuDemo() {
       <select value={dockingSide} onChange={(e) => setDockingSide(e.target.value as AzDockingSide)}>
         {Object.values(AzDockingSide).map((s) => <option key={s} value={s}>{s}</option>)}
       </select>
-      <AzDropdownMenu design={design} dockingSide={dockingSide}>
+      <AzDropdownMenu design={design} dockingSide={dockingSide} headerIconShape={AzHeaderIconShape.ROUNDED} headerIconSize={56}>
         <AzDropdownItem text="Profile" onClick={() => setLast('Profile')} />
         <AzDropdownItem text="Settings" onClick={() => setLast('Settings')} />
         <AzDivider />


### PR DESCRIPTION
## What & why

Following the DSL-conformance work (#471), the app-icon **trigger** was fully fixed. But its **shape and size are a sanctioned customization** — the rail itself exposes them via `azTheme(headerIconShape, headerIconSize)`. So this surfaces them on the dropdown too, without re-opening arbitrary icon tint/source styling.

## Changes

- **Android** (`AzDropdownMenu.kt`): `azConfig` gains `headerIconShape: AzHeaderIconShape = CIRCLE` and `headerIconSize: Dp = 48.dp`. The trigger box + app icon clip to the configured shape (`CIRCLE`→circle, `ROUNDED`→12dp, `SQUARE`/`NONE`→none) at the configured size.
- **React Native** (`AzDropdownMenu.tsx`): adds `headerIconShape?`/`headerIconSize?` props; the app-icon trigger sizes and clips accordingly (radius: circle = half, rounded = 8, square = 0).
- **Web** (`AzDropdownMenu.jsx` + `.css`): same `headerIconShape`/`headerIconSize` props applied via inline size + clip radius.
- **Samples**: Android + PWA demos now render a non-default **rounded, 56dp** app icon.
- **Docs**: README, `docs/DSL.md`, the complete guide (+ both embedded copies), `AGENTS.md`, and the CHANGELOG note the configurable shape/size (and correct "no arbitrary icon styling" → "no arbitrary icon tint/source").

## Verification

- `npx tsc --noEmit` clean; `jest src/__tests__/AzDropdownMenu.test.tsx` → **9/9** (new test asserts the trigger's `width`/`height`/`borderRadius` reflect `headerIconSize`/`headerIconShape`); `npm run build` regenerates `lib/`.
- Robolectric `AzDropdownMenuTest` gains a smoke test that a custom `headerIconShape`/`headerIconSize` still opens the panel. Android has no SDK here, so it relies on CI + review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV

---
_Generated by [Claude Code](https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV)_