### PR TITLE
Auto-generate the About page from the host app's repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,13 +167,17 @@ configurable (mirroring the rail's `azTheme`). Only the dropped list is an overl
   `aznavrail-react/src/components/AzDropdownMenu.tsx` (RN) and `src/web/AzDropdownMenu.jsx` (web).
 - DSL like the rail (collect-then-render): the `content` is a plain `AzDropdownMenuScope.() -> Unit`
   builder. `azConfig(design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape,
-  headerIconSize, showFooter, appRepositoryUrl)` mirrors the rail's `azConfig`/`azTheme` (RN/web take
-  the same as props); items are `azItem`/`azToggle`/`azCycler`/`azDivider` accepting only the rail's
-  per-item knobs (`color`/`textColor`/`fillColor`/`shape`/`enabled`/`closeOnClick`) plus a `route`.
+  headerIconSize, showFooter, inAppAbout = true, appRepositoryUrl = "")` mirrors the rail's
+  `azConfig`/`azTheme` (RN/web take the same as props); items are `azItem`/`azToggle`/`azCycler`/`azDivider`
+  accepting only the rail's per-item knobs (`color`/`textColor`/`fillColor`/`shape`/`enabled`/`closeOnClick`)
+  plus a `route`. `appRepositoryUrl` is an optional override — blank auto-derives the repo from the app
+  namespace (`com.<owner>.<repo>` → `github.com/<owner>/<repo>`), never the AzNavRail library repo.
 - The `MENU` design renders rows at the rail's menu-item text size (Android `titleLarge`; RN/web 16px,
   matching `RailMenuItem`/`.az-menu-item-text`) and — like the rail's expanded menu — appends the
-  footer (About → `appRepositoryUrl`, Feedback → mailto, @HereLiesAz → Instagram) when `showFooter`,
-  mirroring `internal/Footer.kt` / the rail's `renderFooter`.
+  footer (About, Feedback → mailto, @HereLiesAz → Instagram) when `showFooter`, mirroring
+  `internal/Footer.kt` / the rail's `renderFooter`. The dropdown has no onscreen/host area, so tapping
+  About opens a **full-screen** in-app reader drawn as its own layer when `inAppAbout = true` (the
+  default); `inAppAbout = false` opens the resolved repo in a browser.
 - `design` (`AzDropdownDesign { RAIL, MENU }`, default `MENU`) styles the panel as the collapsed rail
   (compact buttons, `collapsedWidth` ≈100dp) or the expanded menu (full-width labeled rows,
   `expandedWidth` ≈160dp). `dockingSide` (`AzDockingSide { LEFT, RIGHT }`) **pins the panel to that
@@ -185,16 +189,30 @@ configurable (mirroring the rail's `azTheme`). Only the dropped list is an overl
   exactly like `MenuItem.kt`. RN/web use an `onNavigate(route)` prop + `route?` on `AzDropdownItem`.
 - Controlled `expanded`/`onExpandedChange` remain. Tapping outside, back, or an item folds it up.
 
-In-app About reader + "More from Az": the footer "About" item opens a built-in, full-screen, themed
-markdown reader (an overlay drawn over the live UI, like the help overlay) instead of opening the repo
-URL in a browser. It auto-discovers the consuming app's docs by listing the `.md` files in the
-repository root and the `docs/` folder of `appRepositoryUrl` via the GitHub contents API, builds a
-table of contents, and renders each doc inline. Fetches are cached (ETag + TTL) to respect GitHub's
-unauthenticated rate limit; offline/limited shows the last cached copy. Public repos only. Configured
-via `azAbout(inAppAbout, moreFromAzEnabled, moreFromAzJsonUrl, moreRailItem)`; `inAppAbout = false`
-restores the browser behavior. A repo-root `.azignore` (one pattern per line; `#` comments; exact
-paths, `dir/` prefixes, or `*` globs) excludes listed docs from the About TOC — implemented in
-`GithubDocsRepository.parseIgnore`/`isIgnored` (Android) and `githubDocs.ts` (React).
+In-app About reader + "More from Az": the footer "About" item opens a built-in, themed markdown reader
+instead of opening the repo URL in a browser. On the rail (Android/web) About + More-from-Az flow
+through the host's `onscreen()` layout path (rail stays docked beside them); the standalone
+`AzDropdownMenu` has no onscreen area, so its About is drawn as its own **full-screen** layer. It
+auto-discovers the consuming app's docs by listing the `.md` files in the repository root and the
+`docs/` folder of the resolved repo via the GitHub contents API, builds a table of contents, and
+renders each doc inline. Fetches are cached (ETag + TTL) to respect GitHub's unauthenticated rate
+limit; offline/limited shows the last cached copy. Public repos only.
+
+Repo resolution: on **Android** the repo is auto-derived from the app **namespace** — `com.<owner>.<repo>`
+→ `https://github.com/<owner>/<repo>` (owner = 2nd segment, repo = last segment; a trailing build
+suffix like `.debug` is stripped), via `GithubDocsRepository.repoUrlFromPackage`. `appRepositoryUrl`
+(on `azConfig` and `AzDropdownMenu`'s `azConfig`, default `""`) is an **optional** override and the
+derivation **never** falls back to the AzNavRail library repo. On **web** there is no namespace, so
+`appRepositoryUrl` is **required** there (no auto-derivation); when unset the About entry is hidden.
+
+Configured via `azAbout(inAppAbout, moreFromAzEnabled, moreFromAzJsonUrl, moreRailItem)`;
+`inAppAbout = false` restores the browser behavior. A repo-root `.azignore` (one pattern per line;
+`#` comments; exact paths, `dir/` prefixes, or `*` globs) excludes listed docs from the About TOC —
+implemented in `GithubDocsRepository.parseIgnore`/`isIgnored` (Android) and `githubDocs.ts` (React).
+
+Guides hidden over footer screens (all platforms): while a footer screen (About or More-from-Az) is
+open, any visible Help cards and any in-progress tutorial are hidden but kept mounted, so they return
+exactly where they were when the footer screen closes.
 
 "More from Az" is a carousel of the author's other apps reachable from the About screen and/or a
 pinned "More" rail item (`moreRailItem`). The maintainer **pastes GitHub repo links, one per line,

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Add JitPack to your `settings.gradle.kts`:
 - **No Menu Mode**: Treat all items as rail items, removing the side drawer.
 - **`AzDropdownMenu`**: A standalone, app-icon drop-down declared with the rail's opinionated DSL (`azConfig` + `azItem`/`azToggle`/`azCycler`/`azDivider`). Its overlay panel is styled as the rail or menu (`design`), width-constrained to match, and pinned to the `dockingSide` screen edge. Items can carry a `route` to drive an `AzNavHost` via a `NavController`, exactly like the rail — and it accepts no styling the rest of the library doesn't.
 - **Sizable Header Icon**: Set the app-icon to an exact diameter via `headerIconSize`.
-- **In-App About Reader**: The footer "About" opens a themed in-app markdown reader that auto-discovers your repo's docs (root + `docs/`) and renders them inline. (`azAbout`)
+- **In-App About Reader**: The footer "About" opens a themed in-app markdown reader that auto-discovers your repo's docs (root + `docs/`) and renders them inline. On Android the repo is auto-derived from the app namespace (`appRepositoryUrl` is an optional override); on web `appRepositoryUrl` is required. (`azAbout`)
 - **More from Az**: A self-versioning carousel of other apps — paste GitHub repo links and CI bakes name/icon/description, a verified Play link, and the homepage website/PWA (WIP apps excluded, Play-first); optionally pinned as a "More" rail item.
 - **AzHostActivityLayout**: A layout container that enforces strict safe zones and automatic alignment rules.
 - **AzNavHost**: A wrapper around `androidx.navigation.compose.NavHost` for seamless integration.
@@ -458,8 +458,11 @@ full-width labeled rows at the **expanded width**, ≈160dp); **`dockingSide`** 
 rail's `azTheme`) and `vibrate`/`expandedWidth`/`collapsedWidth` round out the config. The panel
 **drops from the trigger** automatically (downward when it fits, otherwise upward). The `MENU` design
 renders rows at the rail's menu-item text size and carries the rail's **footer** (About / Feedback /
-@HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind "About"), just like the expanded
-menu.
+@HereLiesAz, gated by `showFooter`), just like the expanded menu. Because the dropdown has no
+onscreen/host area, tapping **About** opens a **full-screen in-app reader** drawn as its own layer
+(when `inAppAbout = true`, the default); set `inAppAbout = false` to open the repo in a browser
+instead. The repo is auto-derived from the app namespace on Android, with `appRepositoryUrl` as an
+optional override (never the AzNavRail library repo).
 
 Items are declared with `azItem` / `azToggle` / `azCycler` / `azDivider`, accepting only the rail's
 sanctioned per-item knobs (`color`/`textColor`/`fillColor`/`shape`/`enabled`/`closeOnClick`). Each may
@@ -507,19 +510,32 @@ const settings: AzNavRailSettings = { headerIconSize: 48 };
 
 The footer **About** item can open a built-in, themed **in-app documentation reader** instead of
 launching the browser. It **auto-discovers** your app's markdown docs — every `.md` file in the repo
