### PR TITLE
fix(dropdown): add the rail footer to the MENU design + match its menu text size

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,9 +158,13 @@ configurable (mirroring the rail's `azTheme`). Only the dropped list is an overl
   `aznavrail-react/src/components/AzDropdownMenu.tsx` (RN) and `src/web/AzDropdownMenu.jsx` (web).
 - DSL like the rail (collect-then-render): the `content` is a plain `AzDropdownMenuScope.() -> Unit`
   builder. `azConfig(design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape,
-  headerIconSize)` mirrors the rail's `azConfig`/`azTheme` (RN/web take `headerIconShape`/
-  `headerIconSize` props); items are `azItem`/`azToggle`/`azCycler`/`azDivider` accepting only the
-  rail's per-item knobs (`color`/`textColor`/`fillColor`/`shape`/`enabled`/`closeOnClick`) plus a `route`.
+  headerIconSize, showFooter, appRepositoryUrl)` mirrors the rail's `azConfig`/`azTheme` (RN/web take
+  the same as props); items are `azItem`/`azToggle`/`azCycler`/`azDivider` accepting only the rail's
+  per-item knobs (`color`/`textColor`/`fillColor`/`shape`/`enabled`/`closeOnClick`) plus a `route`.
+- The `MENU` design renders rows at the rail's menu-item text size (Android `titleLarge`; RN/web 16px,
+  matching `RailMenuItem`/`.az-menu-item-text`) and — like the rail's expanded menu — appends the
+  footer (About → `appRepositoryUrl`, Feedback → mailto, @HereLiesAz → Instagram) when `showFooter`,
+  mirroring `internal/Footer.kt` / the rail's `renderFooter`.
 - `design` (`AzDropdownDesign { RAIL, MENU }`, default `MENU`) styles the panel as the collapsed rail
   (compact buttons, `collapsedWidth` ≈100dp) or the expanded menu (full-width labeled rows,
   `expandedWidth` ≈160dp). `dockingSide` (`AzDockingSide { LEFT, RIGHT }`) **pins the panel to that

--- a/README.md
+++ b/README.md
@@ -455,7 +455,10 @@ Configure it through `azConfig` (mirroring the rail): **`design`** picks `AzDrop
 full-width labeled rows at the **expanded width**, ≈160dp); **`dockingSide`** pins the panel to the
 `LEFT` or `RIGHT` screen edge; the app-icon **`headerIconShape`/`headerIconSize`** (mirroring the
 rail's `azTheme`) and `vibrate`/`expandedWidth`/`collapsedWidth` round out the config. The panel
-**drops from the trigger** automatically (downward when it fits, otherwise upward).
+**drops from the trigger** automatically (downward when it fits, otherwise upward). The `MENU` design
+renders rows at the rail's menu-item text size and carries the rail's **footer** (About / Feedback /
+@HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind "About"), just like the expanded
+menu.
 
 Items are declared with `azItem` / `azToggle` / `azCycler` / `azDivider`, accepting only the rail's
 sanctioned per-item knobs (`color`/`textColor`/`fillColor`/`shape`/`enabled`/`closeOnClick`). Each may

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -11,8 +11,10 @@
   (`AzDropdownDesign` RAIL/MENU → panel width) and `dockingSide` (`AzDockingSide` LEFT/RIGHT screen
   edge); the panel drops from the trigger (RN `Modal` overlay; web fixed panel). `<AzDropdownItem>`
   entries accept the sanctioned per-item knobs plus a `route` dispatched through the menu's
-  `onNavigate` (AzNavHost-style routing). Controlled `expanded`/`onExpandedChange`. Reaches parity
-  with the Android `AzDropdownMenu` DSL.
+  `onNavigate` (AzNavHost-style routing). Controlled `expanded`/`onExpandedChange`. The `MENU` design
+  renders rows at the rail's menu-item text size (16px) and carries the rail's footer
+  (About / Feedback / @HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind "About").
+  Reaches parity with the Android `AzDropdownMenu` DSL.
 - **Sizable header icon** (`headerIconSize`) and the **in-app About reader + "More from Az"**
   carousel (`appRepositoryUrl`, `inAppAbout`, `moreRailItem`) reach parity with Android.
 

--- a/aznavrail-react/src/__tests__/AzDropdownMenu.test.tsx
+++ b/aznavrail-react/src/__tests__/AzDropdownMenu.test.tsx
@@ -116,6 +116,43 @@ describe('AzDropdownMenu', () => {
     expect(style.borderRadius).toBe(8); // ROUNDED → 8
   });
 
+  it('shows the rail footer in the MENU design by default', () => {
+    const { queryByText } = render(
+      <AzDropdownMenu expanded>
+        <AzDropdownItem text="Profile" onClick={() => {}} />
+      </AzDropdownMenu>
+    );
+    expect(queryByText('About')).not.toBeNull();
+    expect(queryByText('Feedback')).not.toBeNull();
+    expect(queryByText('@HereLiesAz')).not.toBeNull();
+  });
+
+  it('omits the footer when showFooter is false and in the RAIL design', () => {
+    const noFooter = render(
+      <AzDropdownMenu expanded showFooter={false}>
+        <AzDropdownItem text="Profile" onClick={() => {}} />
+      </AzDropdownMenu>
+    );
+    expect(noFooter.queryByText('Feedback')).toBeNull();
+
+    const rail = render(
+      <AzDropdownMenu expanded design={AzDropdownDesign.RAIL}>
+        <AzDropdownItem text="Profile" onClick={() => {}} />
+      </AzDropdownMenu>
+    );
+    expect(rail.queryByText('Feedback')).toBeNull();
+  });
+
+  it('renders menu rows at the rail menu-item text size (16)', () => {
+    const { getByText } = render(
+      <AzDropdownMenu expanded>
+        <AzDropdownItem text="Profile" onClick={() => {}} />
+      </AzDropdownMenu>
+    );
+    const style = getByText('Profile').props.style.flat();
+    expect(style).toEqual(expect.arrayContaining([expect.objectContaining({ fontSize: 16 })]));
+  });
+
   it('dispatches an item route through onNavigate before the callback', () => {
     const onNavigate = jest.fn();
     const onClick = jest.fn();

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -267,7 +267,12 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
 /** The MENU design's footer — mirrors the rail's footer (About / Feedback / @HereLiesAz). */
 const AzDropdownFooter: React.FC<{ appRepositoryUrl: string }> = ({ appRepositoryUrl }) => {
   const footerColor = '#6750A4';
-  const open = (url: string) => { Linking.openURL(url).catch(() => {}); };
+  // Only open safe schemes — this also runs on the web via react-native-web, where a `javascript:`
+  // URL would otherwise execute.
+  const open = (url: string) => {
+    const isSafe = url.startsWith('http://') || url.startsWith('https://') || url.startsWith('mailto:');
+    if (isSafe) Linking.openURL(url).catch(() => {});
+  };
   return (
     <View style={styles.footer}>
       <TouchableOpacity onPress={() => open(appRepositoryUrl)} style={styles.footerRow} accessibilityRole="button">
@@ -308,6 +313,8 @@ const styles = StyleSheet.create({
   footer: {
     padding: 16,
     alignItems: 'center',
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(103, 80, 164, 0.12)',
   },
   footerRow: {
     paddingVertical: 6,

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   StyleSheet,
   Vibration,
+  Linking,
   useWindowDimensions,
   ViewStyle,
   LayoutChangeEvent,
@@ -41,6 +42,10 @@ export interface AzDropdownMenuProps {
   headerIconShape?: AzHeaderIconShape;
   /** Diameter (px) of the app-icon trigger (mirrors the rail's `headerIconSize`). */
   headerIconSize?: number;
+  /** Whether the MENU design shows the rail's footer (About / Feedback / @HereLiesAz). */
+  showFooter?: boolean;
+  /** Repository URL opened by the footer's "About" item. */
+  appRepositoryUrl?: string;
   /** Optional controlled open-state. When omitted the menu manages its own. */
   expanded?: boolean;
   /** Called whenever the open-state changes. */
@@ -144,6 +149,8 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
   collapsedWidth = AzNavRailDefaults.CollapsedRailWidth,
   headerIconShape = AzHeaderIconShape.CIRCLE,
   headerIconSize = AzNavRailDefaults.HeaderIconSize,
+  showFooter = true,
+  appRepositoryUrl = 'https://github.com/HereLiesAz/AzNavRail',
   expanded,
   onExpandedChange,
   onNavigate,
@@ -243,12 +250,35 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
                   <AzDropdownMenuContext.Provider value={{ dismiss: () => setOpen(false), design, onNavigate }}>
                     {children}
                   </AzDropdownMenuContext.Provider>
+                  {/* The expanded-menu design carries the rail's footer. */}
+                  {design === AzDropdownDesign.MENU && showFooter && (
+                    <AzDropdownFooter appRepositoryUrl={appRepositoryUrl} />
+                  )}
                 </ScrollView>
               </Pressable>
             </View>
           </Pressable>
         </Modal>
       )}
+    </View>
+  );
+};
+
+/** The MENU design's footer — mirrors the rail's footer (About / Feedback / @HereLiesAz). */
+const AzDropdownFooter: React.FC<{ appRepositoryUrl: string }> = ({ appRepositoryUrl }) => {
+  const footerColor = '#6750A4';
+  const open = (url: string) => { Linking.openURL(url).catch(() => {}); };
+  return (
+    <View style={styles.footer}>
+      <TouchableOpacity onPress={() => open(appRepositoryUrl)} style={styles.footerRow} accessibilityRole="button">
+        <Text style={[styles.footerText, { color: footerColor }]}>About</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={() => open('mailto:hereliesaz@gmail.com?subject=Feedback')} style={styles.footerRow} accessibilityRole="button">
+        <Text style={[styles.footerText, { color: footerColor }]}>Feedback</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={() => open('https://instagram.com/HereLiesAz')} style={styles.footerRow} accessibilityRole="button">
+        <Text style={[styles.footerText, { color: footerColor, opacity: 0.5 }]}>@HereLiesAz</Text>
+      </TouchableOpacity>
     </View>
   );
 };
@@ -263,16 +293,26 @@ const styles = StyleSheet.create({
     shadowRadius: 12,
     shadowOffset: { width: 0, height: 8 },
   },
-  // Expanded-drawer look: full-width labeled row with the menu's 24/12 padding.
+  // Expanded-drawer look: full-width labeled row matching the rail's menu item (16px text, 12/16 pad).
   menuRow: {
     width: '100%',
-    paddingHorizontal: 24,
+    paddingHorizontal: 16,
     paddingVertical: 12,
     alignItems: 'center',
     justifyContent: 'center',
   },
   menuRowText: {
-    fontSize: 22,
+    fontSize: 16,
     textAlign: 'center',
+  },
+  footer: {
+    padding: 16,
+    alignItems: 'center',
+  },
+  footerRow: {
+    paddingVertical: 6,
+  },
+  footerText: {
+    fontSize: 16,
   },
 });

--- a/aznavrail-react/src/web/AzDropdownMenu.css
+++ b/aznavrail-react/src/web/AzDropdownMenu.css
@@ -81,6 +81,7 @@
   align-items: center;
   padding: 16px;
   color: #6750A4;
+  border-top: 1px solid rgba(103, 80, 164, 0.12);
 }
 
 .az-dropdown-menu-footer-item {

--- a/aznavrail-react/src/web/AzDropdownMenu.css
+++ b/aznavrail-react/src/web/AzDropdownMenu.css
@@ -59,10 +59,12 @@
   padding: 4px 0;
 }
 
+/* Matches the rail's menu item text: 16px / weight 500 / centred (see web MenuItem.css). */
 .az-dropdown-menu-item--menu {
-  padding: 12px 24px;
+  padding: 12px 16px;
   text-align: center;
-  font-size: 1.25rem;
+  font-size: 16px;
+  font-weight: 500;
   cursor: pointer;
   user-select: none;
   color: #6750A4;
@@ -71,6 +73,24 @@
 .az-dropdown-menu-item--menu:hover { background-color: rgba(103, 80, 164, 0.08); }
 .az-dropdown-menu-item--menu.disabled { opacity: 0.5; cursor: default; }
 .az-dropdown-menu-item--menu.disabled:hover { background-color: transparent; }
+
+/* The MENU design's footer — mirrors the rail's footer (About / Feedback / @HereLiesAz). */
+.az-dropdown-menu-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+  color: #6750A4;
+}
+
+.az-dropdown-menu-footer-item {
+  padding: 4px 0;
+  font-size: 16px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.az-dropdown-menu-footer-item:hover { text-decoration: underline; }
 
 @keyframes az-dropdown-menu-unfold {
   from { opacity: 0; transform: translateY(-8px); }

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -67,6 +67,8 @@ export const AzDropdownItem = ({ text, onClick, route, shape = 'RECTANGLE', enab
  * @param {boolean} [props.expanded] - Optional controlled open-state.
  * @param {function} [props.onExpandedChange]
  * @param {function} [props.onNavigate] - Called with an item's `route` before its callback.
+ * @param {boolean} [props.showFooter=true] - Whether the menu design shows the About/Feedback/@HereLiesAz footer.
+ * @param {string} [props.appRepositoryUrl] - URL opened by the footer's "About" item.
  * @param {React.ReactNode} props.children
  */
 const AzDropdownMenu = ({
@@ -77,6 +79,8 @@ const AzDropdownMenu = ({
   collapsedWidth = 100,
   headerIconShape = 'CIRCLE',
   headerIconSize = 48,
+  showFooter = true,
+  appRepositoryUrl = 'https://github.com/HereLiesAz/AzNavRail',
   expanded,
   onExpandedChange,
   onNavigate,
@@ -177,6 +181,14 @@ const AzDropdownMenu = ({
           <AzDropdownMenuContext.Provider value={{ dismiss: () => setOpen(false), design, onNavigate }}>
             {children}
           </AzDropdownMenuContext.Provider>
+          {/* The expanded-menu design carries the rail's footer. */}
+          {design === 'menu' && showFooter && (
+            <div className="az-dropdown-menu-footer">
+              <div className="az-dropdown-menu-footer-item" onClick={() => window.open(appRepositoryUrl, '_blank', 'noopener')}>About</div>
+              <div className="az-dropdown-menu-footer-item" onClick={() => window.open('mailto:hereliesaz@gmail.com?subject=Feedback', '_self')}>Feedback</div>
+              <div className="az-dropdown-menu-footer-item" style={{ opacity: 0.5 }} onClick={() => window.open('https://instagram.com/HereLiesAz', '_blank', 'noopener')}>@HereLiesAz</div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -184,9 +184,14 @@ const AzDropdownMenu = ({
           {/* The expanded-menu design carries the rail's footer. */}
           {design === 'menu' && showFooter && (
             <div className="az-dropdown-menu-footer">
-              <div className="az-dropdown-menu-footer-item" onClick={() => window.open(appRepositoryUrl, '_blank', 'noopener')}>About</div>
+              <div className="az-dropdown-menu-footer-item" onClick={() => {
+                // Only follow plain web URLs, never an injected scheme (e.g. javascript:).
+                if (appRepositoryUrl && (appRepositoryUrl.startsWith('http://') || appRepositoryUrl.startsWith('https://'))) {
+                  window.open(appRepositoryUrl, '_blank', 'noopener,noreferrer');
+                }
+              }}>About</div>
               <div className="az-dropdown-menu-footer-item" onClick={() => window.open('mailto:hereliesaz@gmail.com?subject=Feedback', '_self')}>Feedback</div>
-              <div className="az-dropdown-menu-footer-item" style={{ opacity: 0.5 }} onClick={() => window.open('https://instagram.com/HereLiesAz', '_blank', 'noopener')}>@HereLiesAz</div>
+              <div className="az-dropdown-menu-footer-item" style={{ opacity: 0.5 }} onClick={() => window.open('https://instagram.com/HereLiesAz', '_blank', 'noopener,noreferrer')}>@HereLiesAz</div>
             </div>
           )}
         </div>

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -156,9 +156,12 @@ inline like any widget. Tapping it unfolds an **overlay
 panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `design` picks
 `AzDropdownDesign.RAIL` (compact rail buttons at the collapsed width ≈100dp) or `AzDropdownDesign.MENU`
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the
-`LEFT`/`RIGHT` screen edge; the panel drops from the trigger automatically. Items use
-`azItem`/`azToggle`/`azCycler`/`azDivider` with only the rail's sanctioned per-item knobs, plus a
-`route` that navigates the supplied `NavController` (so the drop-down can drive an `AzNavHost`).
+`LEFT`/`RIGHT` screen edge; the panel drops from the trigger automatically. The `MENU` design
+renders rows at the rail's menu-item text size and, like the rail's expanded menu, carries the
+footer (About / Feedback / @HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind
+"About"). Items use `azItem`/`azToggle`/`azCycler`/`azDivider` with only the rail's sanctioned
+per-item knobs, plus a `route` that navigates the supplied `NavController` (so the drop-down can
+drive an `AzNavHost`).
 
 ```kotlin
 AzDropdownMenu(navController = navController) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -1,12 +1,16 @@
 package com.hereliesaz.aznavrail
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -83,6 +87,9 @@ interface AzDropdownMenuScope {
      *   `azTheme(headerIconShape = …)`).
      * @param headerIconSize Diameter of the app-icon trigger (mirrors the rail's
      *   `azTheme(headerIconSize = …)`).
+     * @param showFooter Whether the [AzDropdownDesign.MENU] panel shows the rail's footer
+     *   (About / Feedback / @HereLiesAz), like the rail's expanded menu.
+     * @param appRepositoryUrl Repository URL opened by the footer's "About" item.
      */
     fun azConfig(
         design: AzDropdownDesign = AzDropdownDesign.MENU,
@@ -91,7 +98,9 @@ interface AzDropdownMenuScope {
         expandedWidth: Dp = 160.dp,
         collapsedWidth: Dp = 100.dp,
         headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
-        headerIconSize: Dp = 48.dp
+        headerIconSize: Dp = 48.dp,
+        showFooter: Boolean = true,
+        appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail"
     )
 
     /**
@@ -151,7 +160,9 @@ internal data class AzDropdownConfig(
     val expandedWidth: Dp = 160.dp,
     val collapsedWidth: Dp = 100.dp,
     val headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
-    val headerIconSize: Dp = 48.dp
+    val headerIconSize: Dp = 48.dp,
+    val showFooter: Boolean = true,
+    val appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail"
 )
 
 /** One declared entry, collected by the builder and rendered by the composable. */
@@ -219,10 +230,13 @@ private class AzDropdownMenuScopeImpl : AzDropdownMenuScope {
         expandedWidth: Dp,
         collapsedWidth: Dp,
         headerIconShape: AzHeaderIconShape,
-        headerIconSize: Dp
+        headerIconSize: Dp,
+        showFooter: Boolean,
+        appRepositoryUrl: String
     ) {
         config = AzDropdownConfig(
-            design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape, headerIconSize
+            design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape, headerIconSize,
+            showFooter, appRepositoryUrl
         )
     }
 
@@ -319,6 +333,73 @@ private fun AzDropdownMenuRow(
                 )
             }
         }
+    }
+}
+
+/**
+ * The drop-down's footer for the [AzDropdownDesign.MENU] design — mirrors the rail's footer
+ * ([com.hereliesaz.aznavrail.internal.Footer]): About (opens [appRepositoryUrl]), Feedback (email),
+ * and the @HereLiesAz attribution. Centred [titleLarge] text in the theme primary, like the rail.
+ */
+@Composable
+private fun AzDropdownFooter(appRepositoryUrl: String) {
+    val context = LocalContext.current
+    val footerColor = MaterialTheme.colorScheme.primary
+    val appName = remember(context.packageName) {
+        try {
+            context.packageManager.getApplicationLabel(
+                context.packageManager.getApplicationInfo(context.packageName, 0)
+            ).toString()
+        } catch (e: Exception) {
+            "App"
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "About",
+            style = MaterialTheme.typography.titleLarge.copy(color = footerColor),
+            modifier = Modifier
+                .clickable {
+                    try {
+                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(appRepositoryUrl)))
+                    } catch (e: Exception) {}
+                }
+                .padding(vertical = 4.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Feedback",
+            style = MaterialTheme.typography.titleLarge.copy(color = footerColor),
+            modifier = Modifier
+                .clickable {
+                    try {
+                        val emailIntent = Intent(Intent.ACTION_SENDTO).apply {
+                            data = Uri.parse("mailto:hereliesaz@gmail.com")
+                            putExtra(Intent.EXTRA_SUBJECT, appName)
+                        }
+                        context.startActivity(Intent.createChooser(emailIntent, "Send feedback"))
+                    } catch (e: Exception) {}
+                }
+                .padding(vertical = 4.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "@HereLiesAz",
+            style = MaterialTheme.typography.titleLarge.copy(color = footerColor.copy(alpha = 0.5f)),
+            modifier = Modifier
+                .clickable {
+                    try {
+                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://instagram.com/HereLiesAz")))
+                    } catch (e: Exception) {}
+                }
+                .padding(vertical = 4.dp)
+        )
     }
 }
 
@@ -568,6 +649,11 @@ fun AzDropdownMenu(
                     ) {
                         entries.forEach { entry ->
                             AzDropdownEntryItem(entry, config.design, navController, dismiss)
+                        }
+                        // The expanded-menu design carries the rail's footer (About / Feedback / @HereLiesAz).
+                        if (config.design == AzDropdownDesign.MENU && config.showFooter) {
+                            AzDivider()
+                            AzDropdownFooter(appRepositoryUrl = config.appRepositoryUrl)
                         }
                     }
                 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -366,9 +366,14 @@ private fun AzDropdownFooter(appRepositoryUrl: String) {
             style = MaterialTheme.typography.titleLarge.copy(color = footerColor),
             modifier = Modifier
                 .clickable {
-                    try {
-                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(appRepositoryUrl)))
-                    } catch (e: Exception) {}
+                    // Only follow plain web URLs, never an injected scheme (e.g. javascript:/content:).
+                    val isHttp = appRepositoryUrl.startsWith("http://", ignoreCase = true) ||
+                        appRepositoryUrl.startsWith("https://", ignoreCase = true)
+                    if (isHttp) {
+                        try {
+                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(appRepositoryUrl)))
+                        } catch (e: Exception) {}
+                    }
                 }
                 .padding(vertical = 4.dp)
         )

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -156,9 +156,12 @@ inline like any widget. Tapping it unfolds an **overlay
 panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `design` picks
 `AzDropdownDesign.RAIL` (compact rail buttons at the collapsed width ≈100dp) or `AzDropdownDesign.MENU`
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the
-`LEFT`/`RIGHT` screen edge; the panel drops from the trigger automatically. Items use
-`azItem`/`azToggle`/`azCycler`/`azDivider` with only the rail's sanctioned per-item knobs, plus a
-`route` that navigates the supplied `NavController` (so the drop-down can drive an `AzNavHost`).
+`LEFT`/`RIGHT` screen edge; the panel drops from the trigger automatically. The `MENU` design
+renders rows at the rail's menu-item text size and, like the rail's expanded menu, carries the
+footer (About / Feedback / @HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind
+"About"). Items use `azItem`/`azToggle`/`azCycler`/`azDivider` with only the rail's sanctioned
+per-item knobs, plus a `route` that navigates the supplied `NavController` (so the drop-down can
+drive an `AzNavHost`).
 
 ```kotlin
 AzDropdownMenu(navController = navController) {

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzDropdownMenuTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzDropdownMenuTest.kt
@@ -116,6 +116,30 @@ class AzDropdownMenuTest {
     }
 
     @Test
+    fun menu_design_shows_the_footer_unless_disabled() {
+        composeTestRule.setContent {
+            AzDropdownMenu(expanded = true) {
+                azItem("Profile") { }
+            }
+        }
+        // The MENU design carries the rail's footer.
+        composeTestRule.onNodeWithText("About").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Feedback").assertIsDisplayed()
+        composeTestRule.onNodeWithText("@HereLiesAz").assertIsDisplayed()
+    }
+
+    @Test
+    fun footer_is_hidden_when_showFooter_is_false() {
+        composeTestRule.setContent {
+            AzDropdownMenu(expanded = true) {
+                azConfig(showFooter = false)
+                azItem("Profile") { }
+            }
+        }
+        composeTestRule.onNodeWithText("Feedback").assertDoesNotExist()
+    }
+
+    @Test
     fun route_navigates_the_nav_controller() {
         lateinit var navController: androidx.navigation.NavHostController
         composeTestRule.setContent {

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -156,9 +156,12 @@ inline like any widget. Tapping it unfolds an **overlay
 panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `design` picks
 `AzDropdownDesign.RAIL` (compact rail buttons at the collapsed width ≈100dp) or `AzDropdownDesign.MENU`
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the
-`LEFT`/`RIGHT` screen edge; the panel drops from the trigger automatically. Items use
-`azItem`/`azToggle`/`azCycler`/`azDivider` with only the rail's sanctioned per-item knobs, plus a
-`route` that navigates the supplied `NavController` (so the drop-down can drive an `AzNavHost`).
+`LEFT`/`RIGHT` screen edge; the panel drops from the trigger automatically. The `MENU` design
+renders rows at the rail's menu-item text size and, like the rail's expanded menu, carries the
+footer (About / Feedback / @HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind
+"About"). Items use `azItem`/`azToggle`/`azCycler`/`azDivider` with only the rail's sanctioned
+per-item knobs, plus a `route` that navigates the supplied `NavController` (so the drop-down can
+drive an `AzNavHost`).
 
 ```kotlin
 AzDropdownMenu(navController = navController) {

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -116,7 +116,9 @@ interface AzDropdownMenuScope {
         expandedWidth: Dp = 160.dp,
         collapsedWidth: Dp = 100.dp,
         headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,  // app-icon clip, like azTheme
-        headerIconSize: Dp = 48.dp                          // app-icon diameter, like azTheme
+        headerIconSize: Dp = 48.dp,                         // app-icon diameter, like azTheme
+        showFooter: Boolean = true,                         // MENU footer (About/Feedback/@HereLiesAz)
+        appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail"  // footer "About" link
     )
     fun azItem(text, route = null, color, textColor, fillColor, shape, enabled, closeOnClick = true, onClick)
     fun azToggle(isChecked, toggleOnText, toggleOffText, route = null, …, onToggle)
@@ -129,9 +131,11 @@ interface AzDropdownMenuScope {
 (`AzDropdownDesign.RAIL` = compact rail buttons at `collapsedWidth` ≈100dp; `AzDropdownDesign.MENU`
 = full-width labeled rows at `expandedWidth` ≈160dp), `dockingSide` pins the panel to the `LEFT`
 or `RIGHT` screen edge, and `headerIconShape`/`headerIconSize` set the app-icon trigger's clip and
-diameter (the same knobs the rail exposes via `azTheme`). The panel drops from the trigger
-automatically (downward when it fits, else upward). Items accept only the rail's sanctioned per-item
-knobs, plus a navigation `route`: when set,
+diameter (the same knobs the rail exposes via `azTheme`). The `MENU` design renders rows at the
+rail's menu-item text size and — like the rail's expanded menu — carries the footer
+(About / Feedback / @HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind "About"). The
+panel drops from the trigger automatically (downward when it fits, else upward). Items accept only the
+rail's sanctioned per-item knobs, plus a navigation `route`: when set,
 tapping navigates the `navController` (so the drop-down can drive an `AzNavHost`), then runs the
 callback, then folds up if `closeOnClick`.
 


### PR DESCRIPTION
## What & why

Two fixes to make the `MENU`-design drop-down faithfully match the rail's **expanded menu**, per feedback:

1. **The footer was missing.** The rail's expanded menu has an **About / Feedback / @HereLiesAz** footer (`internal/Footer.kt` / the RN/web `renderFooter`). The drop-down's `MENU` design now appends it.
2. **The menu text was too big.** The drop-down rendered rows at 22 (RN) / 20px (web), but the rail's menu items are **16** / **16px** (`RailMenuItem` / `.az-menu-item-text`). Android already used `titleLarge`, matching the rail's `MenuItem`, so it was unchanged.

## Changes

- **Footer**: `azConfig` (Android) and props (RN/web) gain `showFooter` (default `true`) + `appRepositoryUrl` (both sanctioned rail config). The `MENU` panel appends the footer — **About** → opens `appRepositoryUrl`, **Feedback** → mailto, **@HereLiesAz** → Instagram — mirroring the rail. `RAIL` design and `showFooter = false` omit it. (The standalone drop-down opens the repo URL in the browser rather than pulling in the rail's in-app About reader.)
- **Text size**: MENU rows now match the rail's menu item — RN 22→16, web 1.25rem→16px (+ weight 500, 12/16 padding); Android unchanged (`titleLarge`).

## Verification

- `npx tsc --noEmit` clean; `jest src/__tests__/AzDropdownMenu.test.tsx` → **12/12** (new tests: footer shown in MENU / hidden when `showFooter=false` and in RAIL; rows render at `fontSize: 16`); `npm run build` regenerates `lib/`.
- Robolectric `AzDropdownMenuTest` gains footer presence/absence tests. Android has no SDK here, so it relies on CI + review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV

---
_Generated by [Claude Code](https://claude.ai/code/session_018AVsnJ9UKrbJsLzz1GZjZV)_

## Summary by Sourcery

Align the dropdown menu's MENU design with the rail's expanded menu across Android, React Native, and web.

New Features:
- Add an optional footer to the MENU design dropdown that mirrors the rail footer (About / Feedback / @HereLiesAz), configurable via showFooter and appRepositoryUrl on all platforms.

Enhancements:
- Adjust MENU design dropdown item typography and padding on React Native and web to match the rail menu item text size and weight.
- Document the MENU design's footer behavior and text-size alignment in the DSL docs, guides, README, and changelog, and add tests validating footer visibility and menu text size.
- Harden footer links by restricting About/Feedback URLs to safe http(s)/mailto schemes before opening them.

Tests:
- Extend Android and React Native dropdown menu tests to cover footer presence/absence and MENU text sizing behavior.