### PR TITLE
React/web port: auto-generate About from the host repo + full-screen dropdown About

### DIFF
--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -605,7 +605,11 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
           setIsExpanded(false);
           setShowAbout(true);
         } else if (config.appRepositoryUrl) {
-          Linking.openURL(config.appRepositoryUrl).catch(e => console.error("Could not open About", e));
+          // Only follow safe web URLs — on react-native-web a `javascript:` URL would otherwise execute.
+          const isSafe = config.appRepositoryUrl.startsWith('http://') || config.appRepositoryUrl.startsWith('https://');
+          if (isSafe) {
+            Linking.openURL(config.appRepositoryUrl).catch(e => console.error("Could not open About", e));
+          }
         }
       };
 
@@ -781,9 +785,9 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                 </View>
             )}
 
-            {showAbout && (
+            {showAbout && !!config.appRepositoryUrl && (
                 <AboutOverlay
-                    repoUrl={config.appRepositoryUrl ?? ''}
+                    repoUrl={config.appRepositoryUrl}
                     settings={{ activeColor: config.activeColor, translucentBackground: config.translucentBackground }}
                     moreFromAzEnabled={config.moreFromAzEnabled}
                     moreFromAzJsonUrl={config.moreFromAzJsonUrl}

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -74,7 +74,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
       onExpandedChange,
       onInteraction,
       helpList = {},
-      appRepositoryUrl = 'https://github.com/HereLiesAz/AzNavRail',
+      appRepositoryUrl,
       inAppAbout = true,
       moreFromAzEnabled = true,
       moreFromAzJsonUrl = 'https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json',
@@ -604,7 +604,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
         if (config.inAppAbout) {
           setIsExpanded(false);
           setShowAbout(true);
-        } else {
+        } else if (config.appRepositoryUrl) {
           Linking.openURL(config.appRepositoryUrl).catch(e => console.error("Could not open About", e));
         }
       };
@@ -634,7 +634,9 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
              {enableRailDragging && (
                  <TouchableOpacity onPress={handleUndock} style={{ paddingVertical: 8 }}><Text style={[styles.menuItemText, { color: footerColor, fontWeight: 'bold' }]}>{`Undock`}</Text></TouchableOpacity>
              )}
-             <TouchableOpacity onPress={handleAbout} style={{ paddingVertical: 4 }}><Text style={[styles.menuItemText, { color: footerColor }]}>About</Text></TouchableOpacity>
+             {!!config.appRepositoryUrl && (
+                 <TouchableOpacity onPress={handleAbout} style={{ paddingVertical: 4 }}><Text style={[styles.menuItemText, { color: footerColor }]}>About</Text></TouchableOpacity>
+             )}
              <TouchableOpacity onPress={handleFeedback} style={{ paddingVertical: 4 }}><Text style={[styles.menuItemText, { color: footerColor }]}>Feedback</Text></TouchableOpacity>
              <TouchableOpacity onPress={handleCredit} onLongPress={handleSecLocTrigger} delayLongPress={500} style={{ paddingVertical: 4 }}><Text style={[styles.menuItemText, { color: footerColor, opacity: 0.5 }]}>@HereLiesAz</Text></TouchableOpacity>
         </View>
@@ -760,20 +762,28 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                  </View>
             )}
 
+            {/* While a footer screen (About / More-from-Az) is open, the Help overlay is hidden and
+                input-disabled but kept MOUNTED so its expanded-card state is preserved and restored
+                when the footer screen closes. */}
             {infoScreen && (
-                <HelpOverlay
-                    items={items}
-                    helpList={config.helpList || {}}
-                    onDismiss={onDismissInfoScreen!}
-                    itemBounds={itemBounds}
-                    nestedRailVisibleId={nestedRailVisible}
-                    tutorials={(config as any).tutorials}
-                />
+                <View
+                    style={[StyleSheet.absoluteFill, (showAbout || showMoreFromAz) && { opacity: 0 }]}
+                    pointerEvents={(showAbout || showMoreFromAz) ? 'none' : 'auto'}
+                >
+                    <HelpOverlay
+                        items={items}
+                        helpList={config.helpList || {}}
+                        onDismiss={onDismissInfoScreen!}
+                        itemBounds={itemBounds}
+                        nestedRailVisibleId={nestedRailVisible}
+                        tutorials={(config as any).tutorials}
+                    />
+                </View>
             )}
 
             {showAbout && (
                 <AboutOverlay
-                    repoUrl={config.appRepositoryUrl}
+                    repoUrl={config.appRepositoryUrl ?? ''}
                     settings={{ activeColor: config.activeColor, translucentBackground: config.translucentBackground }}
                     moreFromAzEnabled={config.moreFromAzEnabled}
                     moreFromAzJsonUrl={config.moreFromAzJsonUrl}
@@ -792,6 +802,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
             <TutorialOverlayWrapper
               tutorials={(config as any).tutorials}
               itemBounds={itemBounds}
+              suppressed={showAbout || showMoreFromAz}
             />
         </View>
     </AzNavRailContext.Provider>
@@ -801,7 +812,12 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
 const TutorialOverlayWrapper: React.FC<{
   tutorials?: Record<string, import('./types').AzTutorial>;
   itemBounds: Record<string, any>;
-}> = ({ tutorials, itemBounds }) => {
+  /**
+   * When true, the in-progress tutorial overlay is hidden and input-disabled but kept MOUNTED
+   * (so its scene/card/checklist state is preserved) — used while a footer screen is open.
+   */
+  suppressed?: boolean;
+}> = ({ tutorials, itemBounds, suppressed = false }) => {
   const tutorialController = useAzTutorialController();
   const activeId = tutorialController.activeTutorialId;
 
@@ -810,12 +826,17 @@ const TutorialOverlayWrapper: React.FC<{
   }
 
   return (
-    <AzTutorialOverlay
-      tutorialId={activeId}
-      tutorial={tutorials[activeId]}
-      onDismiss={() => tutorialController.endTutorial()}
-      itemBoundsCache={itemBounds}
-    />
+    <View
+      style={[StyleSheet.absoluteFill, suppressed && { opacity: 0 }]}
+      pointerEvents={suppressed ? 'none' : 'auto'}
+    >
+      <AzTutorialOverlay
+        tutorialId={activeId}
+        tutorial={tutorials[activeId]}
+        onDismiss={() => tutorialController.endTutorial()}
+        itemBoundsCache={itemBounds}
+      />
+    </View>
   );
 };
 

--- a/aznavrail-react/src/__tests__/AzDropdownMenu.test.tsx
+++ b/aznavrail-react/src/__tests__/AzDropdownMenu.test.tsx
@@ -118,11 +118,23 @@ describe('AzDropdownMenu', () => {
 
   it('shows the rail footer in the MENU design by default', () => {
     const { queryByText } = render(
-      <AzDropdownMenu expanded>
+      <AzDropdownMenu expanded appRepositoryUrl="https://github.com/acme/app">
         <AzDropdownItem text="Profile" onClick={() => {}} />
       </AzDropdownMenu>
     );
     expect(queryByText('About')).not.toBeNull();
+    expect(queryByText('Feedback')).not.toBeNull();
+    expect(queryByText('@HereLiesAz')).not.toBeNull();
+  });
+
+  it('hides the footer About when no appRepositoryUrl is set', () => {
+    const { queryByText } = render(
+      <AzDropdownMenu expanded>
+        <AzDropdownItem text="Profile" onClick={() => {}} />
+      </AzDropdownMenu>
+    );
+    // About is gated on appRepositoryUrl; the rest of the footer still renders.
+    expect(queryByText('About')).toBeNull();
     expect(queryByText('Feedback')).not.toBeNull();
     expect(queryByText('@HereLiesAz')).not.toBeNull();
   });

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -16,6 +16,7 @@ import {
 import { AzButton } from './AzButton';
 import { AzButtonShape, AzDockingSide, AzDropdownDesign, AzHeaderIconShape } from '../types';
 import { AzNavRailDefaults } from '../AzNavRailDefaults';
+import { AboutOverlay } from './AboutOverlay';
 
 /** Context the menu provides so item components can navigate, fold the menu, and match its design. */
 interface AzDropdownMenuContextValue {
@@ -44,8 +45,20 @@ export interface AzDropdownMenuProps {
   headerIconSize?: number;
   /** Whether the MENU design shows the rail's footer (About / Feedback / @HereLiesAz). */
   showFooter?: boolean;
-  /** Repository URL opened by the footer's "About" item. */
+  /**
+   * Repository URL backing the footer's "About" item. When unset/blank, "About" is hidden entirely.
+   * When set, "About" opens the in-app reader if {@link inAppAbout} is true, else the URL.
+   */
   appRepositoryUrl?: string;
+  /**
+   * When true (default), the footer "About" opens the full-screen in-app reader; when false it opens
+   * {@link appRepositoryUrl} in a browser. Only takes effect when `appRepositoryUrl` is set.
+   */
+  inAppAbout?: boolean;
+  /** When true (default), the in-app About reader offers a "More from Az" carousel. */
+  moreFromAzEnabled?: boolean;
+  /** Raw URL of the `more-from-az.json` manifest backing the carousel. */
+  moreFromAzJsonUrl?: string;
   /** Optional controlled open-state. When omitted the menu manages its own. */
   expanded?: boolean;
   /** Called whenever the open-state changes. */
@@ -150,7 +163,10 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
   headerIconShape = AzHeaderIconShape.CIRCLE,
   headerIconSize = AzNavRailDefaults.HeaderIconSize,
   showFooter = true,
-  appRepositoryUrl = 'https://github.com/HereLiesAz/AzNavRail',
+  appRepositoryUrl,
+  inAppAbout = true,
+  moreFromAzEnabled = true,
+  moreFromAzJsonUrl = 'https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json',
   expanded,
   onExpandedChange,
   onNavigate,
@@ -162,6 +178,9 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
   const triggerRef = useRef<View>(null);
   const [anchor, setAnchor] = useState<Anchor>({ x: 0, y: 0, width: 0, height: 0 });
   const [panelSize, setPanelSize] = useState({ width: 0, height: 0 });
+  // Full-screen About reader reachable from the dropdown footer (parity with the rail). The
+  // "More from Az" carousel is reachable from within AboutOverlay itself.
+  const [showAbout, setShowAbout] = useState(false);
 
   const setOpen = (value: boolean) => {
     if (expanded === undefined) setInternalOpen(value);
@@ -252,11 +271,26 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
                   </AzDropdownMenuContext.Provider>
                   {/* The expanded-menu design carries the rail's footer. */}
                   {design === AzDropdownDesign.MENU && showFooter && (
-                    <AzDropdownFooter appRepositoryUrl={appRepositoryUrl} />
+                    <AzDropdownFooter
+                      appRepositoryUrl={appRepositoryUrl}
+                      inAppAbout={inAppAbout}
+                      onInAppAbout={() => setShowAbout(true)}
+                    />
                   )}
                 </ScrollView>
               </Pressable>
             </View>
+
+            {/* Full-screen footer screens, rendered above the dropdown panel — mirrors the rail.
+                Gated on `appRepositoryUrl`; About is hidden entirely when it is unset. */}
+            {showAbout && !!appRepositoryUrl && (
+              <AboutOverlay
+                repoUrl={appRepositoryUrl}
+                moreFromAzEnabled={moreFromAzEnabled}
+                moreFromAzJsonUrl={moreFromAzJsonUrl}
+                onDismiss={() => setShowAbout(false)}
+              />
+            )}
           </Pressable>
         </Modal>
       )}
@@ -265,7 +299,11 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
 };
 
 /** The MENU design's footer — mirrors the rail's footer (About / Feedback / @HereLiesAz). */
-const AzDropdownFooter: React.FC<{ appRepositoryUrl: string }> = ({ appRepositoryUrl }) => {
+const AzDropdownFooter: React.FC<{
+  appRepositoryUrl?: string;
+  inAppAbout?: boolean;
+  onInAppAbout?: () => void;
+}> = ({ appRepositoryUrl, inAppAbout = true, onInAppAbout }) => {
   const footerColor = '#6750A4';
   // Only open safe schemes — this also runs on the web via react-native-web, where a `javascript:`
   // URL would otherwise execute.
@@ -273,11 +311,19 @@ const AzDropdownFooter: React.FC<{ appRepositoryUrl: string }> = ({ appRepositor
     const isSafe = url.startsWith('http://') || url.startsWith('https://') || url.startsWith('mailto:');
     if (isSafe) Linking.openURL(url).catch(() => {});
   };
+  const onAbout = () => {
+    if (!appRepositoryUrl) return;
+    if (inAppAbout) onInAppAbout?.();
+    else open(appRepositoryUrl);
+  };
   return (
     <View style={styles.footer}>
-      <TouchableOpacity onPress={() => open(appRepositoryUrl)} style={styles.footerRow} accessibilityRole="button">
-        <Text style={[styles.footerText, { color: footerColor }]}>About</Text>
-      </TouchableOpacity>
+      {/* About is hidden entirely when no repository URL is configured. */}
+      {!!appRepositoryUrl && (
+        <TouchableOpacity onPress={onAbout} style={styles.footerRow} accessibilityRole="button">
+          <Text style={[styles.footerText, { color: footerColor }]}>About</Text>
+        </TouchableOpacity>
+      )}
       <TouchableOpacity onPress={() => open('mailto:hereliesaz@gmail.com?subject=Feedback')} style={styles.footerRow} accessibilityRole="button">
         <Text style={[styles.footerText, { color: footerColor }]}>Feedback</Text>
       </TouchableOpacity>

--- a/aznavrail-react/src/types.ts
+++ b/aznavrail-react/src/types.ts
@@ -107,7 +107,11 @@ export interface AzNavRailSettings {
   secLoc?: string;
   /** Port for the secret-location server (developer feature). */
   secLocPort?: number;
-  /** URL of the app's source repository, shown in the footer and used by the in-app About reader. */
+  /**
+   * URL of the app's source repository, shown in the footer and used by the in-app About reader.
+   * Required to surface "About": when unset or blank, the "About" entry is hidden entirely (the
+   * library never falls back to showing its own docs in a consuming app).
+   */
   appRepositoryUrl?: string;
   /**
    * When true (default), the footer "About" opens the in-app markdown reader (auto-generated from

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useRef, useEffect } from 'react';
 import AzButton from './AzButton';
+import AboutOverlay from './AboutOverlay';
 import './AzDropdownMenu.css';
 
 const AzDropdownMenuContext = createContext(null);
@@ -68,7 +69,10 @@ export const AzDropdownItem = ({ text, onClick, route, shape = 'RECTANGLE', enab
  * @param {function} [props.onExpandedChange]
  * @param {function} [props.onNavigate] - Called with an item's `route` before its callback.
  * @param {boolean} [props.showFooter=true] - Whether the menu design shows the About/Feedback/@HereLiesAz footer.
- * @param {string} [props.appRepositoryUrl] - URL opened by the footer's "About" item.
+ * @param {string} [props.appRepositoryUrl] - URL backing the footer's "About" item. When unset/blank, "About" is hidden.
+ * @param {boolean} [props.inAppAbout=true] - When true, "About" opens the in-app reader; else the URL. Requires `appRepositoryUrl`.
+ * @param {boolean} [props.moreFromAzEnabled=true] - Whether the in-app About reader offers a "More from Az" carousel.
+ * @param {string} [props.moreFromAzJsonUrl] - Raw URL of the `more-from-az.json` manifest.
  * @param {React.ReactNode} props.children
  */
 const AzDropdownMenu = ({
@@ -80,7 +84,10 @@ const AzDropdownMenu = ({
   headerIconShape = 'CIRCLE',
   headerIconSize = 48,
   showFooter = true,
-  appRepositoryUrl = 'https://github.com/HereLiesAz/AzNavRail',
+  appRepositoryUrl,
+  inAppAbout = true,
+  moreFromAzEnabled = true,
+  moreFromAzJsonUrl = 'https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json',
   expanded,
   onExpandedChange,
   onNavigate,
@@ -91,6 +98,8 @@ const AzDropdownMenu = ({
   const rootRef = useRef(null);
   const triggerRef = useRef(null);
   const [rect, setRect] = useState(null);
+  // Full-screen in-app About reader reachable from the dropdown footer (parity with the rail).
+  const [showAbout, setShowAbout] = useState(false);
 
   const setOpen = (value) => {
     if (expanded === undefined) setInternalOpen(value);
@@ -184,17 +193,32 @@ const AzDropdownMenu = ({
           {/* The expanded-menu design carries the rail's footer. */}
           {design === 'menu' && showFooter && (
             <div className="az-dropdown-menu-footer">
-              <div className="az-dropdown-menu-footer-item" onClick={() => {
-                // Only follow plain web URLs, never an injected scheme (e.g. javascript:).
-                if (appRepositoryUrl && (appRepositoryUrl.startsWith('http://') || appRepositoryUrl.startsWith('https://'))) {
-                  window.open(appRepositoryUrl, '_blank', 'noopener,noreferrer');
-                }
-              }}>About</div>
+              {/* About is hidden entirely when no repository URL is configured. */}
+              {!!appRepositoryUrl && (
+                <div className="az-dropdown-menu-footer-item" onClick={() => {
+                  if (inAppAbout) {
+                    setShowAbout(true);
+                  } else if (appRepositoryUrl.startsWith('http://') || appRepositoryUrl.startsWith('https://')) {
+                    // Only follow plain web URLs, never an injected scheme (e.g. javascript:).
+                    window.open(appRepositoryUrl, '_blank', 'noopener,noreferrer');
+                  }
+                }}>About</div>
+              )}
               <div className="az-dropdown-menu-footer-item" onClick={() => window.open('mailto:hereliesaz@gmail.com?subject=Feedback', '_self')}>Feedback</div>
               <div className="az-dropdown-menu-footer-item" style={{ opacity: 0.5 }} onClick={() => window.open('https://instagram.com/HereLiesAz', '_blank', 'noopener,noreferrer')}>@HereLiesAz</div>
             </div>
           )}
         </div>
+      )}
+      {/* Full-screen in-app About reader above the dropdown panel — mirrors the rail. The
+          "More from Az" carousel is reachable from within AboutOverlay itself. */}
+      {showAbout && !!appRepositoryUrl && (
+        <AboutOverlay
+          repoUrl={appRepositoryUrl}
+          moreFromAzEnabled={moreFromAzEnabled}
+          moreFromAzJsonUrl={moreFromAzJsonUrl}
+          onDismiss={() => setShowAbout(false)}
+        />
       )}
     </div>
   );

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -46,7 +46,7 @@ const AzNavRail = ({
     moreFromAzEnabled = true,
     moreFromAzJsonUrl = 'https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json',
     moreRailItem = false,
-    appRepositoryUrl = 'https://github.com/HereLiesAz/AzNavRail'
+    appRepositoryUrl
   } = settings;
 
   // If noMenu is true, we force expanded to false, unless infoScreen overrides (which it doesn't really)
@@ -603,14 +603,16 @@ const AzNavRail = ({
       {showFooter && isExpanded && (
         <div className="footer" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '16px', color: activeColor || 'currentColor' }}>
              <div className="az-menu-item-text" style={{ padding: '8px 0', fontWeight: 'bold' }}>{appName}</div>
-             <div
-               className="az-menu-item-text"
-               style={{ padding: '4px 0', cursor: 'pointer' }}
-               onClick={() => {
-                 if (inAppAbout) { setShowAbout(true); setIsExpanded(false); }
-                 else window.open(appRepositoryUrl, '_blank', 'noopener');
-               }}
-             >About</div>
+             {!!appRepositoryUrl && (
+               <div
+                 className="az-menu-item-text"
+                 style={{ padding: '4px 0', cursor: 'pointer' }}
+                 onClick={() => {
+                   if (inAppAbout) { setShowAbout(true); setIsExpanded(false); }
+                   else window.open(appRepositoryUrl, '_blank', 'noopener');
+                 }}
+               >About</div>
+             )}
              <div className="az-menu-item-text" style={{ padding: '4px 0' }}>Feedback</div>
              <div className="az-menu-item-text" style={{ padding: '4px 0', opacity: 0.5 }}>@HereLiesAz</div>
         </div>
@@ -636,18 +638,27 @@ const AzNavRail = ({
       )}
     </div>
 
+    {/* While a footer screen (About / More-from-Az) is open, the Help overlay is hidden and
+        input-disabled but kept MOUNTED so its expanded-card state is preserved and restored
+        when the footer screen closes. */}
     {infoScreen && (
-        <HelpOverlay
-            items={visibleItems}
-            itemBounds={itemBounds}
-            railWidth={collapsedRailWidth}
-            onDismiss={onDismissInfoScreen}
-            nestedRailVisibleId={nestedRailVisibleId}
-            helpList={settings?.helpList || {}}
-        />
+        <div
+            style={(showAbout || showMoreFromAz)
+                ? { opacity: 0, pointerEvents: 'none' }
+                : undefined}
+        >
+            <HelpOverlay
+                items={visibleItems}
+                itemBounds={itemBounds}
+                railWidth={collapsedRailWidth}
+                onDismiss={onDismissInfoScreen}
+                nestedRailVisibleId={nestedRailVisibleId}
+                helpList={settings?.helpList || {}}
+            />
+        </div>
     )}
 
-    {showAbout && (
+    {showAbout && !!appRepositoryUrl && (
         <AboutOverlay
             repoUrl={appRepositoryUrl}
             settings={settings}

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -609,7 +609,10 @@ const AzNavRail = ({
                  style={{ padding: '4px 0', cursor: 'pointer' }}
                  onClick={() => {
                    if (inAppAbout) { setShowAbout(true); setIsExpanded(false); }
-                   else window.open(appRepositoryUrl, '_blank', 'noopener');
+                   // Only follow safe web URLs, never an injected scheme (e.g. javascript:).
+                   else if (appRepositoryUrl.startsWith('http://') || appRepositoryUrl.startsWith('https://')) {
+                     window.open(appRepositoryUrl, '_blank', 'noopener,noreferrer');
+                   }
                  }}
                >About</div>
              )}


### PR DESCRIPTION
## Why

This is the **React / React-Native / web half** of the About-page change whose Android half merged in #474. It was finalized just after that merge, so it lands here as a follow-up.

## What changed

**Repo source (web has no package namespace, so no auto-derivation).** `appRepositoryUrl` is now **required** on `AzNavRail` and `AzDropdownMenu`; the `https://github.com/HereLiesAz/AzNavRail` default is removed across the native + web variants. When it's unset/blank the footer **"About" is hidden entirely** — the library never falls back to showing its own docs in a consuming app.

**Guides hide over footer screens and restore exactly.** While About / More-from-Az is open, the Help overlay and any in-progress tutorial are hidden and input-disabled but kept **mounted** (`opacity: 0` + `pointerEvents: 'none'`), so their expanded-card / step / checklist state is preserved and restored on close (within-session). Applied in `AzNavRail.tsx` (`HelpOverlay` wrapper + `TutorialOverlayWrapper suppressed`) and `web/AzNavRail.jsx`.

**Dropdown full-screen About.** `AzDropdownMenu` (native + web) gains a full-screen in-app About reader with parity to the rail — an `inAppAbout` toggle (browser fallback when off), gated on `appRepositoryUrl`, with "More from Az" reachable from within the reader.

**Test.** Added a case asserting the dropdown footer "About" is hidden when no `appRepositoryUrl` is set, and updated the existing footer test to pass one.

## Files
- `src/AzNavRail.tsx`, `src/types.ts`
- `src/components/AzDropdownMenu.tsx`
- `src/web/AzNavRail.jsx`, `src/web/AzDropdownMenu.jsx`
- `src/__tests__/AzDropdownMenu.test.tsx`

## Verification

I reviewed the full diff for correctness (default removal, About gating, mounted-but-hidden guide wrappers, default vs named exports across web/TS variants — all consistent). I could **not** run `jest`/`tsc` in my sandbox because npm isn't reachable through its proxy, so please let CI run the React test suite. If anything is red I'll fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018x5xvqJTU6GdrtQykKbzRd

---
_Generated by [Claude Code](https://claude.ai/code/session_018x5xvqJTU6GdrtQykKbzRd)_