-**root** and the **`docs/`** folder of your configured `appRepositoryUrl` — via the GitHub API, builds
+**root** and the **`docs/`** folder of the resolved repository — via the GitHub API, builds
 a table of contents, and renders each doc inline with a markdown renderer themed to the rail
 (`activeColor` links, `translucentBackground` surfaces). A **View on GitHub** button is pinned at the
 bottom with extra spacing.
 
+**Repo resolution differs by platform:**
+
+- **Android** auto-derives the repo from the app's **namespace**: `com.<owner>.<repo>` →
+  `https://github.com/<owner>/<repo>` (owner = 2nd package segment, repo = last segment; a trailing
+  build suffix like `.debug` is stripped). `appRepositoryUrl` is therefore **optional** — set it only
+  when the namespace doesn't match the repo. It **never** falls back to the AzNavRail library repo.
+- **Web** has no package namespace, so `appRepositoryUrl` is **required**; when it is unset the About
+  entry is hidden.
+
+The standalone `AzDropdownMenu` has no onscreen area, so its **About** opens as its own **full-screen**
+in-app reader (same namespace derivation; `inAppAbout = false` reverts to a browser link).
+
 ```kotlin
-azConfig(appRepositoryUrl = "https://github.com/YourOrg/YourApp")
+// Android: appRepositoryUrl is optional — the repo is derived from the namespace by default.
+azConfig(/* appRepositoryUrl = "https://github.com/YourOrg/YourApp" */)  // optional override
 azAbout(inAppAbout = true)   // default; set false to open the repo URL in a browser instead
 ```
 
 ```tsx
 const settings: AzNavRailSettings = {
-  appRepositoryUrl: 'https://github.com/YourOrg/YourApp',
+  appRepositoryUrl: 'https://github.com/YourOrg/YourApp', // required on web
   inAppAbout: true,
 };
 ```
@@ -532,6 +548,9 @@ const settings: AzNavRailSettings = {
   `docs/internal/`, or `*` globs like `*.draft.md`).
 - The system **back** button (Android) / back arrow returns from a doc to the table of contents, then
   dismisses.
+- **Guides hidden over footer screens (all platforms):** while a footer screen (About or More from Az)
+  is open, any visible Help cards and any in-progress tutorial are hidden, and they return **exactly**
+  where they were when the footer screen closes.
 
 ### More from Az
 

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
@@ -100,7 +100,10 @@ fun MainApp() {
                 collapsedWidth = 100.dp,
                 displayAppName = false,
                 showFooter = true,
-                appRepositoryUrl = "https://github.com/HereLiesAz/AzNavRail",
+                // Blank → the About page auto-derives the repo from this app's namespace
+                // (com.hereliesaz.SampleApp → github.com/hereliesaz/SampleApp). The Customization
+                // screen can override it to demo the optional explicit URL.
+                appRepositoryUrl = "",
                 helpLineColors = emptyList(),
                 vibrate = false,
             )

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
@@ -58,7 +58,11 @@ private val helpLinePalettes = listOf(
     "Mono" to listOf(Color(0xFF00ACC1)),
     "Warm" to listOf(Color(0xFFEF6C00), Color(0xFFD32F2F), Color(0xFFC2185B)),
 )
+// The first choice (empty string) is the default: the About page auto-derives the repo from the
+// app's namespace (com.hereliesaz.SampleApp → github.com/hereliesaz/SampleApp). The remaining
+// entries demonstrate the OPTIONAL explicit override.
 private val repoChoices = listOf(
+    "Auto (from namespace)" to "",
     "AzNavRail" to "https://github.com/HereLiesAz/AzNavRail",
     "Anthropic" to "https://github.com/anthropics",
     "JetBrains Compose" to "https://github.com/JetBrains/compose-multiplatform",
@@ -162,6 +166,13 @@ fun CustomizationDemoScreen(
         )
 
         SectionLabel("appRepositoryUrl")
+        Text(
+            "Optional override for the About reader's repo. Blank (Auto) derives it from the app " +
+                "namespace on Android (com.<owner>.<repo> → github.com/<owner>/<repo>); it never " +
+                "falls back to the AzNavRail library repo. On web there is no namespace, so " +
+                "appRepositoryUrl is required there.",
+            style = MaterialTheme.typography.bodySmall,
+        )
         val repoLabel = repoChoices.firstOrNull { it.second == state.appRepositoryUrl }?.first ?: "Custom"
         AzCycler(
             options = repoChoices.map { it.first },
@@ -207,7 +218,7 @@ fun CustomizationDemoScreen(
                         collapsedWidth = 100.dp,
                         displayAppName = false,
                         showFooter = true,
-                        appRepositoryUrl = "https://github.com/HereLiesAz/AzNavRail",
+                        appRepositoryUrl = "",
                         helpLineColors = emptyList(),
                         vibrate = false,
                     )

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **About reader docs clarified for the repo-resolution split.** Android auto-derives the repo from
+  the app namespace (`com.<owner>.<repo>` → `github.com/<owner>/<repo>`), so `appRepositoryUrl` is an
+  optional override there and never falls back to the AzNavRail library repo. On **web** there is no
+  package namespace, so `appRepositoryUrl` remains **required** (no auto-derivation); when it is unset
+  the About entry is hidden. Also documented: the standalone `AzDropdownMenu`'s full-screen in-app
+  About reader, and that visible Help cards and any in-progress tutorial hide while a footer screen
+  (About / More from Az) is open and restore exactly where they were on close. Behavior on web is
+  unchanged — docs/migration notes only.
+
 ## 0.4.1
 
 ### Fixed

--- a/aznavrail-react/MIGRATION_FROM_ANDROID.md
+++ b/aznavrail-react/MIGRATION_FROM_ANDROID.md
@@ -85,16 +85,25 @@ physical docking, the footer, nested-rail popups, the bleeding app-name header, 
 | `azAbout(moreFromAzEnabled = true)` | `moreFromAzEnabled` |
 | `azAbout(moreRailItem = true)` | `moreRailItem` |
 | `azAbout(moreFromAzJsonUrl = "…")` | `moreFromAzJsonUrl` |
-| `azConfig(appRepositoryUrl = "…")` | `appRepositoryUrl` |
+| `azConfig(appRepositoryUrl = "…")` — **optional** override (auto-derived from namespace) | `appRepositoryUrl` — **required** (no namespace to derive from) |
 
 The footer "About" opens an in-app markdown reader that auto-discovers the repo's docs (root +
-`docs/`) via the GitHub API. "More from Az" is a carousel whose `more-from-az.json` you fill by
+`docs/`) via the GitHub API. **Repo resolution differs by platform:** on **Android** the repo is
+auto-derived from the app **namespace** (`com.<owner>.<repo>` → `https://github.com/<owner>/<repo>`),
+so `appRepositoryUrl` is an optional override and never falls back to the AzNavRail library repo.
+**Web has no package namespace, so `appRepositoryUrl` is required there** (no auto-derivation); when
+it is unset the About entry is hidden. The standalone `AzDropdownMenu` has no onscreen area, so its
+About is drawn as its own full-screen layer (Android); set `inAppAbout` false to open the repo in a
+browser instead. While a footer screen (About or More from Az) is open, visible Help cards and any
+in-progress tutorial are hidden and restore exactly where they were on close.
+
+"More from Az" is a carousel whose `more-from-az.json` you fill by
 pasting GitHub repo links (one per line); a GitHub Action resolves each repo and **bakes** the
 finished manifest (name/icon/description, a verified Play link, the homepage website/PWA, WIP
 filtering, Play-first sort). Both screens are themed from `activeColor`/`translucentBackground` and
 built from the library's own components; markdown uses a small self-contained renderer (no
 `react-markdown` dependency). Because resolution is done in CI, "More from Az" metadata is identical
-on web and native — no CORS limitation. Use `appRepositoryUrl` to point the reader at your repo.
+on web and native — no CORS limitation.
 
 ## Bottom sheets
 

--- a/aznavrail/build.gradle.kts
+++ b/aznavrail/build.gradle.kts
@@ -99,6 +99,22 @@ afterEvaluate {
         publications {
             register<MavenPublication>("release") {
                 from(components["release"])
+                pom {
+                    name.set("AzNavRail")
+                    description.set("An opinionated, DSL-driven navigation rail for Jetpack Compose.")
+                    url.set("https://github.com/HereLiesAz/AzNavRail")
+                    // jitpack only emits a <licenses> block in the generated POM when the
+                    // publication declares one; without it licensee/scanners report "no license".
+                    // The name is the SPDX id and the url is the canonical license URL so licensee
+                    // resolves it cleanly.
+                    licenses {
+                        license {
+                            name.set("Apache-2.0")
+                            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                            distribution.set("repo")
+                        }
+                    }
+                }
             }
         }
     }

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -80,8 +80,18 @@ azConfig(
     dockingSide = AzDockingSide.LEFT,    // Enum: LEFT or RIGHT
     noMenu = noMenu,                     // Boolean: Disable the side drawer entirely
     usePhysicalDocking = usePhysicalDocking // Boolean: Anchor to physical hardware edge vs visual left
+    // appRepositoryUrl = ""                // Optional override for the About reader's repo (see below)
 )
 ```
+
+`azConfig` also takes `appRepositoryUrl` (default `""`), the repo the in-app **About** reader uses.
+On **Android** the repo is auto-derived from the app **namespace** — `com.<owner>.<repo>` →
+`https://github.com/<owner>/<repo>` (owner = 2nd segment, repo = last segment; a trailing build
+suffix like `.debug` is stripped) — so `appRepositoryUrl` is an **optional** override and it **never**
+falls back to the AzNavRail library repo. On **web** there is no package namespace, so
+`appRepositoryUrl` is **required** there (no auto-derivation); when unset the About entry is hidden.
+While a footer screen (About or More from Az) is open, visible Help cards and any in-progress tutorial
+are hidden and restore exactly where they were on close (all platforms).
 
 
 ### B. Theming (`azTheme`)
