### PR TITLE
test(aznavrail): import navigation-compose's `composable` in the drop…

### DIFF
--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzDropdownMenuTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/AzDropdownMenuTest.kt
@@ -6,6 +6,10 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.hereliesaz.aznavrail.model.AzDropdownDesign
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -141,16 +145,16 @@ class AzDropdownMenuTest {
 
     @Test
     fun route_navigates_the_nav_controller() {
-        lateinit var navController: androidx.navigation.NavHostController
+        lateinit var navController: NavHostController
         composeTestRule.setContent {
-            navController = androidx.navigation.compose.rememberNavController()
-            androidx.navigation.compose.NavHost(navController, startDestination = "start") {
-                androidx.navigation.compose.composable("start") {
+            navController = rememberNavController()
+            NavHost(navController, startDestination = "start") {
+                composable("start") {
                     AzDropdownMenu(navController = navController) {
                         azItem("Home", route = "home") { }
                     }
                 }
-                androidx.navigation.compose.composable("home") {
+                composable("home") {
                     androidx.compose.material3.Text("home screen")
                 }
             }


### PR DESCRIPTION
…down test

`:aznavrail:testDebugUnitTest` failed to compile because AzDropdownMenuTest.route_navigates_the_nav_controller referenced `androidx.navigation.compose.composable` by its fully-qualified package path. `composable` is an extension function on NavGraphBuilder, which Kotlin cannot resolve via a package-qualified path with an implicit receiver — it must be imported (unlike the plain `NavHost`/`rememberNavController` functions, which resolved fully-qualified). navigation-compose is already on the unit-test classpath via the main `implementation` dependency, so this was only a missing import, not a missing dependency.

Add the navigation-compose imports and de-qualify the calls. This unblocks the whole module unit-test source set (213 tests now compile and run, including the new AboutServiceTest.repoUrlFromPackage cases, which pass).


Claude-Session: https://claude.ai/code/session_018x5xvqJTU6GdrtQykKbzRd