@@ -158,10 +168,13 @@ panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the
 `LEFT`/`RIGHT` screen edge; the panel drops from the trigger automatically. The `MENU` design
 renders rows at the rail's menu-item text size and, like the rail's expanded menu, carries the
-footer (About / Feedback / @HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind
-"About"). Items use `azItem`/`azToggle`/`azCycler`/`azDivider` with only the rail's sanctioned
-per-item knobs, plus a `route` that navigates the supplied `NavController` (so the drop-down can
-drive an `AzNavHost`).
+footer (About / Feedback / @HereLiesAz, gated by `showFooter`). Because the dropdown has no
+onscreen/host area, tapping **About** opens a **full-screen** in-app reader drawn as its own layer
+when `inAppAbout = true` (the default; `inAppAbout = false` opens the repo in a browser). The repo is
+auto-derived from the app namespace on Android, with `azConfig`'s `appRepositoryUrl` as an optional
+override (never the AzNavRail library repo). Items use `azItem`/`azToggle`/`azCycler`/`azDivider` with
+only the rail's sanctioned per-item knobs, plus a `route` that navigates the supplied `NavController`
+(so the drop-down can drive an `AzNavHost`).
 
 ```kotlin
 AzDropdownMenu(navController = navController) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -8,12 +8,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -26,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,7 +59,11 @@ import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
+import com.hereliesaz.aznavrail.internal.AboutOverlay
 import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
+import com.hereliesaz.aznavrail.internal.AzSafeZones
+import com.hereliesaz.aznavrail.internal.MoreFromAzOverlay
+import com.hereliesaz.aznavrail.service.GithubDocsRepository
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzDockingSide
 import com.hereliesaz.aznavrail.model.AzDropdownDesign
@@ -89,7 +97,12 @@ interface AzDropdownMenuScope {
      *   `azTheme(headerIconSize = …)`).
      * @param showFooter Whether the [AzDropdownDesign.MENU] panel shows the rail's footer
      *   (About / Feedback / @HereLiesAz), like the rail's expanded menu.
-     * @param appRepositoryUrl Repository URL opened by the footer's "About" item.
+     * @param inAppAbout When true (the default), the footer's "About" opens a full-screen, in-app
+     *   markdown reader auto-generated from the host app's repo (the dropdown has no onscreen area,
+     *   so it draws its own full-screen layer). When false, "About" opens the repo in a browser.
+     * @param appRepositoryUrl Optional explicit override for the host app's GitHub repository used by
+     *   the "About" screen. Blank (the default) auto-derives it from the app namespace
+     *   (`com.<owner>.<repo>` → `github.com/<owner>/<repo>`); never the AzNavRail library repo.
      */
     fun azConfig(
         design: AzDropdownDesign = AzDropdownDesign.MENU,
@@ -100,7 +113,8 @@ interface AzDropdownMenuScope {
         headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
         headerIconSize: Dp = 48.dp,
         showFooter: Boolean = true,
-        appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail"
+        inAppAbout: Boolean = true,
+        appRepositoryUrl: String = ""
     )
 
     /**
@@ -162,7 +176,8 @@ internal data class AzDropdownConfig(
     val headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
     val headerIconSize: Dp = 48.dp,
     val showFooter: Boolean = true,
-    val appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail"
+    val inAppAbout: Boolean = true,
+    val appRepositoryUrl: String = ""
 )
 
 /** One declared entry, collected by the builder and rendered by the composable. */
@@ -232,11 +247,12 @@ private class AzDropdownMenuScopeImpl : AzDropdownMenuScope {
         headerIconShape: AzHeaderIconShape,
         headerIconSize: Dp,
         showFooter: Boolean,
+        inAppAbout: Boolean,
         appRepositoryUrl: String
     ) {
         config = AzDropdownConfig(
             design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape, headerIconSize,
-            showFooter, appRepositoryUrl
+            showFooter, inAppAbout, appRepositoryUrl
         )
     }
 
@@ -338,11 +354,16 @@ private fun AzDropdownMenuRow(
 
 /**
  * The drop-down's footer for the [AzDropdownDesign.MENU] design — mirrors the rail's footer
- * ([com.hereliesaz.aznavrail.internal.Footer]): About (opens [appRepositoryUrl]), Feedback (email),
- * and the @HereLiesAz attribution. Centred [titleLarge] text in the theme primary, like the rail.
+ * ([com.hereliesaz.aznavrail.internal.Footer]): About, Feedback (email), and the @HereLiesAz
+ * attribution. Centred [titleLarge] text in the theme primary, like the rail.
+ *
+ * @param repoUrl The effective host-app repository (explicit override or namespace-derived) opened
+ *   by "About" when the in-app reader is disabled.
+ * @param onAboutClick When non-null, "About" opens the in-app reader via this callback instead of a
+ *   browser.
  */
 @Composable
-private fun AzDropdownFooter(appRepositoryUrl: String) {
+private fun AzDropdownFooter(repoUrl: String, onAboutClick: (() -> Unit)?) {
     val context = LocalContext.current
     val footerColor = MaterialTheme.colorScheme.primary
     val appName = remember(context.packageName) {
@@ -366,13 +387,17 @@ private fun AzDropdownFooter(appRepositoryUrl: String) {
             style = MaterialTheme.typography.titleLarge.copy(color = footerColor),
             modifier = Modifier
                 .clickable {
-                    // Only follow plain web URLs, never an injected scheme (e.g. javascript:/content:).
-                    val isHttp = appRepositoryUrl.startsWith("http://", ignoreCase = true) ||
-                        appRepositoryUrl.startsWith("https://", ignoreCase = true)
-                    if (isHttp) {
-                        try {
-                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(appRepositoryUrl)))
-                        } catch (e: Exception) {}
+                    if (onAboutClick != null) {
+                        onAboutClick()
+                    } else {
+                        // Only follow plain web URLs, never an injected scheme (e.g. javascript:/content:).
+                        val isHttp = repoUrl.startsWith("http://", ignoreCase = true) ||
+                            repoUrl.startsWith("https://", ignoreCase = true)
+                        if (isHttp) {
+                            try {
+                                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(repoUrl)))
+                            } catch (e: Exception) {}
+                        }
                     }
                 }
                 .padding(vertical = 4.dp)
@@ -585,8 +610,23 @@ fun AzDropdownMenu(
         onExpandedChange?.invoke(value)
     }
 
+    // Full-screen About / More-from-Az reader state. The dropdown has no host/onscreen area, so its
+    // About page is drawn as its own full-screen layer (above everything) rather than inline.
+    var showAbout by rememberSaveable { mutableStateOf(false) }
+    var showMoreFromAz by rememberSaveable { mutableStateOf(false) }
+    // A throwaway rail scope only supplies default theme tokens (accent/surface) to the reused
+    // overlays; the dropdown declares no rail theme of its own.
+    val overlayScope = remember { AzNavRailScopeImpl() }
+
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
+    // The repo backing the About reader: explicit override if set, else derived from the app
+    // namespace. Never the AzNavRail library repo.
+    val effectiveRepoUrl = remember(config.appRepositoryUrl, context.packageName) {
+        config.appRepositoryUrl.ifBlank {
+            GithubDocsRepository.repoUrlFromPackage(context.packageName) ?: config.appRepositoryUrl
+        }
+    }
     val maxPanelHeight = (LocalConfiguration.current.screenHeightDp * 0.8f).dp
     val panelWidth = if (config.design == AzDropdownDesign.RAIL) config.collapsedWidth else config.expandedWidth
 
@@ -658,11 +698,65 @@ fun AzDropdownMenu(
                         // The expanded-menu design carries the rail's footer (About / Feedback / @HereLiesAz).
                         if (config.design == AzDropdownDesign.MENU && config.showFooter) {
                             AzDivider()
-                            AzDropdownFooter(appRepositoryUrl = config.appRepositoryUrl)
+                            AzDropdownFooter(
+                                repoUrl = effectiveRepoUrl,
+                                onAboutClick = if (config.inAppAbout && effectiveRepoUrl.isNotBlank()) {
+                                    { dismiss(); showAbout = true }
+                                } else null
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Full-screen About reader / More-from-Az carousel for the dropdown. Drawn in its own Popup
+        // so it escapes the inline trigger box and covers the whole window (the dropdown has no host
+        // onscreen area). Safe-zone insets come from the system bars since there is no host to
+        // compute the rail's 10%/20% zones.
+        if (showAbout || showMoreFromAz) {
+            val systemBars = WindowInsets.systemBars.asPaddingValues()
+            Popup(
+                popupPositionProvider = AzFullScreenPopupPositionProvider,
+                onDismissRequest = { showAbout = false; showMoreFromAz = false },
+                properties = PopupProperties(focusable = true, dismissOnClickOutside = false)
+            ) {
+                CompositionLocalProvider(
+                    LocalAzSafeZones provides AzSafeZones(
+                        systemBars.calculateTopPadding(),
+                        systemBars.calculateBottomPadding()
+                    )
+                ) {
+                    Box(Modifier.fillMaxSize()) {
+                        if (showAbout) {
+                            AboutOverlay(
+                                repoUrl = effectiveRepoUrl,
+                                scope = overlayScope,
+                                onOpenMoreFromAz = { showMoreFromAz = true },
+                                onDismiss = { showAbout = false },
+                            )
+                        }
+                        // More-from-Az draws above About; dismissing it returns to About underneath.
+                        if (showMoreFromAz) {
+                            MoreFromAzOverlay(
+                                jsonUrl = overlayScope.advancedConfig.moreFromAzJsonUrl,
+                                scope = overlayScope,
+                                onDismiss = { showMoreFromAz = false },
+                            )
                         }
                     }
                 }
             }
         }
     }
+}
+
+/** Positions a [Popup] at the window origin so its `fillMaxSize` content covers the whole screen. */
+private val AzFullScreenPopupPositionProvider = object : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize
+    ): IntOffset = IntOffset(0, 0)
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavHost.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavHost.kt
@@ -31,11 +31,16 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -53,11 +58,15 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.hereliesaz.aznavrail.bottomsheet.AzBottomSheet
 import com.hereliesaz.aznavrail.bottomsheet.AzSheetController
+import com.hereliesaz.aznavrail.internal.AboutOverlay
 import com.hereliesaz.aznavrail.internal.AzBottomSheetItem
 import com.hereliesaz.aznavrail.internal.AzLayoutConfig
 import com.hereliesaz.aznavrail.internal.AzNavMode
 import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
 import com.hereliesaz.aznavrail.internal.AzRailLayoutHelper
+import com.hereliesaz.aznavrail.internal.HelpOverlay
+import com.hereliesaz.aznavrail.internal.MoreFromAzOverlay
+import com.hereliesaz.aznavrail.service.GithubDocsRepository
 import com.hereliesaz.aznavrail.internal.AzSafeZones
 import com.hereliesaz.aznavrail.internal.azResolveSafeBottom
 import com.hereliesaz.aznavrail.internal.AzVisualSide
@@ -174,6 +183,26 @@ internal fun azOrderBackgrounds(items: List<AzBackgroundItem>, pagesEnabled: Boo
 internal fun azOrderOnscreen(items: List<AzOnscreenItem>, pagesEnabled: Boolean): List<AzOnscreenItem> =
     if (pagesEnabled) items.sortedByDescending { it.page } else items
 
+/**
+ * Visually hides and input-disables a guide overlay (Help cards / interactive tutorial) while a
+ * footer screen (About / More-from-Az) is open, WITHOUT removing it from composition. Keeping the
+ * overlay mounted preserves its local progress state (tutorial scene/card/checklist, help
+ * expanded-card/scroll), so it reappears exactly where the user left it once the footer screen is
+ * dismissed. When [suppressed] it draws at `alpha = 0` and swallows all pointer input (so a stray
+ * tap on the still-mounted full-screen background can't dismiss it).
+ */
+internal fun Modifier.azSuppressGuide(suppressed: Boolean): Modifier =
+    if (!suppressed) this
+    else this
+        .graphicsLayer { alpha = 0f }
+        .pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    awaitPointerEvent(PointerEventPass.Initial).changes.forEach { it.consume() }
+                }
+            }
+        }
+
 /** Concrete implementation of [AzNavHostScope] used internally by [AzHostActivityLayout]. */
 class AzNavHostScopeImpl(
     private val railScope: AzNavRailScopeImpl = AzNavRailScopeImpl()
@@ -185,6 +214,30 @@ class AzNavHostScopeImpl(
     val backgrounds = mutableStateListOf<AzBackgroundItem>()
     val onscreenItems = mutableStateListOf<AzOnscreenItem>()
     internal val bottomSheets = mutableStateListOf<AzBottomSheetItem>()
+
+    // --- Built-in overlay visibility ---
+    // The rail (which always runs inside this host) flips these on user action; the host renders the
+    // About reader and "More from Az" carousel through the onscreen() layout path, and the Help
+    // overlay full-screen (it draws connector lines to rail items that live outside the onscreen safe
+    // area). State lives here, not on the rail, so the host can render the overlays like any other
+    // onscreen content. It is deliberately NOT cleared by resetHost(), so visibility survives the DSL
+    // being re-applied on every recomposition.
+    var aboutVisible by mutableStateOf(false)
+        private set
+    var helpVisible by mutableStateOf(false)
+        private set
+    /** When non-null, the Help overlay is scoped to that nested rail's child items. */
+    var helpScopeId by mutableStateOf<String?>(null)
+        private set
+    var moreFromAzVisible by mutableStateOf(false)
+        private set
+
+    fun showAbout() { aboutVisible = true }
+    fun hideAbout() { aboutVisible = false }
+    fun showHelp(scopeId: String?) { helpScopeId = scopeId; helpVisible = true }
+    fun hideHelp() { helpVisible = false; helpScopeId = null }
+    fun showMoreFromAz() { moreFromAzVisible = true }
+    fun hideMoreFromAz() { moreFromAzVisible = false }
 
     fun setController(controller: NavHostController) {
         _navController = controller
@@ -427,6 +480,7 @@ fun AzHostActivityLayout(
 
         CompositionLocalProvider(
             LocalAzNavHostPresent provides true,
+            LocalAzNavHostScope provides scope,
             LocalAzSafeZones provides AzSafeZones(safeTop, safeBottom),
             LocalAzTutorialController provides tutorialController
         ) {
@@ -445,6 +499,74 @@ fun AzHostActivityLayout(
                 reverseLayout = reverseLayout,
                 content = {}
             )
+        }
+
+        // Built-in overlays, host-managed and rendered like the rest of the screen. The rail flips
+        // the visibility flags on this host scope; the host renders the overlays here so they are no
+        // longer bespoke full-screen layers bolted onto the rail.
+        //
+        // About + More-from-Az are full content surfaces, so they flow through the SAME safe-zone /
+        // rail-padding / docking treatment as onscreen() content — the rail stays docked and visible
+        // beside them. Help stays full-screen: it draws connector lines from rail items (which sit in
+        // the rail strip, outside the onscreen safe area) to their cards, so it must span the window.
+        val effectiveRepoUrl = remember(railScope.appRepositoryUrl, context.packageName) {
+            railScope.appRepositoryUrl.ifBlank {
+                GithubDocsRepository.repoUrlFromPackage(context.packageName) ?: railScope.appRepositoryUrl
+            }
+        }
+
+        CompositionLocalProvider(
+            LocalAzNavHostScope provides scope,
+            LocalAzSafeZones provides AzSafeZones(safeTop, safeBottom),
+            LocalAzTutorialController provides tutorialController,
+        ) {
+            if (scope.aboutVisible || scope.moreFromAzVisible) {
+                // Pad only the rail offset; the overlays apply top/bottom safe-zone insets themselves
+                // from the LocalAzSafeZones provided above (so the same composables work standalone
+                // under the dropdown, which has no host wrapper).
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = topPadding, bottom = bottomPadding, start = startPadding, end = endPadding)
+                ) {
+                    if (scope.aboutVisible) {
+                        AboutOverlay(
+                            repoUrl = effectiveRepoUrl,
+                            scope = railScope,
+                            onOpenMoreFromAz = if (railScope.advancedConfig.moreFromAzEnabled) {
+                                { scope.showMoreFromAz() }
+                            } else null,
+                            onDismiss = { scope.hideAbout() },
+                        )
+                    }
+                    // More-from-Az draws above About (later in the Box), so opening it from the About
+                    // screen covers it and dismissing returns to About underneath.
+                    if (scope.moreFromAzVisible) {
+                        MoreFromAzOverlay(
+                            jsonUrl = railScope.advancedConfig.moreFromAzJsonUrl,
+                            scope = railScope,
+                            onDismiss = { scope.hideMoreFromAz() },
+                        )
+                    }
+                }
+            }
+
+            // While a footer screen (About / More-from-Az) is open, the Help overlay is hidden but
+            // kept mounted so its expanded-card/scroll state restores untouched on close.
+            if (scope.helpVisible) {
+                Box(Modifier.azSuppressGuide(scope.aboutVisible || scope.moreFromAzVisible)) {
+                    HelpOverlay(
+                        items = railScope.navItems,
+                        helpLineColors = railScope.helpLineColors,
+                        onDismiss = { scope.hideHelp(); railScope.advancedConfig.onDismissHelp?.invoke() },
+                        itemBoundsCache = railScope.itemBoundsCache,
+                        helpList = railScope.advancedConfig.helpList,
+                        nestedRailOpenId = scope.helpScopeId,
+                        tutorials = railScope.advancedConfig.tutorials,
+                        onTutorialLaunch = { id -> tutorialController.startTutorial(id); scope.hideHelp() },
+                    )
+                }
+            }
         }
 
         // Bottom sheets registered via azBottomSheet { ... } draw above EVERYTHING — including

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -70,16 +70,14 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import coil.compose.rememberAsyncImagePainter
-import com.hereliesaz.aznavrail.internal.AboutOverlay
 import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
 import com.hereliesaz.aznavrail.internal.AzNavRailLogger
-import com.hereliesaz.aznavrail.internal.MoreFromAzOverlay
 import com.hereliesaz.aznavrail.internal.CyclerTransientState
 import com.hereliesaz.aznavrail.internal.Footer
-import com.hereliesaz.aznavrail.internal.HelpOverlay
 import com.hereliesaz.aznavrail.internal.MenuItem
 import com.hereliesaz.aznavrail.internal.RailItems
 import com.hereliesaz.aznavrail.internal.SecretScreens
+import com.hereliesaz.aznavrail.service.GithubDocsRepository
 import com.hereliesaz.aznavrail.model.AzDockingSide
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzNavItem
@@ -231,6 +229,13 @@ fun AzNavRail(
     val appIcon = remember(packageName) {
         try { packageManager.getApplicationIcon(packageName) } catch (e: Exception) { null }
     }
+    // The repo backing the About screen / footer link: the explicit override if set, otherwise
+    // auto-derived from the app namespace. Never the AzNavRail library repo.
+    val effectiveRepoUrl = remember(scope.appRepositoryUrl, packageName) {
+        scope.appRepositoryUrl.ifBlank {
+            GithubDocsRepository.repoUrlFromPackage(packageName) ?: scope.appRepositoryUrl
+        }
+    }
 
     var isExpanded by remember { mutableStateOf(if (scope.noMenu) false else initiallyExpanded) }
     var isFloating by remember { mutableStateOf(false) }
@@ -238,13 +243,12 @@ fun AzNavRail(
     var offsetY by remember { mutableStateOf(0f) }
     var showFloatingButtons by remember { mutableStateOf(false) }
     var railContentHeight by remember { mutableStateOf(0f) }
-    var showHelpOverlay by remember { mutableStateOf(false) }
-    // About reader + "More from Az" carousel overlays (drawn over the live UI like the help overlay).
-    var showAboutOverlay by remember { mutableStateOf(false) }
-    var showMoreFromAz by remember { mutableStateOf(false) }
-    // When the help item that triggered the overlay lives inside a nested rail, this holds the
-    // parent item's id so the overlay shows only that nested rail's cards. Null = main rail scope.
-    var helpScopeId by remember { mutableStateOf<String?>(null) }
+    // Built-in overlay visibility (About / Help / More-from-Az) lives on the host scope so the host
+    // can render those overlays like the rest of the screen. The rail reads it here for
+    // snapshot-reactive UI below and flips it via host.show*/hide* in the trigger handlers. The host
+    // is always present (the rail errors out above without one), so this is effectively non-null.
+    val hostScope = LocalAzNavHostScope.current as? AzNavHostScopeImpl
+    val showHelpOverlay = hostScope?.helpVisible == true
     var wasFloatingOpenBeforeDrag by remember { mutableStateOf(false) }
     val tutorialController = LocalAzTutorialController.current
     val activeTutorialId by tutorialController.activeTutorialId
@@ -302,28 +306,26 @@ fun AzNavRail(
     // Tracks the last evaluated result of each host's `expandWhen` condition for edge detection.
     val expandWhenSeen = remember { mutableMapOf<String, Boolean>() }
 
-    val toggleHelpOverlay = remember(scope) {
+    val toggleHelpOverlay = remember(scope, hostScope) {
         { itemId: String? ->
             if (itemId != null && scope.advancedConfig.tutorials.containsKey(itemId)) {
                 tutorialController.startTutorial(itemId)
-                showHelpOverlay = false // ensure help overlay is closed
-                helpScopeId = null
+                hostScope?.hideHelp() // ensure help overlay is closed
             } else {
-                if (showHelpOverlay) {
-                    showHelpOverlay = false
-                    helpScopeId = null
+                if (hostScope?.helpVisible == true) {
+                    hostScope.hideHelp()
                     scope.advancedConfig.onDismissHelp?.invoke()
                 } else {
                     // Locate the tapped help item's parent nested rail (if any) so the overlay
                     // can scope its cards to that rail. A help item under a `azNestedRail { ... }`
                     // block lives in some parent's `nestedRailItems`; a main-rail help item lives
                     // directly in scope.navItems and resolves to scope=null.
-                    helpScopeId = itemId?.let { id ->
+                    val scopeId = itemId?.let { id ->
                         scope.navItems.firstOrNull { parent ->
                             parent.isNestedRail && parent.nestedRailItems?.any { it.id == id } == true
                         }?.id
                     }
-                    showHelpOverlay = true
+                    hostScope?.showHelp(scopeId)
                 }
             }
         }
@@ -798,7 +800,7 @@ fun AzNavRail(
                             ) {
                                 val moreColor = scope.activeColor.takeOrElse { MaterialTheme.colorScheme.primary }
                                 AzButton(
-                                    onClick = { showMoreFromAz = true },
+                                    onClick = { hostScope?.showMoreFromAz() },
                                     text = "More",
                                     color = moreColor,
                                     activeColor = moreColor,
@@ -824,9 +826,10 @@ fun AzNavRail(
                             },
                             onSecretClick = onSecretClick,
                             scope = scope,
+                            repoUrl = effectiveRepoUrl,
                             footerColor = scope.activeColor,
                             onAboutClick = if (scope.advancedConfig.inAppAbout) {
-                                { isExpanded = false; showAboutOverlay = true }
+                                { isExpanded = false; hostScope?.showAbout() }
                             } else null
                         )
                     }
@@ -836,50 +839,22 @@ fun AzNavRail(
     }
 }
 
-    if (showHelpOverlay) {
-        // helpScopeId controls the overlay's item scope: null = main rail, non-null = the parent
-        // nested-rail id whose children are the only items the overlay should describe.
-        HelpOverlay(
-            items = scope.navItems,
-            helpLineColors = scope.helpLineColors,
-            onDismiss = { toggleHelpOverlay(null) },
-            itemBoundsCache = scope.itemBoundsCache,
-            helpList = scope.advancedConfig.helpList,
-            nestedRailOpenId = helpScopeId,
-            tutorials = scope.advancedConfig.tutorials,
-            onTutorialLaunch = { toggleHelpOverlay(it) }
-        )
-    }
-
-    // In-app About reader overlay (auto-generated from the repo's markdown docs).
-    if (showAboutOverlay) {
-        AboutOverlay(
-            repoUrl = scope.appRepositoryUrl,
-            scope = scope,
-            onOpenMoreFromAz = if (scope.advancedConfig.moreFromAzEnabled) {
-                { showMoreFromAz = true }
-            } else null,
-            onDismiss = { showAboutOverlay = false }
-        )
-    }
-
-    // "More from Az" carousel overlay, drawn above the About reader.
-    if (showMoreFromAz) {
-        MoreFromAzOverlay(
-            jsonUrl = scope.advancedConfig.moreFromAzJsonUrl,
-            scope = scope,
-            onDismiss = { showMoreFromAz = false }
-        )
-    }
-
+    // The About reader, Help overlay, and "More from Az" carousel are now rendered by
+    // AzHostActivityLayout (About + More-from-Az flow through the onscreen() layout path; Help stays
+    // full-screen). The rail only flips their visibility on the host scope via the trigger handlers
+    // above. The interactive tutorial spotlight stays here — it is a guided overlay, not a content
+    // screen. While a footer screen (About / More-from-Az) is open it is hidden but kept mounted,
+    // so an in-progress tutorial resumes at the exact same scene/card/checklist on close.
     activeTutorialId?.let { tutorialId ->
         scope.advancedConfig.tutorials[tutorialId]?.let { tutorial ->
-            AzTutorialOverlay(
-                tutorialId = tutorialId,
-                tutorial = tutorial,
-                onDismiss = { tutorialController.endTutorial() },
-                itemBoundsCache = scope.itemBoundsCache
-            )
+            Box(Modifier.azSuppressGuide(hostScope?.aboutVisible == true || hostScope?.moreFromAzVisible == true)) {
+                AzTutorialOverlay(
+                    tutorialId = tutorialId,
+                    tutorial = tutorial,
+                    onDismiss = { tutorialController.endTutorial() },
+                    itemBoundsCache = scope.itemBoundsCache
+                )
+            }
         }
     }
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -65,9 +65,12 @@ interface AzNavRailScope {
      * @param expandedWidth The width of the rail when expanded (menu visible).
      * @param collapsedWidth The width of the rail when collapsed.
      * @param showFooter Whether to show the footer (Privacy, Terms, Help) in the menu.
-     * @param appRepositoryUrl The URL of the application's repository to link to in the footer's "About" section. Defaults to the AzNavRail repo.
+     * @param appRepositoryUrl Optional explicit override for the host app's GitHub repository used by
+     *   the "About" screen. Leave blank (the default) to auto-derive it from the app's namespace
+     *   (`com.<owner>.<repo>` → `github.com/<owner>/<repo>`); set it only when the namespace doesn't
+     *   match the repo. **Not required.**
      */
-    fun azConfig(dockingSide: AzDockingSide = AzDockingSide.LEFT, packButtons: Boolean = false, noMenu: Boolean = false, vibrate: Boolean = false, displayAppName: Boolean = false, activeClassifiers: Set<String> = emptySet(), usePhysicalDocking: Boolean = false, expandedWidth: Dp = 160.dp, collapsedWidth: Dp = 100.dp, showFooter: Boolean = true, appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail")
+    fun azConfig(dockingSide: AzDockingSide = AzDockingSide.LEFT, packButtons: Boolean = false, noMenu: Boolean = false, vibrate: Boolean = false, displayAppName: Boolean = false, activeClassifiers: Set<String> = emptySet(), usePhysicalDocking: Boolean = false, expandedWidth: Dp = 160.dp, collapsedWidth: Dp = 100.dp, showFooter: Boolean = true, appRepositoryUrl: String = "")
 
     /**
      * Configures the visual theme of the rail.
@@ -106,9 +109,11 @@ interface AzNavRailScope {
      *
      * When [inAppAbout] is true (the default), tapping the footer's "About" item opens an in-app,
      * themed markdown reader that auto-discovers this app's documentation (`.md` files in the repo
-     * root and `docs/` folder of [azConfig]'s `appRepositoryUrl`), builds a table of contents, and
-     * renders each doc inline. A GitHub repo button sits pinned at the bottom. Set [inAppAbout] to
-     * false to restore the legacy behavior of opening the repository URL in a browser.
+     * root and `docs/` folder). The repository is derived automatically from the app's namespace
+     * (`com.<owner>.<repo>` → `github.com/<owner>/<repo>`); [azConfig]'s `appRepositoryUrl` is only
+     * an optional override. A table of contents is built and each doc rendered inline, with a GitHub
+     * repo button pinned at the bottom. Set [inAppAbout] to false to restore the legacy behavior of
+     * opening the repository URL in a browser.
      *
      * When [moreFromAzEnabled] is true (the default), the About screen also offers a "More from Az"
      * entry that opens a carousel of the library author's other apps, fetched at runtime from
@@ -643,8 +648,12 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     var collapsedWidth: Dp = 100.dp
     /** Whether the footer (About, Feedback, @HereLiesAz) is shown when the menu is expanded. */
     var showFooter: Boolean = true
-    /** URL opened when the user taps "About" in the footer. */
-    var appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail"
+    /**
+     * Optional explicit override for the host app's GitHub repository used by the "About" screen.
+     * Blank (the default) means auto-derive it from the app namespace at render time. Never defaults
+     * to the AzNavRail library repo.
+     */
+    var appRepositoryUrl: String = ""
     /** Logical docking side used to calculate the visual side and slide-in direction. */
     var dockingSide: AzDockingSide = AzDockingSide.LEFT
     /** If true, buttons are packed with no spacing between them. */

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AboutOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AboutOverlay.kt
@@ -74,6 +74,8 @@ internal fun AboutOverlay(
     val context = LocalContext.current
     val accent = scope.activeColor.takeIf { it != Color.Unspecified } ?: MaterialTheme.colorScheme.primary
     val surface = scope.translucentBackground.takeIf { it != Color.Unspecified } ?: MaterialTheme.colorScheme.surface
+    // Safe-zone insets come from the host (rail) or a dropdown-supplied default; rail-offset padding,
+    // when present, is applied by the caller's wrapper.
     val safe = LocalAzSafeZones.current
     var selected by remember { mutableStateOf<AzDocEntry?>(null) }
 

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
@@ -34,7 +34,9 @@ import com.hereliesaz.aznavrail.AzNavRailScopeImpl
  * @param onToggle Callback to collapse the rail (bound to the Close action, currently unused in footer).
  * @param onUndock Callback to detach the rail into FAB mode.
  * @param onSecretClick Callback that opens the Secret Screens dialog; null when [com.hereliesaz.aznavrail.model.AzAdvancedConfig.secLoc] is unset.
- * @param scope The active rail scope used to read dragging/undock flags and the repository URL.
+ * @param scope The active rail scope used to read dragging/undock flags.
+ * @param repoUrl The effective host-app repository URL (explicit override or namespace-derived),
+ *   opened in a browser by "About" when the in-app reader is disabled.
  * @param footerColor Tint color applied to all footer text items.
  * @param onAboutClick When non-null, the "About" item invokes this (to open the in-app About reader)
  *   instead of opening the repository URL in a browser. Null restores the legacy browser behavior.
@@ -46,6 +48,7 @@ internal fun Footer(
     onUndock: () -> Unit,
     onSecretClick: (() -> Unit)?,
     scope: AzNavRailScopeImpl,
+    repoUrl: String,
     footerColor: Color,
     onAboutClick: (() -> Unit)? = null
 ) {
@@ -77,7 +80,7 @@ internal fun Footer(
                     if (onAboutClick != null) {
                         onAboutClick()
                     } else {
-                        try { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(scope.appRepositoryUrl))) } catch (e: Exception) {}
+                        try { if (repoUrl.isNotBlank()) context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(repoUrl))) } catch (e: Exception) {}
                     }
                 }
                 .padding(vertical = 4.dp)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/GithubDocsRepository.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/GithubDocsRepository.kt
@@ -16,6 +16,30 @@ object GithubDocsRepository {
 
     private val REPO_REGEX = Regex("""github\.com[/:]([^/]+)/([^/?#]+)""")
 
+    /** Build suffixes an `applicationIdSuffix` commonly appends; stripped before deriving the repo. */
+    private val BUILD_SUFFIXES = listOf("debug", "dev", "staging", "release", "beta", "alpha")
+
+    /**
+     * Derives the host app's GitHub repository URL from its package namespace, following the
+     * convention that the namespace reveals the repo: `com.<owner>.<repo>` →
+     * `https://github.com/<owner>/<repo>`. The owner is the second segment, the repo is the last
+     * segment (a trailing build suffix like `.debug` is stripped first, so `applicationIdSuffix`
+     * builds still resolve). GitHub owners/repos are case-insensitive, so no case fix-up is needed.
+     *
+     * Returns null when the package has fewer than three segments to derive from.
+     */
+    fun repoUrlFromPackage(packageName: String): String? {
+        val segments = packageName.split('.').filter { it.isNotBlank() }
+        if (segments.size < 3) return null
+        val owner = segments[1]
+        val last = segments.last()
+        // Drop a trailing build-variant suffix (e.g. com.hereliesaz.SampleApp.debug) when there is
+        // still a real repo segment in front of it.
+        val repo = if (last.lowercase() in BUILD_SUFFIXES && segments.size >= 4) segments[segments.size - 2] else last
+        if (owner.isBlank() || repo.isBlank()) return null
+        return "https://github.com/$owner/$repo"
+    }
+
     /** Extracts `owner` / `repo` from a GitHub URL, stripping a trailing `.git`. Null if not GitHub. */
     fun parseRepo(repoUrl: String): Pair<String, String>? {
         val m = REPO_REGEX.find(repoUrl) ?: return null

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -80,8 +80,18 @@ azConfig(
     dockingSide = AzDockingSide.LEFT,    // Enum: LEFT or RIGHT
     noMenu = noMenu,                     // Boolean: Disable the side drawer entirely
     usePhysicalDocking = usePhysicalDocking // Boolean: Anchor to physical hardware edge vs visual left
+    // appRepositoryUrl = ""                // Optional override for the About reader's repo (see below)
 )
 ```
+
+`azConfig` also takes `appRepositoryUrl` (default `""`), the repo the in-app **About** reader uses.
+On **Android** the repo is auto-derived from the app **namespace** — `com.<owner>.<repo>` →
+`https://github.com/<owner>/<repo>` (owner = 2nd segment, repo = last segment; a trailing build
+suffix like `.debug` is stripped) — so `appRepositoryUrl` is an **optional** override and it **never**
+falls back to the AzNavRail library repo. On **web** there is no package namespace, so
+`appRepositoryUrl` is **required** there (no auto-derivation); when unset the About entry is hidden.
+While a footer screen (About or More from Az) is open, visible Help cards and any in-progress tutorial
+are hidden and restore exactly where they were on close (all platforms).
 
 
 ### B. Theming (`azTheme`)
@@ -158,10 +168,13 @@ panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the
 `LEFT`/`RIGHT` screen edge; the panel drops from the trigger automatically. The `MENU` design
 renders rows at the rail's menu-item text size and, like the rail's expanded menu, carries the
-footer (About / Feedback / @HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind
-"About"). Items use `azItem`/`azToggle`/`azCycler`/`azDivider` with only the rail's sanctioned
-per-item knobs, plus a `route` that navigates the supplied `NavController` (so the drop-down can
-drive an `AzNavHost`).
+footer (About / Feedback / @HereLiesAz, gated by `showFooter`). Because the dropdown has no
+onscreen/host area, tapping **About** opens a **full-screen** in-app reader drawn as its own layer
+when `inAppAbout = true` (the default; `inAppAbout = false` opens the repo in a browser). The repo is
+auto-derived from the app namespace on Android, with `azConfig`'s `appRepositoryUrl` as an optional
+override (never the AzNavRail library repo). Items use `azItem`/`azToggle`/`azCycler`/`azDivider` with
+only the rail's sanctioned per-item knobs, plus a `route` that navigates the supplied `NavController`
+(so the drop-down can drive an `AzNavHost`).
 
 ```kotlin
 AzDropdownMenu(navController = navController) {

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AboutServiceTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AboutServiceTest.kt
@@ -25,6 +25,22 @@ class AboutServiceTest {
     }
 
     @Test
+    fun `repoUrlFromPackage derives the host app repo from its namespace`() {
+        assertEquals("https://github.com/hereliesaz/SampleApp", GithubDocsRepository.repoUrlFromPackage("com.hereliesaz.SampleApp"))
+        // A trailing build-variant suffix (applicationIdSuffix) is stripped.
+        assertEquals("https://github.com/hereliesaz/SampleApp", GithubDocsRepository.repoUrlFromPackage("com.hereliesaz.SampleApp.debug"))
+        // The derived URL parses back to the same owner/repo via the existing parser.
+        assertEquals("hereliesaz" to "SampleApp", GithubDocsRepository.parseRepo(GithubDocsRepository.repoUrlFromPackage("com.hereliesaz.SampleApp")!!))
+    }
+
+    @Test
+    fun `repoUrlFromPackage returns null when the namespace is too short`() {
+        assertNull(GithubDocsRepository.repoUrlFromPackage("com.example"))
+        assertNull(GithubDocsRepository.repoUrlFromPackage("single"))
+        assertNull(GithubDocsRepository.repoUrlFromPackage(""))
+    }
+
+    @Test
     fun `humanize turns filenames into titles`() {
         assertEquals("Migration Guide", GithubDocsRepository.humanize("MIGRATION_GUIDE.md"))
         assertEquals("Api", GithubDocsRepository.humanize("api.md"))

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/internal/FooterTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/internal/FooterTest.kt
@@ -33,6 +33,7 @@ class FooterTest {
                 onToggle = { onToggleCalled = true },
                 onUndock = { onUndockCalled = true },
                 scope = scope,
+                repoUrl = "https://github.com/hereliesaz/TestApp",
                 footerColor = Color.Red,
                 onSecretClick = {}
             )
@@ -59,6 +60,7 @@ class FooterTest {
                 onToggle = { },
                 onUndock = { },
                 scope = scope,
+                repoUrl = "https://github.com/hereliesaz/TestApp",
                 footerColor = Color.Red,
                 onSecretClick = {}
             )

--- a/docs/API.md
+++ b/docs/API.md
@@ -100,12 +100,22 @@ fun azConfig(
     expandedWidth: Dp = 160.dp,
     collapsedWidth: Dp = 100.dp,
     showFooter: Boolean = true,
-    appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail"
+    appRepositoryUrl: String = ""
 )
 ~~~
 
-> A hamburger drop-down menu is a standalone composable, **`AzDropdownMenu`** — not a rail mode. See
-> the README's "`AzDropdownMenu`" section and `docs/DSL.md`.
+* `appRepositoryUrl` — **optional** override for the host app's GitHub repo used by the About reader.
+  Blank (the default) auto-derives the repo from the app **namespace**: `com.<owner>.<repo>` →
+  `https://github.com/<owner>/<repo>` (owner = 2nd segment, repo = last segment; a trailing build
+  suffix like `.debug` is stripped). It **never** falls back to the AzNavRail library repo. (Helper:
+  `GithubDocsRepository.repoUrlFromPackage`.) On **web** there is no package namespace, so
+  `appRepositoryUrl` is **required** there (no auto-derivation); when unset the About entry is hidden.
+
+> A hamburger drop-down menu is a standalone composable, **`AzDropdownMenu`** — not a rail mode. Its
+> `azConfig` also takes `inAppAbout = true` and `appRepositoryUrl = ""`; because the dropdown has no
+> onscreen area, "About" opens a **full-screen** in-app reader (`inAppAbout = false` reverts to a
+> browser link). Same namespace derivation as the rail. See the README's "`AzDropdownMenu`" section
+> and `docs/DSL.md`.
 
 ### `azTheme`
 Controls the visual style of the rail.
@@ -137,10 +147,16 @@ fun azAbout(
 ~~~
 
 * `inAppAbout` — footer "About" opens the in-app markdown reader (auto-generated from the repo's docs)
-  instead of opening `appRepositoryUrl` in a browser.
+  instead of opening the resolved repo in a browser. The repo is auto-derived from the app namespace
+  on Android (`azConfig`'s `appRepositoryUrl` is an optional override); on web `appRepositoryUrl` is
+  required (the About entry is hidden when it is unset).
 * `moreFromAzEnabled` — show the "More from Az" entry inside the About screen.
 * `moreFromAzJsonUrl` — raw URL of the link-only, CI-versioned `more-from-az.json` manifest.
 * `moreRailItem` — also pin a "More" item at the bottom of the collapsed rail that opens the carousel.
+
+> **Guides hidden over footer screens (all platforms):** while a footer screen (About or More from Az)
+> is open, visible Help cards and any in-progress tutorial are hidden, and they return exactly where
+> they were when the footer screen closes.
 
 ---
 

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -80,8 +80,18 @@ azConfig(
     dockingSide = AzDockingSide.LEFT,    // Enum: LEFT or RIGHT
     noMenu = noMenu,                     // Boolean: Disable the side drawer entirely
     usePhysicalDocking = usePhysicalDocking // Boolean: Anchor to physical hardware edge vs visual left
+    // appRepositoryUrl = ""                // Optional override for the About reader's repo (see below)
 )
 ```
+
+`azConfig` also takes `appRepositoryUrl` (default `""`), the repo the in-app **About** reader uses.
+On **Android** the repo is auto-derived from the app **namespace** — `com.<owner>.<repo>` →
+`https://github.com/<owner>/<repo>` (owner = 2nd segment, repo = last segment; a trailing build
+suffix like `.debug` is stripped) — so `appRepositoryUrl` is an **optional** override and it **never**
+falls back to the AzNavRail library repo. On **web** there is no package namespace, so
+`appRepositoryUrl` is **required** there (no auto-derivation); when unset the About entry is hidden.
+While a footer screen (About or More from Az) is open, visible Help cards and any in-progress tutorial
+are hidden and restore exactly where they were on close (all platforms).
 
 
 ### B. Theming (`azTheme`)
@@ -158,10 +168,13 @@ panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the
 `LEFT`/`RIGHT` screen edge; the panel drops from the trigger automatically. The `MENU` design
 renders rows at the rail's menu-item text size and, like the rail's expanded menu, carries the
-footer (About / Feedback / @HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind
-"About"). Items use `azItem`/`azToggle`/`azCycler`/`azDivider` with only the rail's sanctioned
-per-item knobs, plus a `route` that navigates the supplied `NavController` (so the drop-down can
-drive an `AzNavHost`).
+footer (About / Feedback / @HereLiesAz, gated by `showFooter`). Because the dropdown has no
+onscreen/host area, tapping **About** opens a **full-screen** in-app reader drawn as its own layer
+when `inAppAbout = true` (the default; `inAppAbout = false` opens the repo in a browser). The repo is
+auto-derived from the app namespace on Android, with `azConfig`'s `appRepositoryUrl` as an optional
+override (never the AzNavRail library repo). Items use `azItem`/`azToggle`/`azCycler`/`azDivider` with
+only the rail's sanctioned per-item knobs, plus a `route` that navigates the supplied `NavController`
+(so the drop-down can drive an `AzNavHost`).
 
 ```kotlin
 AzDropdownMenu(navController = navController) {

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -25,9 +25,16 @@ fun azConfig(
     expandedWidth: Dp = 160.dp,
     collapsedWidth: Dp = 100.dp,
     showFooter: Boolean = true,
-    appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail"
+    appRepositoryUrl: String = ""
 )
 ~~~
+
+`appRepositoryUrl` is an **optional** override for the About reader's repo. Blank (the default)
+auto-derives the repo from the app **namespace** on Android: `com.<owner>.<repo>` →
+`https://github.com/<owner>/<repo>` (owner = 2nd segment, repo = last segment; trailing build suffixes
+like `.debug` are stripped). It **never** falls back to the AzNavRail library repo. On **web** there is
+no namespace, so `appRepositoryUrl` is **required** (no auto-derivation); when unset the About entry is
+hidden.
 
 > A hamburger drop-down menu is **not** a rail mode. Use the standalone `AzDropdownMenu` composable —
 > placed inline like `AzButton`, with no `AzNavHost`, no scope, and no safe zones. See
@@ -82,9 +89,15 @@ fun azAbout(
 )
 ~~~
 
-The About reader auto-discovers the markdown docs (root + `docs/`) of `azConfig`'s `appRepositoryUrl`
-via the GitHub API (cached; public repos only) and renders them inline. "More from Az" is a link-only,
-CI-versioned carousel — see the README's "In-App About Reader" and "More from Az" sections.
+The About reader auto-discovers the markdown docs (root + `docs/`) of the resolved repo via the GitHub
+API (cached; public repos only) and renders them inline. On **Android** the repo is auto-derived from
+the app namespace (`azConfig`'s `appRepositoryUrl` is an optional override, never the AzNavRail library
+repo); on **web** `appRepositoryUrl` is required (the About entry is hidden when unset). "More from Az"
+is a link-only, CI-versioned carousel — see the README's "In-App About Reader" and "More from Az"
+sections.
+
+While a footer screen (About or More from Az) is open, visible Help cards and any in-progress tutorial
+are hidden, and they return exactly where they were when the footer screen closes (all platforms).
 
 `onInteraction` is called whenever any rail item is interacted with — click, toggle, cycler advance, nested rail open, reloc drag, or host expand/collapse. It fires for both leaf items (`azRailItem` / `azRailSubItem`) and host items (`azRailHostItem`), in both the compact rail and the expanded menu, so opening a host menu is observable just like tapping a leaf. It receives the item's `id` and the `AzNavItem` itself, enabling analytics, UI feedback, and tutorial advancement (pair it with `controller.fireEvent(...)` and an `AzAdvanceCondition.Event` card) without per-item callbacks.
 
@@ -118,7 +131,8 @@ interface AzDropdownMenuScope {
         headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,  // app-icon clip, like azTheme
         headerIconSize: Dp = 48.dp,                         // app-icon diameter, like azTheme
         showFooter: Boolean = true,                         // MENU footer (About/Feedback/@HereLiesAz)
-        appRepositoryUrl: String = "https://github.com/HereLiesAz/AzNavRail"  // footer "About" link
+        inAppAbout: Boolean = true,                          // "About" opens a full-screen in-app reader
+        appRepositoryUrl: String = ""                        // optional override; else derived from namespace
     )
     fun azItem(text, route = null, color, textColor, fillColor, shape, enabled, closeOnClick = true, onClick)
     fun azToggle(isChecked, toggleOnText, toggleOffText, route = null, …, onToggle)
@@ -133,8 +147,12 @@ interface AzDropdownMenuScope {
 or `RIGHT` screen edge, and `headerIconShape`/`headerIconSize` set the app-icon trigger's clip and
 diameter (the same knobs the rail exposes via `azTheme`). The `MENU` design renders rows at the
 rail's menu-item text size and — like the rail's expanded menu — carries the footer
-(About / Feedback / @HereLiesAz, gated by `showFooter`, with `appRepositoryUrl` behind "About"). The
-panel drops from the trigger automatically (downward when it fits, else upward). Items accept only the
+(About / Feedback / @HereLiesAz, gated by `showFooter`). Because the dropdown has no onscreen/host
+area, tapping **About** opens a **full-screen in-app reader** drawn as its own layer when
+`inAppAbout = true` (the default); `inAppAbout = false` opens the repo in a browser. The repo is
+auto-derived from the app namespace on Android, with `appRepositoryUrl` as an optional override (never
+the AzNavRail library repo). The panel drops from the trigger automatically (downward when it fits,
+else upward). Items accept only the
 rail's sanctioned per-item knobs, plus a navigation `route`: when set,
 tapping navigates the `navController` (so the drop-down can drive an `AzNavHost`), then runs the
 callback, then folds up if `closeOnClick`.

--- a/sample-pwa/src/App.tsx
+++ b/sample-pwa/src/App.tsx
@@ -80,6 +80,9 @@ function App() {
     collapsedRailWidth: 136,
     displayAppNameInHeader: false,
     showFooter: true,
+    // Web has no package namespace, so appRepositoryUrl is REQUIRED (no auto-derivation) — when
+    // unset the About entry is hidden. Android instead auto-derives it from the app namespace and
+    // treats appRepositoryUrl as an optional override.
     appRepositoryUrl: 'https://github.com/HereLiesAz/AzNavRail',
     vibrate: false,
     activeClassifiers: new Set<string>(),

--- a/sample-pwa/src/screens/AboutDemo.tsx
+++ b/sample-pwa/src/screens/AboutDemo.tsx
@@ -18,10 +18,24 @@ export default function AboutDemo() {
         <h3 style={{ marginBottom: 4 }}>In-app About reader</h3>
         <p style={{ opacity: 0.85, marginTop: 0 }}>
           Expand the rail and tap <strong>About</strong> in the footer. The reader auto-discovers the
-          markdown docs in the configured repository's root and <code>docs/</code> folder
-          (<code>appRepositoryUrl</code>), builds a table of contents, and renders each doc inline. A
-          GitHub button is pinned at the bottom. Configure with{' '}
-          <code>inAppAbout</code> (set false to open the repo in a browser instead).
+          markdown docs in the configured repository's root and <code>docs/</code> folder, builds a
+          table of contents, and renders each doc inline. A GitHub button is pinned at the bottom.
+          Configure with <code>inAppAbout</code> (set false to open the repo in a browser instead).
+        </p>
+        <p style={{ opacity: 0.85, marginTop: 0 }}>
+          <strong>Repo resolution differs by platform.</strong> On Android the repo is auto-derived
+          from the app namespace (<code>com.&lt;owner&gt;.&lt;repo&gt;</code> →{' '}
+          <code>github.com/&lt;owner&gt;/&lt;repo&gt;</code>), so <code>appRepositoryUrl</code> is an
+          optional override and never falls back to the AzNavRail library repo. On web there is no
+          package namespace, so <code>appRepositoryUrl</code> is <strong>required</strong> (set in{' '}
+          <code>App.tsx</code>); when it is unset the About entry is hidden.
+        </p>
+        <p style={{ opacity: 0.85, marginTop: 0 }}>
+          The standalone <code>AzDropdownMenu</code> has no onscreen area, so its <strong>About</strong>{' '}
+          opens as its own full-screen in-app reader (same namespace derivation; <code>inAppAbout=false</code>{' '}
+          reverts to a browser link). While a footer screen (About or More from Az) is open, visible Help
+          cards and any in-progress tutorial are hidden, and they return exactly where they were when the
+          footer screen closes.
         </p>
       </section>
 

--- a/sample-pwa/src/screens/CustomizationDemo.tsx
+++ b/sample-pwa/src/screens/CustomizationDemo.tsx
@@ -105,13 +105,18 @@ export default function CustomizationDemo({
         onChange={(v) => onChange({ ...state, vibrate: v })}
       />
 
-      <Block label="appRepositoryUrl">
+      <Block label="appRepositoryUrl (required on web)">
         <select
           value={state.appRepositoryUrl}
           onChange={(e) => onChange({ ...state, appRepositoryUrl: e.target.value })}
         >
           {repoChoices.map((r) => <option key={r.url} value={r.url}>{r.label}</option>)}
         </select>
+        <span style={{ opacity: 0.6, fontSize: 13, fontWeight: 400 }}>
+          Web has no package namespace, so this is required for the About reader (unset hides the
+          About entry). Android auto-derives the repo from the app namespace and treats this as an
+          optional override.
+        </span>
       </Block>
 
       <Block label="activeClassifiers">


### PR DESCRIPTION
## Why

The in-app About reader (PR #463) defaulted `appRepositoryUrl` to the **AzNavRail library repo**, so any consuming app that didn't hand-write `azConfig(appRepositoryUrl = …)` got an About page listing *AzNavRail's own docs* — useless inside someone else's app. It was also drawn as a bespoke full-screen overlay instead of flowing through the rail's `onscreen()` layout like everything else, and nothing auto-populated the repo despite this being a DSL-style library.

## What changed

**Repo is auto-derived from the app namespace.** `GithubDocsRepository.repoUrlFromPackage` maps `com.<owner>.<repo>` → `https://github.com/<owner>/<repo>` (owner = 2nd segment, repo = last; trailing build suffixes like `.debug` stripped). `appRepositoryUrl` now defaults to `""` and is an **optional override** — it never falls back to the library repo.

**About + More-from-Az route through `onscreen()`.** Overlay visibility moved onto `AzNavHostScopeImpl`; `AzHostActivityLayout` renders About + More-from-Az inside the rail-padded layout (safe zones, rail padding, docking mirror). Help stays full-screen because it draws connector lines to rail items that live outside the safe area.

**Guides hide over footer screens and restore exactly.** When About/More-from-Az opens, any visible Help cards and any in-progress tutorial are hidden but kept mounted (`Modifier.azSuppressGuide`), so they return to the same step/scroll on close (within-session).

**Dropdown menu gets a full-screen About reader.** `AzDropdownMenu` has no host/onscreen area, so it draws its own full-screen About/More reader in a `Popup`, with the same namespace-derived repo and an `inAppAbout` toggle (browser fallback when off).

**React / web port.** Web has no package namespace, so `appRepositoryUrl` is **required** there; the library-repo default is removed and the About entry is hidden when it's unset. Guides hide/restore over footer screens; the dropdown gets the full-screen About too. *(Being finalized — the React commit lands on this branch shortly.)*

**Samples + docs.** SampleApp now auto-derives `github.com/hereliesaz/SampleApp`; sample-pwa keeps the URL set with updated copy; README, `docs/API.md`, `docs/DSL.md`, the Complete Guide (canonical + both embedded copies), `AGENTS.md`, and the React migration guide all describe the new behavior.

**Bonus — POM license fix.** The published POM declared no `<licenses>`, so jitpack/licensee reported "no license" despite the project being Apache-2.0. Added a root `LICENSE` and a `pom { licenses { … } }` block (SPDX id `Apache-2.0` + canonical URL) to the release publication. **Cut a new tag** so jitpack rebuilds with the updated POM.

## Verification

- `:aznavrail:compileDebugKotlin` and `:SampleApp:compileDebugKotlin` ✅
- `generatePomFileForReleasePublication` now emits `<name>Apache-2.0</name>` ✅
- Unit tests for `repoUrlFromPackage` added; React `jest`/`tsc` run as the React commit lands.

## Known issue (pre-existing, unrelated)

`AzDropdownMenuTest.kt` fails to compile on a clean tree (missing `androidx.navigation.compose.composable` on the test classpath), which blocks the whole `:aznavrail:testDebugUnitTest` task independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018x5xvqJTU6GdrtQykKbzRd

---
_Generated by [Claude Code](https://claude.ai/code/session_018x5xvqJTU6GdrtQykKbzRd)_