### PR TITLE
Guidance: arbitrary on-screen targets, paged/manual advance, observability

### DIFF
--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
@@ -25,6 +25,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import com.hereliesaz.aznavrail.tutorial.AzGuideShape
+import com.hereliesaz.aznavrail.tutorial.AzInstructionStep
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
@@ -155,6 +158,12 @@ fun MainApp() {
     // Status-driven guidance demo: a custom status backed by app state (see the `azStatus`/`azEdge`
     // declarations below and the activate buttons in TutorialDemoScreen).
     var guideTaskDone by remember { mutableStateOf(false) }
+    // Worked example state: an arbitrary, MOVING on-screen highlight target (a draggable coach ball,
+    // reported in window-space) plus the status it flips when dragged.
+    var coachBallBounds by remember { mutableStateOf<Rect?>(null) }
+    var coachBallDragged by remember { mutableStateOf(false) }
+    // Host-driven guidance suppression (e.g. while a gesture is in progress).
+    var suppressGuidance by remember { mutableStateOf(false) }
 
     AzHostActivityLayout(
         navController = navController,
@@ -245,6 +254,29 @@ fun MainApp() {
         azGoal(id = "guide_onboarding", target = "az.screen.bottom-sheet", label = "See the Bottom Sheets demo", autoStartWhen = "az.screen.tutorial")
         azGoal(id = "guide_expand_host", target = "az.host.rail-host.expanded", label = "Expand the Rail Host")
         azGoal(id = "guide_custom_task", target = "guide_task_done", label = "Complete a custom task")
+
+        // ---------- Worked example: arbitrary moving target + a mixed manual/reactive paged goal ----------
+        // A host-registered target tracks the draggable "coach ball" the screen draws (window-space px),
+        // so the spotlight follows it every frame. The single paged edge mixes two tap-advanced info
+        // steps with one actionable step that auto-advances when the ball is dragged.
+        azGuidanceTarget("coach.ball") {
+            coachBallBounds?.let { b -> AzGuideShape.Circle(b.center.x, b.center.y, b.minDimension / 2f, padding = 8f) }
+        }
+        azStatus("coach_ball_dragged") { coachBallDragged }
+        azEdge(
+            from = "az.screen.tutorial",
+            to = "coach_ball_dragged",
+            title = "Meet the coach",
+            steps = listOf(
+                AzInstructionStep("This coach is status-driven. Tap to continue."),
+                AzInstructionStep("It can point at moving on-screen things, not just rail items.", highlightTargetId = "coach.ball"),
+                AzInstructionStep("Now drag the circle to finish.", highlightTargetId = "coach.ball", advanceWhen = "coach_ball_dragged"),
+            ),
+        )
+        azGoal(id = "guide_coach", target = "coach_ball_dragged", label = "Meet the moving-target coach")
+        // Host-driven suppression: while the toggle is on the overlay hides; when it flips off, guidance
+        // re-shows after the default ~700 ms settle.
+        azSuppressGuide { suppressGuidance }
 
         // ---------- Showcase navigation menu items ----------
         azMenuItem(id = "showcase-home", text = "Showcase Home", route = "showcase-home", screenTitle = "Showcase", info = "Index of every demo screen in this sample.")
@@ -662,6 +694,12 @@ fun MainApp() {
                         taskDone = guideTaskDone,
                         onMarkTaskDone = { guideTaskDone = true },
                         onResetTask = { guideTaskDone = false },
+                        coachBallDragged = coachBallDragged,
+                        onCoachBallBounds = { coachBallBounds = it },
+                        onCoachBallDrag = { coachBallDragged = true },
+                        onResetCoach = { coachBallDragged = false },
+                        suppressed = suppressGuidance,
+                        onToggleSuppress = { suppressGuidance = !suppressGuidance },
                     )
                 }
                 composable("fab-overlay") {

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/TutorialDemoScreen.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/TutorialDemoScreen.kt
@@ -1,39 +1,71 @@
 package com.hereliesaz.SampleApp.screens
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.tutorial.LocalAzGuidanceController
+import kotlin.math.roundToInt
 
 /**
  * Demonstrates the status-driven **guidance** framework (the reactive replacement for the old
  * scripted scene/card tutorial).
  *
- * The statuses, edges and goals are declared in the host DSL in `MainApp` (`azStatus`/`azEdge`/
- * `azGoal`). This screen only drives the [com.hereliesaz.aznavrail.tutorial.AzGuidanceController]:
- * it activates goals, and the framework figures out — live — which instruction to show next and
- * places each as a callout next to the control you'd use. There is no Next button; performing the
- * action flips a status and the callout advances on its own.
+ * The statuses, edges, goals and the moving-target registration are declared in the host DSL in
+ * `MainApp` (`azStatus`/`azEdge`/`azGoal`/`azGuidanceTarget`/`azSuppressGuide`). This screen drives the
+ * [com.hereliesaz.aznavrail.tutorial.AzGuidanceController]: it activates goals, draws the draggable
+ * "coach ball" (an arbitrary on-screen highlight target), and observes the live `current` instruction.
  *
  * @param taskDone Current value of the custom `guide_task_done` status (owned by `MainApp`).
  * @param onMarkTaskDone Flips that status true, satisfying the `guide_custom_task` goal.
  * @param onResetTask Flips it back so the custom goal can be demoed again.
+ * @param coachBallDragged Whether the coach ball has been dragged (the `coach_ball_dragged` status).
+ * @param onCoachBallBounds Reports the coach ball's window-space bounds so the host target can track it.
+ * @param onCoachBallDrag Called when the user starts dragging the coach ball (flips its status).
+ * @param onResetCoach Resets the coach-ball status so the paged goal can be demoed again.
+ * @param suppressed Whether host-driven guidance suppression is on.
+ * @param onToggleSuppress Toggles suppression (the overlay hides while on, re-shows after the settle).
  */
 @Composable
 fun TutorialDemoScreen(
     taskDone: Boolean,
     onMarkTaskDone: () -> Unit,
     onResetTask: () -> Unit,
+    coachBallDragged: Boolean,
+    onCoachBallBounds: (Rect) -> Unit,
+    onCoachBallDrag: () -> Unit,
+    onResetCoach: () -> Unit,
+    suppressed: Boolean,
+    onToggleSuppress: () -> Unit,
 ) {
     val guidance = LocalAzGuidanceController.current
 
@@ -96,6 +128,63 @@ fun TutorialDemoScreen(
         Text("Satisfy / reset the custom status", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
         AzButton(onClick = onMarkTaskDone, text = "Mark task done (flip guide_task_done)")
         AzButton(onClick = onResetTask, text = "Reset task")
+
+        // ---------- Worked example: moving target + a mixed manual/reactive paged goal ----------
+        Text("Moving-target coach (paged)", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text(
+            "One goal, three steps in one edge: two tap-advanced info steps, then an actionable step " +
+                "that auto-advances when you drag the circle. The spotlight is an arbitrary on-screen " +
+                "shape (a circle) registered with azGuidanceTarget — it tracks the circle as it moves.",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        AzButton(onClick = { guidance.activate("guide_coach") }, text = "Activate moving-target coach")
+
+        // The draggable coach ball. It reports its window-space bounds so the host target can spotlight
+        // it, and flips `coach_ball_dragged` on first drag (auto-advancing the last step).
+        Box(modifier = Modifier.fillMaxSize().height(140.dp)) {
+            var offset by remember { mutableStateOf(Offset.Zero) }
+            Box(
+                modifier = Modifier
+                    .offset { IntOffset(offset.x.roundToInt(), offset.y.roundToInt()) }
+                    .size(72.dp)
+                    .clip(CircleShape)
+                    .background(if (coachBallDragged) Color(0xFF4CAF50) else Color(0xFFFFC107))
+                    .onGloballyPositioned { onCoachBallBounds(it.boundsInWindow()) }
+                    .pointerInput(Unit) {
+                        detectDragGestures(onDragStart = { onCoachBallDrag() }) { change, drag ->
+                            change.consume(); offset += drag
+                        }
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    if (coachBallDragged) "✓" else "drag",
+                    color = Color.Black,
+                    style = MaterialTheme.typography.labelMedium,
+                )
+            }
+        }
+        AzButton(onClick = onResetCoach, text = "Reset coach status")
+
+        // Observability: the live current instruction the framework is showing.
+        Text("Observed current instruction", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        val cur = guidance.current
+        Text(
+            cur?.let {
+                "“${it.text}” — step ${it.stepIndex + 1}/${it.stepTotal}" +
+                    (it.targetId?.let { id -> ", target=$id" } ?: "") +
+                    (it.goalId?.let { id -> ", goal=$id" } ?: "")
+            } ?: "(nothing showing)",
+            style = MaterialTheme.typography.bodySmall,
+        )
+
+        Text("Suppression", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text(
+            "Drives azSuppressGuide from host state: while on, the overlay hides; when you turn it off " +
+                "guidance re-shows after a ~700 ms settle (so a callout never pops over a finishing gesture).",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        AzButton(onClick = onToggleSuppress, text = if (suppressed) "Suppression: ON (tap to clear)" else "Suppression: off (tap to suppress)")
 
         Text("Stop guiding", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
         AzButton(

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.5.0
+
+### Added
+- **Arbitrary moving highlight targets.** Register a window-space shape with **`<AzGuidanceTarget id
+  shape={() => AzGuideShape | null} />`** and point an edge/step at it via `highlightTargetId`. The shape
+  (`{ type: 'Circle' | 'Rect' | 'Path', … }`, recomputed each frame) lets the spotlight track an
+  on-screen object drawn over a canvas; returning `null` degrades to text-only. New exports:
+  `AzGuidanceTarget`, `AzGuideShape`, `AzPathCmd`, `shapeBounds`, `resolveShape`.
+- **Paged steps & manual advance.** `<AzEdge steps={[…]} />` reveals one `AzInstructionStep` at a time:
+  an informational step (no `advanceWhen`) advances on tap; a step with `advanceWhen="<statusId>"`
+  auto-advances when that status flips (reactive wins). One goal can mix “read this” and “now do this”
+  steps. The controller gains `advance(stepKey)` / `next(stepKey)` / `back(stepKey)` and no-arg
+  `advance()`.
+- **Dynamic rail-item highlights.** The `AZ_ITEM_ACTIVE` (`'az.item.active'`) token and a
+  `highlightSelector={() => string | null}` prop resolve the highlight to the active or a runtime rail
+  item each frame.
+- **Observable current instruction.** The controller exposes `currentInstructions: AzGuidanceSnapshot[]`
+  and `current`, so a host can mirror what's showing (text/title/target/step) with bespoke rendering.
+- **Gesture-time suppression.** **`<AzSuppressGuide predicate settleMs />`** hides guidance while the
+  predicate is true and re-shows after a settle delay once it clears.
+- **Custom callout rendering.** **`<AzGuideRenderer render={(snapshot, bounds) => …} />`** replaces the
+  built-in callout body (the dim/ring still draw).
+
+### Fixed
+- The guidance docs incorrectly showed `autoStartWhen` as a function; it is a **status id** string.
+
+### Notes
+- All additions are backward-compatible: existing `<AzStatus>` / `<AzEdge>` / `<AzGoal>` usage is
+  unchanged. **Parity:** a `Path` target is ringed by its bounding box (RN can't multi-hole / path-mask).
+
 ## Unreleased
 
 ### Removed

--- a/aznavrail-react/KNOWN_GAPS.md
+++ b/aznavrail-react/KNOWN_GAPS.md
@@ -55,6 +55,13 @@ each target over a light dim instead of a real punch-out. Routing, callouts, and
 identical; only the highlight rendering differs. There is no plan to emulate a pixel-perfect punch-out
 on web.
 
+The same applies to **arbitrary shape targets** (`AzGuidanceTarget` / `highlightTargetId`): Android
+punches the actual `Circle` / `Rect` / `Path` geometry out of the dim, while React rings the target's
+**bounding box** (a `Path` target is therefore approximated by its AABB, not its true outline). The
+resolved shape is still published on the controller (`currentInstructions[i].resolvedShape`), so a host
+that wants a pixel-accurate highlight can draw it itself via `<AzGuideRenderer>` or by observing the
+snapshot.
+
 ## `AzActivity` / `AzGraphInterface`
 
 The Android library exposes an `AzActivity` base class plus a KSP-generated

--- a/aznavrail-react/package.json
+++ b/aznavrail-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@HereLiesAz/aznavrail-react",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "description": "A contemptably stubborn navigation rail for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -28,8 +28,8 @@ import { HelpOverlay } from './components/HelpOverlay';
 import { AboutOverlay } from './components/AboutOverlay';
 import { MoreFromAzOverlay } from './components/MoreFromAzOverlay';
 import { AzGuidanceProvider, useAzGuidanceContext } from './guidance/AzGuidanceController';
-import { useActiveStatuses, computeBuiltinStatuses } from './guidance/AzStatusEngine';
-import { routeInstructions, computeAutoEdges } from './guidance/AzGuidance';
+import { useActiveStatuses, computeBuiltinStatuses, useGuidanceSuppressed } from './guidance/AzStatusEngine';
+import { routeInstructions, computeAutoEdges, snapshotsOf, edgeStepKey } from './guidance/AzGuidance';
 import { AzInstructionOverlay } from './components/AzInstructionOverlay';
 
 /** Props for the `AzNavRail` component, extending all `AzNavRailSettings` options. */
@@ -963,8 +963,8 @@ const AzGuidanceLayer: React.FC<{
   const activeStatuses = useActiveStatuses(guidance.statusPredicates, activeClassifiers, builtins);
   const edges = useMemo(() => [...guidance.edges, ...computeAutoEdges(items)], [guidance.edges, items]);
   const frame = useMemo(
-    () => routeInstructions(edges, guidance.goals, guidance.activeGoals, activeStatuses),
-    [edges, guidance.goals, guidance.activeGoals, activeStatuses],
+    () => routeInstructions(edges, guidance.goals, guidance.activeGoals, activeStatuses, (k) => guidance.stepIndex(k)),
+    [edges, guidance.goals, guidance.activeGoals, activeStatuses, guidance.stepIndex],
   );
   // Self-arming onboarding goals: activate once their trigger status holds (unless already completed).
   useEffect(() => {
@@ -975,13 +975,42 @@ const AzGuidanceLayer: React.FC<{
       }
     });
   }, [activeStatuses, guidance]);
-  // Auto-advance: a goal whose target is now true is reached → deactivate it and persist.
+  // Auto-advance: a goal whose target is now true is reached → deactivate it and persist. Persist
+  // reactive step advances into the cursor so a later tap continues from the shown step.
   useEffect(() => {
+    if (!guidance.enabled) return;
     frame.reachedGoals.forEach((g) => guidance.markReached(g));
+    frame.resolved.forEach((r) => {
+      if (r.stepTotal > 1) {
+        const key = edgeStepKey(r.edge);
+        if (guidance.stepIndex(key) < r.stepIndex) guidance.setStep(key, r.stepIndex);
+      }
+    });
   }, [frame, guidance]);
+  // Publish the observable snapshot (while enabled) so a host can mirror it with bespoke rendering.
+  const snapshots = useMemo(
+    () => (guidance.enabled ? snapshotsOf(frame.resolved, itemBounds, activeItemId) : []),
+    [guidance.enabled, frame, itemBounds, activeItemId],
+  );
+  useEffect(() => {
+    guidance.publishCurrent(snapshots);
+  }, [snapshots, guidance]);
 
-  if (!guidance.enabled) return null;
-  return <AzInstructionOverlay instructions={frame.instructions} itemBounds={itemBounds} accent={accent} />;
+  // Host-driven suppression (observed even when hidden, so it can re-show after the settle).
+  const suppressed = useGuidanceSuppressed(guidance.suppressors);
+
+  if (!guidance.enabled || suppressed) return null;
+  return (
+    <AzInstructionOverlay
+      resolved={frame.resolved}
+      itemBounds={itemBounds}
+      accent={accent}
+      activeItemId={activeItemId}
+      targets={guidance.targets}
+      onAdvance={(k) => guidance.advance(k)}
+      renderSlot={guidance.renderer}
+    />
+  );
 };
 
 /**

--- a/aznavrail-react/src/__tests__/AzGuidanceExpansion.test.ts
+++ b/aznavrail-react/src/__tests__/AzGuidanceExpansion.test.ts
@@ -1,0 +1,111 @@
+import { routeInstructions } from '../guidance/AzGuidance';
+import {
+  AZ_ITEM_ACTIVE,
+  resolveAzHighlight,
+  resolveItemId,
+  resolveShape,
+  shapeBounds,
+} from '../guidance/AzStatus';
+import { anySuppressorActive } from '../guidance/AzStatusEngine';
+import type { AzEdge, AzGoal, AzGuideShape, AzItemBounds } from '../guidance/AzStatus';
+
+/** Parity with the Kotlin AzGuidanceExpansionTest: paged steps, highlight resolution, suppression. */
+
+const stepped: AzEdge = {
+  from: 'a',
+  to: 'done',
+  instruction: { text: 'step0' },
+  steps: [
+    { text: 'step0' },
+    { text: 'step1', highlightTargetId: 'ball', advanceWhen: 'x' },
+    { text: 'step2' },
+  ],
+};
+const goals: Record<string, AzGoal> = { g: { id: 'g', target: 'done' } };
+
+describe('paged routing', () => {
+  it('shows the step at the cursor', () => {
+    const f0 = routeInstructions([stepped], goals, ['g'], new Set(['a']), () => 0);
+    expect(f0.instructions[0].text).toBe('step0');
+    expect(f0.resolved[0].stepIndex).toBe(0);
+    expect(f0.resolved[0].stepTotal).toBe(3);
+
+    const f1 = routeInstructions([stepped], goals, ['g'], new Set(['a']), () => 1);
+    expect(f1.instructions[0].text).toBe('step1');
+    expect(f1.resolved[0].instruction.highlight).toEqual({ type: 'Target', id: 'ball' });
+  });
+
+  it('reactive advanceWhen wins over the tap cursor', () => {
+    const f = routeInstructions([stepped], goals, ['g'], new Set(['a', 'x']), () => 1);
+    expect(f.instructions[0].text).toBe('step2');
+    expect(f.resolved[0].stepIndex).toBe(2);
+  });
+
+  it('does not skip an informational step when a later step status is already true', () => {
+    const f = routeInstructions([stepped], goals, ['g'], new Set(['a', 'x']), () => 0);
+    expect(f.instructions[0].text).toBe('step0');
+  });
+
+  it('reaches a paged goal when its target becomes true', () => {
+    const f = routeInstructions([stepped], goals, ['g'], new Set(['a', 'done']), () => 1);
+    expect(f.reachedGoals.has('g')).toBe(true);
+    expect(f.instructions).toHaveLength(0);
+  });
+
+  it('keeps single-callout edges unchanged (stepTotal 1)', () => {
+    const edge: AzEdge = { from: 'a', to: 'b', instruction: { text: 'Do A', highlight: { type: 'Item', id: 'ia' } } };
+    const f = routeInstructions([edge], { g: { id: 'g', target: 'b' } }, ['g'], new Set(['a']));
+    expect(f.instructions[0].text).toBe('Do A');
+    expect(f.resolved[0].stepTotal).toBe(1);
+  });
+});
+
+describe('highlight + shape resolution', () => {
+  it('resolveAzHighlight precedence is target, selector, active token, item, none', () => {
+    expect(resolveAzHighlight('item', () => 'sel', 't')).toEqual({ type: 'Target', id: 't' });
+    expect(resolveAzHighlight('item', () => 'sel', undefined).type).toBe('Dynamic');
+    expect(resolveAzHighlight(AZ_ITEM_ACTIVE, undefined, undefined)).toEqual({ type: 'ActiveItem' });
+    expect(resolveAzHighlight('item', undefined, undefined)).toEqual({ type: 'Item', id: 'item' });
+    expect(resolveAzHighlight(undefined, undefined, undefined)).toEqual({ type: 'None' });
+  });
+
+  it('resolveItemId folds ActiveItem and Dynamic against the live active id', () => {
+    expect(resolveItemId({ type: 'ActiveItem' }, 'home')).toBe('home');
+    expect(resolveItemId({ type: 'Dynamic', selector: () => 'layer.1' }, null)).toBe('layer.1');
+    expect(resolveItemId({ type: 'Dynamic', selector: () => AZ_ITEM_ACTIVE }, 'home')).toBe('home');
+    expect(resolveItemId({ type: 'Target', id: 't' }, 'home')).toBeNull();
+  });
+
+  it('resolveShape resolves targets, areas and items, degrading to null', () => {
+    const circle: AzGuideShape = { type: 'Circle', cx: 1, cy: 2, radius: 3 };
+    const targets = { t: () => circle, gone: () => null };
+    expect(resolveShape({ type: 'Target', id: 't' }, {}, null, targets)).toEqual(circle);
+    expect(resolveShape({ type: 'Target', id: 'gone' }, {}, null, targets)).toBeNull();
+    expect(resolveShape({ type: 'Target', id: 'missing' }, {}, null, targets)).toBeNull();
+    expect(resolveShape({ type: 'Area', left: 5, top: 6, width: 7, height: 8 }, {}, null, {})?.type).toBe('Rect');
+
+    const cache: Record<string, AzItemBounds> = { home: { x: 0, y: 0, width: 10, height: 10 } };
+    expect(resolveShape({ type: 'Item', id: 'home' }, cache, null, {})?.type).toBe('Rect');
+    expect(resolveShape({ type: 'Item', id: 'nope' }, cache, null, {})).toBeNull();
+    expect(resolveShape({ type: 'ActiveItem' }, cache, 'home', {})?.type).toBe('Rect');
+    expect(resolveShape({ type: 'ActiveItem' }, cache, null, {})).toBeNull();
+  });
+
+  it('shapeBounds wraps each geometry with padding', () => {
+    expect(shapeBounds({ type: 'Circle', cx: 100, cy: 50, radius: 10, padding: 5 })).toEqual({ left: 85, top: 35, width: 30, height: 30 });
+    expect(shapeBounds({ type: 'Rect', left: 10, top: 20, width: 30, height: 40 })).toEqual({ left: 10, top: 20, width: 30, height: 40 });
+    expect(
+      shapeBounds({ type: 'Path', commands: [{ type: 'M', x: 0, y: 0 }, { type: 'Q', x1: 5, y1: 30, x: 10, y: 20 }, { type: 'Z' }] }),
+    ).toEqual({ left: 0, top: 0, width: 10, height: 30 });
+  });
+});
+
+describe('suppression', () => {
+  it('anySuppressorActive ORs predicates and treats a throw as false', () => {
+    expect(anySuppressorActive([])).toBe(false);
+    expect(anySuppressorActive([[700, () => true]])).toBe(true);
+    expect(anySuppressorActive([[700, () => false]])).toBe(false);
+    expect(anySuppressorActive([[0, () => false], [0, () => true]])).toBe(true);
+    expect(anySuppressorActive([[0, () => { throw new Error('boom'); }]])).toBe(false);
+  });
+});

--- a/aznavrail-react/src/components/AzInstructionOverlay.tsx
+++ b/aznavrail-react/src/components/AzInstructionOverlay.tsx
@@ -1,61 +1,85 @@
 import React from 'react';
-import { View, Text, StyleSheet, Dimensions } from 'react-native';
-import type { AzGuideHighlight, AzInstruction } from '../guidance/AzStatus';
-
-type Bounds = { x: number; y: number; width: number; height: number };
+import { View, Text, StyleSheet, Dimensions, Pressable } from 'react-native';
+import type {
+  AzGuidanceRenderer,
+  AzGuideShape,
+  AzInstruction,
+  AzItemBounds,
+  AzShapeBounds,
+} from '../guidance/AzStatus';
+import { resolveShape, shapeBounds } from '../guidance/AzStatus';
+import type { ResolvedInstruction } from '../guidance/AzGuidance';
+import { edgeStepKey } from '../guidance/AzGuidance';
 
 interface Props {
-  instructions: AzInstruction[];
-  itemBounds: Record<string, Bounds>;
+  resolved: ResolvedInstruction[];
+  itemBounds: Record<string, AzItemBounds>;
   accent?: string;
+  activeItemId?: string | null;
+  targets?: Record<string, () => AzGuideShape | null>;
+  /** Called when a tap-advanceable step's callout is pressed. */
+  onAdvance?: (key: string) => void;
+  /** Host renderer replacing the built-in callout body. */
+  renderSlot?: AzGuidanceRenderer | null;
 }
 
 const CALLOUT_W = 240;
 
-function resolveBounds(h: AzGuideHighlight | undefined, cache: Record<string, Bounds>): Bounds | null {
-  if (!h) return null;
-  if (h.type === 'Item') return cache[h.id] || null;
-  if (h.type === 'Area') return { x: h.left, y: h.top, width: h.width, height: h.height };
-  return null;
-}
-
 /**
  * Renders the current guidance instructions as callouts, **each placed next to its own highlight
- * target** (so the user sees, in place, how to accomplish each active goal). The overlay never blocks
- * input — it is `box-none` throughout so taps reach the real controls; there is no Next button, the
- * app's own state change advances guidance.
+ * target** (so the user sees, in place, how to accomplish each active goal). Targets may be rail items,
+ * the active item, or host-registered arbitrary shapes (circle / rect / path). The overlay never blocks
+ * input except on a tap-advanceable info-step callout, which advances the paged edge on press.
  *
  * (Parity note: where the Android overlay punches a true spotlight hole per target, the React overlay
- * draws an accent ring around each target over a light dim — multi-hole masking isn't portable across
- * React Native primitives.)
+ * draws an accent ring around each target over a light dim. A `Path` target is ringed by its bounding
+ * box — multi-hole / path masking isn't portable across React Native primitives.)
  */
-export const AzInstructionOverlay: React.FC<Props> = ({ instructions, itemBounds, accent = '#6200ee' }) => {
-  if (!instructions || instructions.length === 0) return null;
+export const AzInstructionOverlay: React.FC<Props> = ({
+  resolved,
+  itemBounds,
+  accent = '#6200ee',
+  activeItemId = null,
+  targets = {},
+  onAdvance,
+  renderSlot,
+}) => {
+  if (!resolved || resolved.length === 0) return null;
   const screen = Dimensions.get('window');
 
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
       <View style={[StyleSheet.absoluteFill, styles.dim]} pointerEvents="none" />
-      {instructions.map((ins, i) => {
-        const b = resolveBounds(ins.highlight, itemBounds);
+      {resolved.map((r, i) => {
+        const ins = r.instruction;
+        const highlight = ins.highlight ?? { type: 'None' };
+        const shape = resolveShape(highlight, itemBounds, activeItemId, targets);
+        const b: AzShapeBounds | null = shape ? shapeBounds(shape) : null;
+        const stepKey = edgeStepKey(r.edge);
+        const currentStep = r.edge.steps?.[r.stepIndex];
+        const tappable = r.stepTotal > 1 && r.stepIndex < r.stepTotal - 1 && currentStep?.advanceWhen == null;
+        const onPress = tappable && onAdvance ? () => onAdvance(stepKey) : undefined;
+
+        const body = renderSlot
+          ? renderSlot(toSnapshotLite(r, shape, b), b)
+          : <Callout ins={ins} accent={accent} stepIndex={r.stepIndex} stepTotal={r.stepTotal} tappable={!!onPress} />;
+
         if (!b) {
           return (
-            <View key={i} style={styles.floatWrap} pointerEvents="none">
-              <Callout ins={ins} accent={accent} />
+            <View key={i} style={styles.floatWrap} pointerEvents="box-none">
+              <Tappable onPress={onPress}>{body}</Tappable>
             </View>
           );
         }
-        const belowHasRoom = b.y + b.height + 96 < screen.height;
-        const top = belowHasRoom ? b.y + b.height + 8 : Math.max(0, b.y - 96);
-        const left = Math.max(8, Math.min(b.x, screen.width - CALLOUT_W - 8));
+        const ring = ringStyle(shape!, b, accent);
+        const belowHasRoom = b.top + b.height + 96 < screen.height;
+        const top = belowHasRoom ? b.top + b.height + 8 : Math.max(0, b.top - 96);
+        const left = Math.max(8, Math.min(b.left, screen.width - CALLOUT_W - 8));
         return (
           <React.Fragment key={i}>
-            <View
-              pointerEvents="none"
-              style={[styles.ring, { left: b.x - 4, top: b.y - 4, width: b.width + 8, height: b.height + 8, borderColor: accent }]}
-            />
-            <View pointerEvents="none" style={[styles.calloutWrap, { left, top }]}>
-              <Callout ins={ins} accent={accent} />
+            <View pointerEvents="none" style={ring} />
+            <View pointerEvents="box-none" style={[styles.calloutWrap, { left, top }]}>
+              <Tappable onPress={onPress}>{body}</Tappable>
             </View>
           </React.Fragment>
         );
@@ -64,17 +88,65 @@ export const AzInstructionOverlay: React.FC<Props> = ({ instructions, itemBounds
   );
 };
 
-const Callout: React.FC<{ ins: AzInstruction; accent: string }> = ({ ins, accent }) => (
+const Tappable: React.FC<{ onPress?: () => void; children: React.ReactNode }> = ({ onPress, children }) => {
+  if (!onPress) return <View pointerEvents="none">{children}</View>;
+  return <Pressable onPress={onPress}>{children}</Pressable>;
+};
+
+/** A bounding ring around the shape (circle gets a circular border; rect/path get a rounded box). */
+function ringStyle(shape: AzGuideShape, b: AzShapeBounds, accent: string) {
+  const radius = shape.type === 'Circle' ? Math.min(b.width, b.height) / 2 : shape.type === 'Rect' ? (shape.cornerRadius ?? 12) : 12;
+  return {
+    position: 'absolute' as const,
+    left: b.left - 4,
+    top: b.top - 4,
+    width: b.width + 8,
+    height: b.height + 8,
+    borderWidth: 2,
+    borderColor: accent,
+    borderRadius: radius + 4,
+  };
+}
+
+/** Minimal snapshot for the render slot (mirrors the controller's published snapshot). */
+function toSnapshotLite(r: ResolvedInstruction, shape: AzGuideShape | null, b: AzShapeBounds | null) {
+  const h = r.instruction.highlight ?? { type: 'None' as const };
+  return {
+    text: r.instruction.text,
+    title: r.instruction.title,
+    goalId: r.goalId,
+    highlight: h,
+    targetId: h.type === 'Target' ? h.id : null,
+    resolvedShape: shape,
+    resolvedBounds: b,
+    stepIndex: r.stepIndex,
+    stepTotal: r.stepTotal,
+    stepKey: edgeStepKey(r.edge),
+  };
+}
+
+const Callout: React.FC<{ ins: AzInstruction; accent: string; stepIndex: number; stepTotal: number; tappable: boolean }> = ({
+  ins,
+  accent,
+  stepIndex,
+  stepTotal,
+  tappable,
+}) => (
   <View style={styles.callout}>
     {ins.title ? <Text style={[styles.title, { color: accent }]}>{ins.title}</Text> : null}
     <Text style={styles.text}>{ins.text}</Text>
     {ins.media ? <View style={styles.media}>{ins.media()}</View> : null}
+    {stepTotal > 1 ? (
+      <View style={styles.stepRow}>
+        <Text style={styles.stepCount}>{`${stepIndex + 1} / ${stepTotal}`}</Text>
+        {tappable ? <Text style={[styles.tapHint, { color: accent }]}>Tap to continue ▸</Text> : null}
+      </View>
+    ) : null}
   </View>
 );
 
 const styles = StyleSheet.create({
   dim: { backgroundColor: 'rgba(0,0,0,0.35)' },
-  ring: { position: 'absolute', borderWidth: 2, borderRadius: 12 },
   calloutWrap: { position: 'absolute', maxWidth: CALLOUT_W },
   floatWrap: { position: 'absolute', left: 0, right: 0, bottom: 24, alignItems: 'center' },
   callout: {
@@ -91,4 +163,7 @@ const styles = StyleSheet.create({
   title: { fontWeight: 'bold', marginBottom: 4 },
   text: { color: '#222222' },
   media: { marginTop: 8 },
+  stepRow: { flexDirection: 'row', justifyContent: 'space-between', marginTop: 8 },
+  stepCount: { fontSize: 12, color: '#888888' },
+  tapHint: { fontSize: 12 },
 });

--- a/aznavrail-react/src/guidance/AzGuidance.ts
+++ b/aznavrail-react/src/guidance/AzGuidance.ts
@@ -1,4 +1,13 @@
-import type { AzEdge, AzGoal, AzGuideHighlight, AzInstruction } from './AzStatus';
+import type {
+  AzEdge,
+  AzGoal,
+  AzGuideHighlight,
+  AzGuidanceSnapshot,
+  AzGuideShape,
+  AzInstruction,
+  AzItemBounds,
+} from './AzStatus';
+import { edgeStepKey, resolveShape, resolveTargetId, shapeBounds, stepHighlight, stepToInstruction } from './AzStatus';
 import type { AzNavItem } from '../types';
 
 /**
@@ -38,8 +47,19 @@ export function nextHop(edges: AzEdge[], activeStatuses: Set<string>, target: st
   return null;
 }
 
+/** One instruction the engine has chosen to show, resolved to its current paged step. */
+export interface ResolvedInstruction {
+  instruction: AzInstruction;
+  edge: AzEdge;
+  goalId: string | null;
+  stepIndex: number;
+  stepTotal: number;
+}
+
 /** The set of instructions to show right now, plus the goals already at their target. */
 export interface GuidanceFrame {
+  resolved: ResolvedInstruction[];
+  /** Back-compat view: just the per-step instructions to render. */
   instructions: AzInstruction[];
   reachedGoals: Set<string>;
 }
@@ -51,9 +71,30 @@ function highlightKey(h?: AzGuideHighlight): string {
       return `item:${h.id}`;
     case 'Area':
       return `area:${h.left},${h.top},${h.width},${h.height}`;
+    case 'Target':
+      return `target:${h.id}`;
     default:
       return h.type;
   }
+}
+
+/**
+ * Resolves an edge to the instruction for its current step. A non-paged edge resolves to its single
+ * instruction; a paged edge consults `stepIndexOf` then advances past leading steps whose `advanceWhen`
+ * is already satisfied (reactive advance wins over the tap cursor). Mirrors Kotlin `resolveEdge`.
+ */
+export function resolveEdge(
+  edge: AzEdge,
+  goalId: string | null,
+  stepIndexOf: (key: string) => number,
+  activeStatuses: Set<string>,
+): ResolvedInstruction {
+  const steps = edge.steps ?? [];
+  if (steps.length === 0) return { instruction: edge.instruction, edge, goalId, stepIndex: 0, stepTotal: 1 };
+  const last = steps.length - 1;
+  let idx = Math.max(0, Math.min(stepIndexOf(edgeStepKey(edge)), last));
+  while (idx < last && steps[idx].advanceWhen != null && activeStatuses.has(steps[idx].advanceWhen as string)) idx++;
+  return { instruction: stepToInstruction(steps[idx], edge.instruction.title), edge, goalId, stepIndex: idx, stepTotal: steps.length };
 }
 
 /**
@@ -66,8 +107,9 @@ export function routeInstructions(
   goals: Record<string, AzGoal>,
   activeGoalIds: string[],
   activeStatuses: Set<string>,
+  stepIndexOf: (key: string) => number = () => 0,
 ): GuidanceFrame {
-  const out = new Map<string, AzInstruction>();
+  const out = new Map<string, ResolvedInstruction>();
   const reached = new Set<string>();
   const keyOf = (ins: AzInstruction) => `${ins.text}|${highlightKey(ins.highlight)}`;
   for (const gid of activeGoalIds) {
@@ -78,13 +120,61 @@ export function routeInstructions(
       continue;
     }
     const e = nextHop(edges, activeStatuses, goal.target);
-    if (e) out.set(keyOf(e.instruction), e.instruction);
+    if (e) {
+      const r = resolveEdge(e, gid, stepIndexOf, activeStatuses);
+      out.set(keyOf(r.instruction), r);
+    }
   }
   for (const e of edges) {
-    if (e.to == null && activeStatuses.has(e.from)) out.set(keyOf(e.instruction), e.instruction);
+    if (e.to == null && activeStatuses.has(e.from)) {
+      const r = resolveEdge(e, null, stepIndexOf, activeStatuses);
+      out.set(keyOf(r.instruction), r);
+    }
   }
-  return { instructions: Array.from(out.values()), reachedGoals: reached };
+  const resolved = Array.from(out.values());
+  return { resolved, instructions: resolved.map((r) => r.instruction), reachedGoals: reached };
 }
+
+/** Builds the public `AzGuidanceSnapshot` for a resolved instruction (the `shape` resolved by caller). */
+export function toSnapshot(
+  r: ResolvedInstruction,
+  shape: AzGuideShape | null,
+  activeItemId: string | null,
+): AzGuidanceSnapshot {
+  const h = r.instruction.highlight ?? { type: 'None' };
+  return {
+    text: r.instruction.text,
+    title: r.instruction.title,
+    goalId: r.goalId,
+    highlight: h,
+    targetId: resolveTargetId(h, activeItemId),
+    resolvedShape: shape,
+    resolvedBounds: shape ? shapeBounds(shape) : null,
+    stepIndex: r.stepIndex,
+    stepTotal: r.stepTotal,
+    stepKey: edgeStepKey(r.edge),
+  };
+}
+
+/**
+ * Resolves each resolved instruction to a snapshot. Moving-target shapes are intentionally NOT invoked
+ * here (the host has its own shape and gets the `targetId`); only stable rail-item bounds are resolved.
+ */
+export function snapshotsOf(
+  resolved: ResolvedInstruction[],
+  cache: Record<string, AzItemBounds>,
+  activeItemId: string | null,
+): AzGuidanceSnapshot[] {
+  return resolved.map((r) => {
+    const h = r.instruction.highlight ?? { type: 'None' };
+    // Don't invoke moving target lambdas here (the host has its own shape + the targetId).
+    const shape = h.type === 'Target' ? null : resolveShape(h, cache, activeItemId, {});
+    return toSnapshot(r, shape, activeItemId);
+  });
+}
+
+// Re-exported for the overlay/layer and tests.
+export { resolveShape, stepHighlight, edgeStepKey };
 
 /**
  * Derives the guidance **auto-edges** for the rail's own affordances, so the developer only hand-authors

--- a/aznavrail-react/src/guidance/AzGuidanceController.tsx
+++ b/aznavrail-react/src/guidance/AzGuidanceController.tsx
@@ -1,5 +1,12 @@
 import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
-import type { AzEdge, AzGoal, AzStatusPredicate } from './AzStatus';
+import type {
+  AzEdge,
+  AzGoal,
+  AzGuidanceRenderer,
+  AzGuidanceSnapshot,
+  AzGuideShapeProvider,
+  AzStatusPredicate,
+} from './AzStatus';
 
 const STORAGE_KEY = 'az_navrail_completed_goals';
 
@@ -55,19 +62,45 @@ export interface AzGuidanceController {
   /** Mark a goal reached: deactivate it and persist completion. */
   markReached: (goalId: string) => void;
   isCompleted: (goalId: string) => boolean;
+  // --- Paged-edge step cursor (transient; only goal completion persists) ---
+  /** Current step index for the paged edge identified by `key` (see `edgeStepKey`). */
+  stepIndex: (key: string) => number;
+  /** Set the step cursor for `key` (used by the overlay to sync reactive auto-advance). */
+  setStep: (key: string, index: number) => void;
+  /** Advance the paged edge `key` (or the first active paged instruction when omitted). */
+  advance: (key?: string) => void;
+  /** Alias for `advance`. */
+  next: (key?: string) => void;
+  /** Step the paged edge `key` back one (never below 0). */
+  back: (key: string) => void;
+  // --- Observable current instruction(s) (Gap C) ---
+  /** The guidance callouts being shown right now (one per active goal, plus passive tips). */
+  currentInstructions: AzGuidanceSnapshot[];
+  /** The primary (first) current instruction, a convenience for single-goal flows. */
+  current: AzGuidanceSnapshot | null;
 }
 
-/** Internal context value: the controller plus the live status/edge/goal registry. */
+/** Internal context value: the controller plus the live status/edge/goal/target registry. */
 interface AzGuidanceContextValue extends AzGuidanceController {
   statusPredicates: Record<string, AzStatusPredicate>;
   edges: AzEdge[];
   goals: Record<string, AzGoal>;
+  targets: Record<string, AzGuideShapeProvider>;
+  suppressors: Array<[number, () => boolean]>;
+  renderer: AzGuidanceRenderer | null;
   registerStatus: (id: string, predicate: AzStatusPredicate) => void;
   unregisterStatus: (id: string) => void;
   registerEdge: (key: string, edge: AzEdge) => void;
   unregisterEdge: (key: string) => void;
   registerGoal: (goal: AzGoal) => void;
   unregisterGoal: (id: string) => void;
+  registerTarget: (id: string, shape: AzGuideShapeProvider) => void;
+  unregisterTarget: (id: string) => void;
+  registerSuppressor: (key: string, settleMs: number, predicate: () => boolean) => void;
+  unregisterSuppressor: (key: string) => void;
+  setRenderer: (renderer: AzGuidanceRenderer | null) => void;
+  /** Publish the latest routed snapshot list. Called by the rail; not for app use. */
+  publishCurrent: (snapshots: AzGuidanceSnapshot[]) => void;
 }
 
 const AzGuidanceContext = createContext<AzGuidanceContextValue | null>(null);
@@ -92,6 +125,9 @@ export const AzGuidanceProvider: React.FC<AzGuidanceProviderProps> = ({ children
   const statusRef = useRef<Record<string, AzStatusPredicate>>({});
   const edgeRef = useRef<Record<string, AzEdge>>({});
   const goalRef = useRef<Record<string, AzGoal>>({});
+  const targetRef = useRef<Record<string, AzGuideShapeProvider>>({});
+  const suppressorRef = useRef<Record<string, [number, () => boolean]>>({});
+  const rendererRef = useRef<AzGuidanceRenderer | null>(null);
   const [version, setVersion] = useState(0);
   const bump = useCallback(() => setVersion((v) => v + 1), []);
 
@@ -101,6 +137,31 @@ export const AzGuidanceProvider: React.FC<AzGuidanceProviderProps> = ({ children
   const unregisterEdge = useCallback((key: string) => { delete edgeRef.current[key]; bump(); }, [bump]);
   const registerGoal = useCallback((goal: AzGoal) => { goalRef.current[goal.id] = goal; bump(); }, [bump]);
   const unregisterGoal = useCallback((id: string) => { delete goalRef.current[id]; bump(); }, [bump]);
+  const registerTarget = useCallback((id: string, shape: AzGuideShapeProvider) => { targetRef.current[id] = shape; bump(); }, [bump]);
+  const unregisterTarget = useCallback((id: string) => { delete targetRef.current[id]; bump(); }, [bump]);
+  const registerSuppressor = useCallback((key: string, settleMs: number, predicate: () => boolean) => { suppressorRef.current[key] = [settleMs, predicate]; bump(); }, [bump]);
+  const unregisterSuppressor = useCallback((key: string) => { delete suppressorRef.current[key]; bump(); }, [bump]);
+  const setRenderer = useCallback((renderer: AzGuidanceRenderer | null) => { rendererRef.current = renderer; bump(); }, [bump]);
+
+  // Transient paged-edge step cursor (only goal completion persists).
+  const [stepCursor, setStepCursor] = useState<Record<string, number>>({});
+  const stepIndex = useCallback((key: string) => stepCursor[key] ?? 0, [stepCursor]);
+  const setStep = useCallback((key: string, index: number) => {
+    setStepCursor((prev) => ({ ...prev, [key]: Math.max(0, index) }));
+  }, []);
+  const back = useCallback((key: string) => {
+    setStepCursor((prev) => ({ ...prev, [key]: Math.max(0, (prev[key] ?? 0) - 1) }));
+  }, []);
+
+  // Observable current instruction(s).
+  const [currentInstructions, setCurrentInstructions] = useState<AzGuidanceSnapshot[]>([]);
+  const publishCurrent = useCallback((snaps: AzGuidanceSnapshot[]) => { setCurrentInstructions(snaps); }, []);
+  const advance = useCallback((key?: string) => {
+    const resolvedKey = key ?? currentInstructions.find((s) => s.stepTotal > 1)?.stepKey;
+    if (resolvedKey == null) return;
+    setStepCursor((prev) => ({ ...prev, [resolvedKey]: (prev[resolvedKey] ?? 0) + 1 }));
+  }, [currentInstructions]);
+  const next = advance;
 
   const enable = useCallback(() => setEnabled(true), []);
   const disable = useCallback(() => setEnabled(false), []);
@@ -126,16 +187,24 @@ export const AzGuidanceProvider: React.FC<AzGuidanceProviderProps> = ({ children
   const edges = useMemo(() => Object.values(edgeRef.current), [version]);
   const goals = useMemo(() => ({ ...goalRef.current }), [version]);
   const statusPredicates = useMemo(() => ({ ...statusRef.current }), [version]);
+  const targets = useMemo(() => ({ ...targetRef.current }), [version]);
+  const suppressors = useMemo<Array<[number, () => boolean]>>(() => Object.values(suppressorRef.current), [version]);
+  const renderer = useMemo(() => rendererRef.current, [version]);
+  const current = currentInstructions.length > 0 ? currentInstructions[0] : null;
 
   const value = useMemo<AzGuidanceContextValue>(
     () => ({
       enabled, activeGoals, completedGoals, enable, disable, activate, deactivate, markReached, isCompleted,
-      statusPredicates, edges, goals,
+      stepIndex, setStep, advance, next, back, currentInstructions, current,
+      statusPredicates, edges, goals, targets, suppressors, renderer,
       registerStatus, unregisterStatus, registerEdge, unregisterEdge, registerGoal, unregisterGoal,
+      registerTarget, unregisterTarget, registerSuppressor, unregisterSuppressor, setRenderer, publishCurrent,
     }),
     [enabled, activeGoals, completedGoals, enable, disable, activate, deactivate, markReached, isCompleted,
-     statusPredicates, edges, goals,
-     registerStatus, unregisterStatus, registerEdge, unregisterEdge, registerGoal, unregisterGoal],
+     stepIndex, setStep, advance, next, back, currentInstructions, current,
+     statusPredicates, edges, goals, targets, suppressors, renderer,
+     registerStatus, unregisterStatus, registerEdge, unregisterEdge, registerGoal, unregisterGoal,
+     registerTarget, unregisterTarget, registerSuppressor, unregisterSuppressor, setRenderer, publishCurrent],
   );
 
   return <AzGuidanceContext.Provider value={value}>{children}</AzGuidanceContext.Provider>;
@@ -145,8 +214,11 @@ export const AzGuidanceProvider: React.FC<AzGuidanceProviderProps> = ({ children
 const NOOP: AzGuidanceContextValue = {
   enabled: false, activeGoals: [], completedGoals: [],
   enable: () => {}, disable: () => {}, activate: () => {}, deactivate: () => {}, markReached: () => {}, isCompleted: () => false,
-  statusPredicates: {}, edges: [], goals: {},
+  stepIndex: () => 0, setStep: () => {}, advance: () => {}, next: () => {}, back: () => {},
+  currentInstructions: [], current: null,
+  statusPredicates: {}, edges: [], goals: {}, targets: {}, suppressors: [], renderer: null,
   registerStatus: () => {}, unregisterStatus: () => {}, registerEdge: () => {}, unregisterEdge: () => {}, registerGoal: () => {}, unregisterGoal: () => {},
+  registerTarget: () => {}, unregisterTarget: () => {}, registerSuppressor: () => {}, unregisterSuppressor: () => {}, setRenderer: () => {}, publishCurrent: () => {},
 };
 
 /** Internal: full context (controller + registry), used by the rail engine and the DSL components. */

--- a/aznavrail-react/src/guidance/AzGuidanceScope.tsx
+++ b/aznavrail-react/src/guidance/AzGuidanceScope.tsx
@@ -77,18 +77,33 @@ export const AzEdge: React.FC<AzEdgeProps> = (props) => {
     props.highlightItemId ?? '',
     props.highlightTargetId ?? '',
     props.highlightSelector ? 'sel' : '',
-    JSON.stringify(props.steps ?? []),
+    // Serialize steps by value (functions are dropped by JSON.stringify), but encode each step's
+    // selector *presence* so toggling a step's highlightSelector on/off re-registers. Identity changes
+    // of an existing selector are handled live via propsRef in the effect below — not here.
+    JSON.stringify((props.steps ?? []).map((s) => ({
+      text: s.text, title: s.title, highlightItemId: s.highlightItemId,
+      highlightTargetId: s.highlightTargetId, side: s.side, advanceWhen: s.advanceWhen,
+      sel: s.highlightSelector ? 'sel' : '',
+    }))),
   ].join('|');
   useEffect(() => {
     const p = propsRef.current;
+    // `sig` deliberately ignores `highlightSelector` identity (and JSON.stringify drops the function
+    // fields of `steps`) so a fresh selector closure each render can't loop register→bump→render. The
+    // tradeoff is that the registered edge must resolve selectors LIVE from `propsRef` — otherwise it
+    // would freeze the first render's closure and the spotlight would point at a stale item.
+    const liveEdgeSelector = p.highlightSelector ? () => propsRef.current.highlightSelector?.() ?? null : undefined;
+    const liveSteps = p.steps?.map((s, idx) =>
+      s.highlightSelector ? { ...s, highlightSelector: () => propsRef.current.steps?.[idx]?.highlightSelector?.() ?? null } : s,
+    );
     let instruction: AzInstruction;
-    if (p.steps && p.steps.length > 0) {
-      const first = p.steps[0];
+    if (liveSteps && liveSteps.length > 0) {
+      const first = liveSteps[0];
       instruction = { text: first.text, title: first.title ?? p.title, highlight: stepHighlight(first), side: first.side };
     } else {
-      instruction = { text: p.text ?? '', title: p.title, highlight: resolveAzHighlight(p.highlightItemId, p.highlightSelector, p.highlightTargetId) };
+      instruction = { text: p.text ?? '', title: p.title, highlight: resolveAzHighlight(p.highlightItemId, liveEdgeSelector, p.highlightTargetId) };
     }
-    reg.registerEdge(keyRef.current!, { from, to: to ?? null, instruction, steps: p.steps });
+    reg.registerEdge(keyRef.current!, { from, to: to ?? null, instruction, steps: liveSteps });
     return () => reg.unregisterEdge(keyRef.current!);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reg, from, to, sig]);

--- a/aznavrail-react/src/guidance/AzGuidanceScope.tsx
+++ b/aznavrail-react/src/guidance/AzGuidanceScope.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useRef } from 'react';
 import { useAzGuidanceContext } from './AzGuidanceController';
-import type { AzGuideHighlight } from './AzStatus';
+import type {
+  AzGuidanceRenderer,
+  AzGuideShapeProvider,
+  AzInstruction,
+  AzInstructionStep,
+} from './AzStatus';
+import { resolveAzHighlight, stepHighlight } from './AzStatus';
 
 /**
  * Registers a status-driven guidance **status** — a named boolean predicate that becomes a node in the
@@ -32,7 +38,13 @@ export const AzStatus: React.FC<AzStatusProps> = ({ id, predicate }) => {
  * Registers a guidance **edge**: while status `from` is true, the shown instruction tells the user how
  * to make status `to` true (an interactive hop). A passive edge (omit `to`) just shows the instruction
  * while `from` holds. The rail auto-generates edges for its own affordances, so author edges here for
- * transitions into your own custom statuses. `highlightItemId` chooses what the callout sits next to.
+ * transitions into your own custom statuses.
+ *
+ * Choose what the callout sits next to (precedence): `highlightTargetId` (a host-registered arbitrary
+ * shape, see `<AzGuidanceTarget>`), then `highlightSelector` (a rail item id resolved each frame), then
+ * `highlightItemId` (a static rail item, or the `AZ_ITEM_ACTIVE` token). Provide `steps` to make the
+ * edge **paged** — several sub-pointers under one milestone, advanced by tap (or reactively per step's
+ * `advanceWhen`).
  *
  * @example
  * ```tsx
@@ -42,20 +54,117 @@ export const AzStatus: React.FC<AzStatusProps> = ({ id, predicate }) => {
 export interface AzEdgeProps {
   from: string;
   to?: string | null;
-  text: string;
+  text?: string;
   title?: string;
   highlightItemId?: string;
+  highlightTargetId?: string;
+  highlightSelector?: () => string | null;
+  steps?: AzInstructionStep[];
 }
 let edgeCounter = 0;
-export const AzEdge: React.FC<AzEdgeProps> = ({ from, to = null, text, title, highlightItemId }) => {
+export const AzEdge: React.FC<AzEdgeProps> = (props) => {
+  const { from, to = null } = props;
   const reg = useAzGuidanceContext();
   const keyRef = useRef<string>();
   if (!keyRef.current) keyRef.current = `az_edge_${edgeCounter++}`;
+  const propsRef = useRef(props);
+  propsRef.current = props;
+  // Re-register only when value-content changes — NOT on every render (a fresh `steps`/`selector`
+  // identity each render would otherwise loop with the registry's version bump).
+  const sig = [
+    props.text ?? '',
+    props.title ?? '',
+    props.highlightItemId ?? '',
+    props.highlightTargetId ?? '',
+    props.highlightSelector ? 'sel' : '',
+    JSON.stringify(props.steps ?? []),
+  ].join('|');
   useEffect(() => {
-    const highlight: AzGuideHighlight = highlightItemId ? { type: 'Item', id: highlightItemId } : { type: 'None' };
-    reg.registerEdge(keyRef.current!, { from, to: to ?? null, instruction: { text, title, highlight } });
+    const p = propsRef.current;
+    let instruction: AzInstruction;
+    if (p.steps && p.steps.length > 0) {
+      const first = p.steps[0];
+      instruction = { text: first.text, title: first.title ?? p.title, highlight: stepHighlight(first), side: first.side };
+    } else {
+      instruction = { text: p.text ?? '', title: p.title, highlight: resolveAzHighlight(p.highlightItemId, p.highlightSelector, p.highlightTargetId) };
+    }
+    reg.registerEdge(keyRef.current!, { from, to: to ?? null, instruction, steps: p.steps });
     return () => reg.unregisterEdge(keyRef.current!);
-  }, [reg, from, to, text, title, highlightItemId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reg, from, to, sig]);
+  return null;
+};
+
+/**
+ * Registers a **moving on-screen highlight target** the guidance overlay can spotlight by id (via
+ * `<AzEdge highlightTargetId={id} />`). `shape` returns the current `AzGuideShape` in **window-space px**
+ * (circle / rect / path) each frame, so the spotlight can track an object drawn over a canvas. Return
+ * `null` while the target is absent (the callout degrades to text-only).
+ *
+ * @example
+ * ```tsx
+ * <AzGuidanceTarget id="ball" shape={() => ({ type: 'Circle', cx: ball.x, cy: ball.y, radius: 40 })} />
+ * ```
+ */
+export interface AzGuidanceTargetProps {
+  id: string;
+  shape: AzGuideShapeProvider;
+}
+export const AzGuidanceTarget: React.FC<AzGuidanceTargetProps> = ({ id, shape }) => {
+  const reg = useAzGuidanceContext();
+  const shapeRef = useRef(shape);
+  shapeRef.current = shape;
+  useEffect(() => {
+    reg.registerTarget(id, () => shapeRef.current());
+    return () => reg.unregisterTarget(id);
+  }, [reg, id]);
+  return null;
+};
+
+/**
+ * Suppresses all guidance while `predicate` is true — drive it from your own gesture state so a callout
+ * never pops over an in-progress pinch/drag. When it flips back to false, guidance re-shows after a
+ * `settleMs` settle delay. Several suppressors compose (OR); the largest `settleMs` wins.
+ *
+ * @example
+ * ```tsx
+ * <AzSuppressGuide predicate={() => gesture.inProgress} settleMs={700} />
+ * ```
+ */
+export interface AzSuppressGuideProps {
+  predicate: () => boolean;
+  settleMs?: number;
+}
+let suppressCounter = 0;
+export const AzSuppressGuide: React.FC<AzSuppressGuideProps> = ({ predicate, settleMs = 700 }) => {
+  const reg = useAzGuidanceContext();
+  const keyRef = useRef<string>();
+  if (!keyRef.current) keyRef.current = `az_suppress_${suppressCounter++}`;
+  const predRef = useRef(predicate);
+  predRef.current = predicate;
+  useEffect(() => {
+    reg.registerSuppressor(keyRef.current!, settleMs, () => predRef.current());
+    return () => reg.unregisterSuppressor(keyRef.current!);
+  }, [reg, settleMs]);
+  return null;
+};
+
+/**
+ * Replaces the built-in guidance callout body with host-drawn content (the dim + spotlight still draw).
+ * `render` receives the current `AzGuidanceSnapshot` and the resolved target bounds (window-space px, or
+ * `null` when text-only) — for apps drawing bespoke callouts over a canvas.
+ */
+export interface AzGuideRendererProps {
+  render: AzGuidanceRenderer;
+}
+export const AzGuideRenderer: React.FC<AzGuideRendererProps> = ({ render }) => {
+  const reg = useAzGuidanceContext();
+  const ref = useRef(render);
+  ref.current = render;
+  useEffect(() => {
+    reg.setRenderer((snap, bounds) => ref.current(snap, bounds));
+    return () => reg.setRenderer(null);
+  }, [reg]);
   return null;
 };
 

--- a/aznavrail-react/src/guidance/AzStatus.ts
+++ b/aznavrail-react/src/guidance/AzStatus.ts
@@ -15,6 +15,12 @@ import type { ReactNode } from 'react';
  *  - a built-in `az.*` id derived from the live rail/host/route/help state.
  */
 
+/**
+ * The dynamic highlight token: passed anywhere a `highlightItemId` is accepted, it spotlights whatever
+ * rail item is currently `*.active` (resolved fresh every frame). Degrades to text-only when none is.
+ */
+export const AZ_ITEM_ACTIVE = 'az.item.active';
+
 /** What a guidance instruction spotlights. */
 export type AzGuideHighlight =
   | { type: 'None' }
@@ -22,7 +28,64 @@ export type AzGuideHighlight =
   /** Spotlight the rail item with this id (looked up in the item-bounds cache). */
   | { type: 'Item'; id: string }
   /** Spotlight an explicit window-space rectangle. */
-  | { type: 'Area'; left: number; top: number; width: number; height: number };
+  | { type: 'Area'; left: number; top: number; width: number; height: number }
+  /** Spotlight whatever rail item is currently active (resolved at render time). Text-only if none. */
+  | { type: 'ActiveItem' }
+  /** Spotlight the rail item whose id `selector` returns each frame (runtime/dynamic items). */
+  | { type: 'Dynamic'; selector: () => string | null }
+  /** Spotlight a host-registered arbitrary on-screen shape (see `<AzGuidanceTarget>`). Text-only if absent. */
+  | { type: 'Target'; id: string };
+
+/**
+ * A spotlight geometry in **window-space px** (the same space as the item-bounds cache, so it aligns
+ * with the overlay at zero offset). Returned by an `<AzGuidanceTarget>` shape function each frame, so a
+ * target can track a moving on-screen object. `padding` inflates the spotlight uniformly.
+ */
+export type AzGuideShape =
+  | { type: 'Circle'; cx: number; cy: number; radius: number; padding?: number }
+  | { type: 'Rect'; left: number; top: number; width: number; height: number; cornerRadius?: number; padding?: number }
+  | { type: 'Path'; commands: AzPathCmd[]; padding?: number };
+
+/** One command of an `AzGuideShape` path, in absolute window-space px (SVG-style). */
+export type AzPathCmd =
+  | { type: 'M'; x: number; y: number }
+  | { type: 'L'; x: number; y: number }
+  | { type: 'Q'; x1: number; y1: number; x: number; y: number }
+  | { type: 'C'; x1: number; y1: number; x2: number; y2: number; x: number; y: number }
+  | { type: 'Z' };
+
+/** Axis-aligned window-space bounds of a shape (inflated by its padding); used for callout placement. */
+export interface AzShapeBounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** Computes the axis-aligned bounds of an `AzGuideShape` (mirrors Kotlin `AzGuideShape.bounds()`). */
+export function shapeBounds(shape: AzGuideShape): AzShapeBounds {
+  const p = shape.padding ?? 0;
+  if (shape.type === 'Circle') {
+    return { left: shape.cx - shape.radius - p, top: shape.cy - shape.radius - p, width: 2 * (shape.radius + p), height: 2 * (shape.radius + p) };
+  }
+  if (shape.type === 'Rect') {
+    return { left: shape.left - p, top: shape.top - p, width: shape.width + 2 * p, height: shape.height + 2 * p };
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  const acc = (x: number, y: number) => {
+    minX = Math.min(minX, x); minY = Math.min(minY, y); maxX = Math.max(maxX, x); maxY = Math.max(maxY, y);
+  };
+  for (const c of shape.commands) {
+    if (c.type === 'M' || c.type === 'L') acc(c.x, c.y);
+    else if (c.type === 'Q') { acc(c.x1, c.y1); acc(c.x, c.y); }
+    else if (c.type === 'C') { acc(c.x1, c.y1); acc(c.x2, c.y2); acc(c.x, c.y); }
+  }
+  if (minX > maxX) return { left: 0, top: 0, width: 0, height: 0 };
+  return { left: minX - p, top: minY - p, width: maxX - minX + 2 * p, height: maxY - minY + 2 * p };
+}
 
 /** Preferred placement of a callout relative to its highlight target. */
 export type AzCalloutSide = 'Auto' | 'Above' | 'Below' | 'Start' | 'End';
@@ -42,14 +105,120 @@ export interface AzInstruction {
 }
 
 /**
+ * One paged sub-step of a multi-step edge. A single milestone can carry several, revealed one at a time
+ * (informational steps advance on tap; a step with `advanceWhen` advances reactively), moving the
+ * spotlight as the user reads.
+ */
+export interface AzInstructionStep {
+  text: string;
+  title?: string;
+  /** Rail item id to spotlight; the `AZ_ITEM_ACTIVE` token resolves to the active item. */
+  highlightItemId?: string;
+  /** A host-registered arbitrary on-screen target (see `<AzGuidanceTarget>`); highest precedence. */
+  highlightTargetId?: string;
+  side?: AzCalloutSide;
+  /** Resolved every frame to the rail item id to spotlight (runtime/dynamic items). */
+  highlightSelector?: () => string | null;
+  /** Status id that auto-advances past this step when true (reactive wins over the tap cursor). */
+  advanceWhen?: string;
+}
+
+/**
  * One edge of the flowchart: while status `from` is true, performing `instruction` is expected to make
  * status `to` true (an interactive hop). A passive edge (`to === null`) just shows info while `from`
- * holds. Authored via `<AzEdge>`, or auto-generated for rail affordances.
+ * holds. When `steps` is non-empty the edge is **paged** (revealed one step at a time). Authored via
+ * `<AzEdge>`, or auto-generated for rail affordances.
  */
 export interface AzEdge {
   from: string;
   to: string | null;
   instruction: AzInstruction;
+  steps?: AzInstructionStep[];
+}
+
+/**
+ * A read-only snapshot of one guidance callout currently being shown, published live on the controller
+ * (`currentInstructions`) so a host can mirror it with bespoke rendering and analytics.
+ */
+export interface AzGuidanceSnapshot {
+  text: string;
+  title?: string;
+  goalId: string | null;
+  highlight: AzGuideHighlight;
+  targetId: string | null;
+  resolvedShape: AzGuideShape | null;
+  resolvedBounds: AzShapeBounds | null;
+  stepIndex: number;
+  stepTotal: number;
+  stepKey: string;
+}
+
+/** Resolves a highlight directive into an `AzGuideHighlight` (mirrors Kotlin `resolveAzHighlight`). */
+export function resolveAzHighlight(
+  highlightItemId?: string,
+  highlightSelector?: () => string | null,
+  highlightTargetId?: string,
+): AzGuideHighlight {
+  if (highlightTargetId != null) return { type: 'Target', id: highlightTargetId };
+  if (highlightSelector != null) return { type: 'Dynamic', selector: highlightSelector };
+  if (highlightItemId === AZ_ITEM_ACTIVE) return { type: 'ActiveItem' };
+  if (highlightItemId != null) return { type: 'Item', id: highlightItemId };
+  return { type: 'None' };
+}
+
+/** This step's highlight directive as an `AzGuideHighlight`. */
+export function stepHighlight(step: AzInstructionStep): AzGuideHighlight {
+  return resolveAzHighlight(step.highlightItemId, step.highlightSelector, step.highlightTargetId);
+}
+
+/** This step as a standalone `AzInstruction` (used when the overlay pages a stepped edge). */
+export function stepToInstruction(step: AzInstructionStep, edgeTitle?: string): AzInstruction {
+  return { text: step.text, title: step.title ?? edgeTitle, highlight: stepHighlight(step), side: step.side };
+}
+
+/** The rail item id a highlight points at (folding ActiveItem/Dynamic against the live active id). */
+export function resolveItemId(h: AzGuideHighlight, activeItemId: string | null): string | null {
+  if (h.type === 'Item') return h.id;
+  if (h.type === 'ActiveItem') return activeItemId;
+  if (h.type === 'Dynamic') {
+    const id = h.selector();
+    return id === AZ_ITEM_ACTIVE ? activeItemId : id;
+  }
+  return null;
+}
+
+/** The resolved target/item id this highlight points at, if any (for the snapshot/analytics). */
+export function resolveTargetId(h: AzGuideHighlight, activeItemId: string | null): string | null {
+  if (h.type === 'Target') return h.id;
+  return resolveItemId(h, activeItemId);
+}
+
+/** Window-space item bounds as tracked by the rail (`UIManager.measureInWindow`). */
+export interface AzItemBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Resolves a highlight to the concrete `AzGuideShape` to spotlight (window-space px), or null. */
+export function resolveShape(
+  h: AzGuideHighlight,
+  cache: Record<string, AzItemBounds>,
+  activeItemId: string | null,
+  targets: Record<string, () => AzGuideShape | null>,
+): AzGuideShape | null {
+  if (h.type === 'Area') return { type: 'Rect', left: h.left, top: h.top, width: h.width, height: h.height };
+  if (h.type === 'Target') return targets[h.id]?.() ?? null;
+  const itemId = resolveItemId(h, activeItemId);
+  if (itemId == null) return null;
+  const b = cache[itemId];
+  return b ? { type: 'Rect', left: b.x, top: b.y, width: b.width, height: b.height } : null;
+}
+
+/** Stable per-edge cursor key (string fields only), matching Kotlin `AzEdge.stepKey()`. */
+export function edgeStepKey(edge: AzEdge): string {
+  return `${edge.from} ${edge.to ?? ''} ${edge.instruction.text}`;
 }
 
 /**
@@ -66,3 +235,12 @@ export interface AzGoal {
 
 /** A status predicate — a named boolean over app state. */
 export type AzStatusPredicate = () => boolean;
+
+/** A moving-target shape provider (window-space px each frame), registered via `<AzGuidanceTarget>`. */
+export type AzGuideShapeProvider = () => AzGuideShape | null;
+
+/** Host renderer replacing the built-in callout body (the dim/spotlight still draws). */
+export type AzGuidanceRenderer = (snapshot: AzGuidanceSnapshot, bounds: AzShapeBounds | null) => ReactNode;
+
+/** A registered guidance suppressor: `[settleMs, predicate]`. */
+export type AzGuidanceSuppressor = [number, () => boolean];

--- a/aznavrail-react/src/guidance/AzStatusEngine.ts
+++ b/aznavrail-react/src/guidance/AzStatusEngine.ts
@@ -42,6 +42,45 @@ function setsEqual(a: Set<string>, b: Set<string>): boolean {
   return true;
 }
 
+/** True if any registered suppressor predicate is currently true (a throwing predicate counts false). */
+export function anySuppressorActive(suppressors: Array<[number, () => boolean]>): boolean {
+  return suppressors.some(([, predicate]) => {
+    try {
+      return predicate();
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Returns whether the guidance overlay should currently be hidden, given the host's `suppressors` (each
+ * `[settleMs, predicate]`, registered via `<AzSuppressGuide>`). True immediately while any predicate is
+ * true; when all go false, a settle delay (the largest registered `settleMs`) elapses before it flips
+ * back to false. Predicates are re-evaluated each render and on the same ~300 ms poll as
+ * {@link useActiveStatuses}. Mirrors Kotlin `rememberGuidanceSuppressed`.
+ */
+export function useGuidanceSuppressed(suppressors: Array<[number, () => boolean]>): boolean {
+  const rawNow = anySuppressorActive(suppressors);
+  const settleMs = suppressors.reduce((m, [s]) => Math.max(m, s), 0);
+  const [suppressed, setSuppressed] = useState(false);
+  // Poll so predicates backed by non-React sources resolve within the interval.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => setTick((x) => x + 1), STATUS_POLL_MS);
+    return () => clearInterval(t);
+  }, []);
+  useEffect(() => {
+    if (rawNow) {
+      setSuppressed(true);
+      return;
+    }
+    const id = setTimeout(() => setSuppressed(false), settleMs);
+    return () => clearTimeout(id);
+  }, [rawNow, settleMs]);
+  return suppressed;
+}
+
 /**
  * Observes the app's full status set reactively and returns the ids currently **true**, unioned from
  * developer predicates, active classifiers, and the built-in `az.*` ids.

--- a/aznavrail-react/src/guidance/AzStatusEngine.ts
+++ b/aznavrail-react/src/guidance/AzStatusEngine.ts
@@ -63,7 +63,8 @@ export function anySuppressorActive(suppressors: Array<[number, () => boolean]>)
 export function useGuidanceSuppressed(suppressors: Array<[number, () => boolean]>): boolean {
   const rawNow = anySuppressorActive(suppressors);
   const settleMs = suppressors.reduce((m, [s]) => Math.max(m, s), 0);
-  const [suppressed, setSuppressed] = useState(false);
+  // Seed from the live state so the overlay starts hidden when it should (no first-render flash).
+  const [suppressed, setSuppressed] = useState(rawNow);
   // Poll so predicates backed by non-React sources resolve within the interval.
   const [, setTick] = useState(0);
   useEffect(() => {

--- a/aznavrail-react/src/index.tsx
+++ b/aznavrail-react/src/index.tsx
@@ -28,18 +28,44 @@ export type { AzToggleProps, AzCyclerProps } from './types';
 export { AzHelpRailItem, AzHelpSubItem } from './AzNavRailScope';
 
 // --- Status-driven guidance framework (replaces the scripted tutorial) ---
-export { AzStatus, AzEdge, AzGoal } from './guidance/AzGuidanceScope';
-export type { AzStatusProps, AzEdgeProps, AzGoalProps } from './guidance/AzGuidanceScope';
+export { AzStatus, AzEdge, AzGoal, AzGuidanceTarget, AzSuppressGuide, AzGuideRenderer } from './guidance/AzGuidanceScope';
+export type {
+  AzStatusProps,
+  AzEdgeProps,
+  AzGoalProps,
+  AzGuidanceTargetProps,
+  AzSuppressGuideProps,
+  AzGuideRendererProps,
+} from './guidance/AzGuidanceScope';
 export { AzGuidanceProvider, useAzGuidanceController } from './guidance/AzGuidanceController';
 export type { AzGuidanceController } from './guidance/AzGuidanceController';
+export {
+  AZ_ITEM_ACTIVE,
+  shapeBounds,
+  resolveAzHighlight,
+  resolveShape,
+  resolveItemId,
+  resolveTargetId,
+  edgeStepKey,
+} from './guidance/AzStatus';
 export type {
   AzGuideHighlight,
+  AzGuideShape,
+  AzPathCmd,
+  AzShapeBounds,
+  AzItemBounds,
   AzCalloutSide,
   AzInstruction,
+  AzInstructionStep,
+  AzGuidanceSnapshot,
+  AzGuideShapeProvider,
+  AzGuidanceRenderer,
+  AzGuidanceSuppressor,
   AzGoal as AzGoalDef,
   AzEdge as AzEdgeDef,
   AzStatusPredicate,
 } from './guidance/AzStatus';
 export { AzInstructionOverlay } from './components/AzInstructionOverlay';
-export { useActiveStatuses, computeBuiltinStatuses } from './guidance/AzStatusEngine';
-export { nextHop, routeInstructions, computeAutoEdges } from './guidance/AzGuidance';
+export { useActiveStatuses, computeBuiltinStatuses, useGuidanceSuppressed, anySuppressorActive } from './guidance/AzStatusEngine';
+export { nextHop, routeInstructions, computeAutoEdges, resolveEdge, toSnapshot, snapshotsOf } from './guidance/AzGuidance';
+export type { ResolvedInstruction, GuidanceFrame } from './guidance/AzGuidance';

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -762,12 +762,13 @@ val controller = AzHostActivityLayout(
         highlightItemId = "feature-a"
     )
 
-    // 3. Declare goals. autoStartWhen self-activates the onboarding goal once.
+    // 3. Declare goals. autoStartWhen is a STATUS ID (not a lambda): the goal self-activates once that
+    //    status becomes true, and only if it hasn't already been completed (completion is tracked for you).
     azGoal(
         id = "onboarding",
         target = "profileComplete",
         label = "Finish onboarding",
-        autoStartWhen = { !guidance.isCompleted("onboarding") }
+        autoStartWhen = "az.app.ready"
     )
     azGoal(id = "find-features", target = "az.host.features.expanded", label = "Discover Features")
 }
@@ -833,12 +834,12 @@ function AppRail() {
                 highlightItemId="feature-a"
             />
 
-            {/* 3. Goals; autoStartWhen self-activates onboarding */}
+            {/* 3. Goals; autoStartWhen is a STATUS ID (not a function) that self-activates onboarding once */}
             <AzGoal
                 id="onboarding"
                 target="profileComplete"
                 label="Finish onboarding"
-                autoStartWhen={() => !done.includes('onboarding')}
+                autoStartWhen="az.app.ready"
             />
             <AzGoal id="find-features" target="az.host.features.expanded" label="Discover Features" />
         </AzNavRail>
@@ -872,7 +873,131 @@ a light dim — it does **not** punch a true spotlight hole out of the dim layer
 `BlendMode.Clear` punch-out). This is a minor visual difference; routing and advancement behave
 identically.
 
-### 9.6 Migration from the old scripted tutorial framework
+### 9.6 Highlighting arbitrary on-screen targets (`azGuidanceTarget`)
+
+`highlightItemId` points at a **rail item**. To spotlight **arbitrary on-screen content that is not a
+rail item** — a ball drawn over a camera/AR canvas, an aiming line, an on-screen slider — register a
+**guidance target**: an id mapped to a function returning the current shape in **window-space px**
+(circle, rounded-rect, or path), recomputed every frame so the spotlight tracks a moving object. Then
+reference it from an edge (or a step) with `highlightTargetId`. If the function returns `null` (target
+absent), the callout gracefully degrades to text-only.
+
+The library both **draws a default spotlight** for the shape (circle/rect/path punch-out) **and**
+publishes the resolved shape on the controller (see §9.8) so a host can draw its own highlight.
+
+```kotlin
+// Window-space shape, recomputed each frame (read Compose state inside for smooth tracking).
+azGuidanceTarget("target.ball") {
+    val b = ballBounds.value ?: return@azGuidanceTarget null   // null ⇒ text-only
+    AzGuideShape.Circle(b.center.x, b.center.y, b.minDimension / 2f, padding = 8f)
+}
+azEdge(from = "az.app.ready", to = "ball.aimed", text = "Aim at the ball", highlightTargetId = "target.ball")
+```
+
+`AzGuideShape` is `Circle(cx, cy, radius, padding)`, `Rect(left, top, width, height, cornerRadius,
+padding)`, or `Path(commands, padding)` where `commands` are absolute `AzPathCmd` (`MoveTo`/`LineTo`/
+`QuadTo`/`CubicTo`/`Close`). React mirrors this as `{ type: 'Circle' | 'Rect' | 'Path', … }`:
+
+```tsx
+<AzGuidanceTarget id="target.ball" shape={() => ball ? { type: 'Circle', cx: ball.x, cy: ball.y, radius: ball.r, padding: 8 } : null} />
+<AzEdge from="az.app.ready" to="ball.aimed" text="Aim at the ball" highlightTargetId="target.ball" />
+```
+
+You can also point at the **currently-active rail item** without naming a static id by passing the
+`az.item.active` token (`AZ_ITEM_ACTIVE`) as `highlightItemId`, or resolve a runtime item id every frame
+with `highlightSelector = { viewModel.activeLayerId }` (React: `highlightSelector={() => activeLayerId}`)
+— useful for dynamically-created rail items (e.g. `layer.<uuid>`).
+
+### 9.7 Paged steps & manual advance
+
+A single edge can carry an ordered list of **steps** — several sub-pointers under one milestone,
+revealed one at a time, moving the spotlight as the user reads. A step with no `advanceWhen` is
+**informational**: its callout shows a *“Tap to continue”* affordance and advances on tap. A step with
+`advanceWhen = "<statusId>"` is **actionable**: it auto-advances the instant that status becomes true
+(reactive advance always wins over the tap cursor). The whole edge still completes when its `to`
+status becomes true — so a single goal can mix “read this” steps with “now do this” steps.
+
+```kotlin
+azGuidanceTarget("target.ball") { ballShape() }
+azStatus("ball.dragged") { gesture.value.dragged }
+azEdge(
+    from = "az.app.ready",
+    to = "ball.dragged",
+    title = "Meet the coach",
+    steps = listOf(
+        AzInstructionStep("This is a protractor."),                                  // info: tap to advance
+        AzInstructionStep("This handle sets the angle.", highlightTargetId = "target.ball"), // info on a moving target
+        AzInstructionStep("Drag the handle to rotate.", highlightTargetId = "target.ball",
+                          advanceWhen = "ball.dragged"),                              // actionable: reactive
+    ),
+)
+azGoal(id = "learnProtractor", target = "ball.dragged", autoStartWhen = "az.app.ready")
+```
+
+```tsx
+<AzGuidanceTarget id="target.ball" shape={ballShape} />
+<AzStatus id="ball.dragged" predicate={() => gesture.dragged} />
+<AzEdge from="az.app.ready" to="ball.dragged" title="Meet the coach" steps={[
+    { text: 'This is a protractor.' },
+    { text: 'This handle sets the angle.', highlightTargetId: 'target.ball' },
+    { text: 'Drag the handle to rotate.', highlightTargetId: 'target.ball', advanceWhen: 'ball.dragged' },
+]} />
+<AzGoal id="learnProtractor" target="ball.dragged" autoStartWhen="az.app.ready" />
+```
+
+`AzInstructionStep(text, title?, highlightItemId?, highlightTargetId?, side?, highlightSelector?,
+advanceWhen?)` — each step can spotlight its own target. To drive paging yourself (e.g. a host “Next”
+button), the controller exposes `advance(stepKey)` / `next(stepKey)` / `back(stepKey)` (and a no-arg
+`advance()` that advances the first active paged instruction); read the `stepKey` from the snapshot
+(§9.8). Step cursors are transient — only **goal completion** persists.
+
+### 9.8 Observing the current instruction
+
+The controller publishes the callouts it is currently showing, so a host can mirror them with bespoke
+rendering (e.g. a pulsing highlight drawn over its own canvas) and analytics. The framework can show
+several at once (one per active goal), so it is a list with a singular convenience.
+
+```kotlin
+val snap = controller.current                  // AzGuidanceSnapshot? (the primary one)
+val all = controller.currentInstructions       // List<AzGuidanceSnapshot>
+// Or observe reactively (non-Compose): controller.currentFlow: StateFlow<List<AzGuidanceSnapshot>>
+// Inside composition: LocalAzGuidanceController.current?.currentInstructions
+```
+
+`AzGuidanceSnapshot` carries `text`, `title`, `goalId`, `highlight`, `targetId`, `resolvedShape` /
+`resolvedBounds` (window-space, when available), `stepIndex` / `stepTotal`, and `stepKey`. React mirrors
+this on the controller from `useAzGuidanceController()` (`current`, `currentInstructions`).
+
+### 9.9 Suppressing guidance during gestures
+
+Drive suppression from your own gesture state so a callout never pops over an in-progress pinch/drag.
+While the predicate is true the overlay hides; when it flips back to false, guidance re-shows after a
+configurable **settle delay** (default ~700 ms). Several suppressors compose (OR); the largest settle
+wins.
+
+```kotlin
+azSuppressGuide(settleMs = 700) { gesture.inProgress }
+```
+
+```tsx
+<AzSuppressGuide predicate={() => gesture.inProgress} settleMs={700} />
+```
+
+### 9.10 Custom callout rendering (optional)
+
+To draw the callout body yourself (over a camera/canvas), register a renderer; the dim + spotlight
+punch-out still draw, but the callout content is yours. It receives the current snapshot and the
+resolved target bounds.
+
+```kotlin
+azGuideRenderer { snapshot, bounds -> MyCallout(snapshot, bounds) }
+```
+
+```tsx
+<AzGuideRenderer render={(snapshot, bounds) => <MyCallout snapshot={snapshot} bounds={bounds} />} />
+```
+
+### 9.11 Migration from the old scripted tutorial framework
 
 The scripted scene/card framework was removed. Map old constructs to the new ones:
 

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -86,13 +86,18 @@ import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzNavItem
 import com.hereliesaz.aznavrail.model.AzNestedRailAlignment
 import com.hereliesaz.aznavrail.model.AzOrientation
+import com.hereliesaz.aznavrail.tutorial.AzGuideHighlight
 import com.hereliesaz.aznavrail.tutorial.AzInstructionOverlay
 import com.hereliesaz.aznavrail.tutorial.LocalAzGuidanceController
 import com.hereliesaz.aznavrail.tutorial.computeAutoEdges
 import com.hereliesaz.aznavrail.tutorial.computeBuiltinStatuses
 import com.hereliesaz.aznavrail.tutorial.rememberActiveStatuses
 import com.hereliesaz.aznavrail.tutorial.rememberAzGuidanceController
+import com.hereliesaz.aznavrail.tutorial.rememberGuidanceSuppressed
+import com.hereliesaz.aznavrail.tutorial.resolveShape
 import com.hereliesaz.aznavrail.tutorial.routeInstructions
+import com.hereliesaz.aznavrail.tutorial.stepKey
+import com.hereliesaz.aznavrail.tutorial.toSnapshot
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
@@ -917,6 +922,10 @@ fun AzNavRail(
         }
     }
 
+    // Host-driven suppression (e.g. while a gesture is in progress); observed even when the overlay is
+    // hidden so it can re-show after the settle delay. Must be called unconditionally each recomposition.
+    val guidanceSuppressed by rememberGuidanceSuppressed(scope.guidanceSuppressors)
+
     if (guidanceController.enabled &&
         hostScope?.aboutVisible != true && hostScope?.moreFromAzVisible != true
     ) {
@@ -931,7 +940,8 @@ fun AzNavRail(
             )
         }
         // Cache the BFS routing: recompute only when the edges/goals/statuses change (or the reactive
-        // active-goal set, read inside derivedStateOf) — not on every recomposition from drag/animation.
+        // active-goal set / paged-step cursor, read inside derivedStateOf) — not on every recomposition
+        // from drag/animation.
         val frame = remember(guidanceEdges, guidanceGoalsMap, activeStatuses) {
             derivedStateOf {
                 routeInstructions(
@@ -939,6 +949,7 @@ fun AzNavRail(
                     goals = guidanceGoalsMap,
                     activeGoalIds = guidanceController.activeGoals,
                     activeStatuses = activeStatuses,
+                    stepIndexOf = { guidanceController.stepIndex(it) },
                 )
             }
         }.value
@@ -946,11 +957,42 @@ fun AzNavRail(
         LaunchedEffect(frame.reachedGoals, guidanceController) {
             frame.reachedGoals.forEach { guidanceController.markReached(it) }
         }
-        AzInstructionOverlay(
-            instructions = frame.instructions,
-            itemBoundsCache = scope.itemBoundsCache,
-            accent = if (scope.activeColor != Color.Unspecified) scope.activeColor else MaterialTheme.colorScheme.primary,
-        )
+        // Persist reactive step advances into the cursor so a later tap continues from the shown step.
+        LaunchedEffect(frame.resolved, guidanceController) {
+            frame.resolved.forEach { r ->
+                if (r.stepTotal > 1 && guidanceController.stepIndex(r.edge.stepKey()) < r.stepIndex) {
+                    guidanceController.setStep(r.edge.stepKey(), r.stepIndex)
+                }
+            }
+        }
+        // Publish the observable snapshot. Target shapes are NOT resolved here (that would subscribe the
+        // composition to a moving target's per-frame state); the host has its own shape and gets the
+        // `targetId`. Non-target highlights resolve cheaply from the stable bounds cache.
+        val activeItemId = guidanceActiveItemId
+        val snapshots = remember(frame.resolved, activeItemId, scope.itemBoundsCache.toMap()) {
+            frame.resolved.map { r ->
+                val h = r.instruction.highlight
+                val shape = if (h is AzGuideHighlight.Target) null
+                else h.resolveShape(scope.itemBoundsCache, activeItemId, emptyMap())
+                r.toSnapshot(shape, activeItemId)
+            }
+        }
+        LaunchedEffect(snapshots, guidanceController) { guidanceController.publishCurrent(snapshots) }
+
+        if (!guidanceSuppressed) {
+            AzInstructionOverlay(
+                resolved = frame.resolved,
+                itemBoundsCache = scope.itemBoundsCache,
+                accent = if (scope.activeColor != Color.Unspecified) scope.activeColor else MaterialTheme.colorScheme.primary,
+                activeItemId = activeItemId,
+                targets = scope.guidanceTargets,
+                controller = guidanceController,
+                renderSlot = scope.guidanceRenderer,
+            )
+        }
+    } else {
+        // Nothing showing: clear the published snapshot so observers see an empty state.
+        LaunchedEffect(guidanceController) { guidanceController.publishCurrent(emptyList()) }
     }
 }
 

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -1,11 +1,16 @@
 package com.hereliesaz.aznavrail
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Rect
+import com.hereliesaz.aznavrail.tutorial.AzGuidanceSnapshot
+import com.hereliesaz.aznavrail.tutorial.AzGuideShape
+import com.hereliesaz.aznavrail.tutorial.AzInstructionStep
+import com.hereliesaz.aznavrail.tutorial.toHighlight
 import androidx.compose.animation.core.Easing
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -182,16 +187,53 @@ interface AzNavRailScope {
      * Registers a guidance **edge**: while status [from] is true, the shown instruction tells the user
      * how to make status [to] true (an interactive hop). A passive edge ([to] = `null`) just shows the
      * instruction while [from] holds. AzNavHost auto-generates edges for rail affordances; author edges
-     * here for transitions into your own custom statuses. [highlightItemId]/[highlightArea] choose what
-     * the callout is placed next to.
+     * here for transitions into your own custom statuses.
+     *
+     * Choose what the callout is placed next to, in precedence order:
+     *  - [highlightTargetId] — a host-registered arbitrary on-screen shape (see [azGuidanceTarget]);
+     *  - [highlightSelector] — a rail item id resolved every frame (for runtime/dynamic items);
+     *  - [highlightItemId] — a static rail item id, or the [AZ_ITEM_ACTIVE][com.hereliesaz.aznavrail.tutorial.AZ_ITEM_ACTIVE]
+     *    token to spotlight the currently-active item.
+     *
+     * Provide [steps] to make the edge **paged**: several sub-pointers under one milestone, revealed one
+     * at a time (informational steps advance on tap; a step with `advanceWhen` advances reactively). When
+     * [steps] is given, [text]/[highlight*] describe only the fallback first callout; the steps drive it.
      */
     fun azEdge(
         from: String,
         to: String? = null,
-        text: String,
+        text: String? = null,
         title: String? = null,
         highlightItemId: String? = null,
+        highlightTargetId: String? = null,
+        highlightSelector: (() -> String?)? = null,
+        steps: List<AzInstructionStep> = emptyList(),
     )
+
+    /**
+     * Registers a **moving on-screen highlight target** the guidance overlay can spotlight by id (via
+     * `azEdge(highlightTargetId = id)`). [shape] returns the current [AzGuideShape] in **window-space px**
+     * (circle / rounded-rect / path), recomputed every frame, so the spotlight can track an object drawn
+     * over a camera/AR canvas. Return `null` while the target is absent (the callout degrades to
+     * text-only). Read Compose snapshot state inside [shape] for smooth tracking.
+     */
+    fun azGuidanceTarget(id: String, shape: () -> AzGuideShape?)
+
+    /**
+     * Suppresses all guidance while [predicate] is true — drive it from your own gesture state so a
+     * callout never pops over an in-progress pinch/drag. When [predicate] flips back to false, guidance
+     * re-shows after a [settleMs] settle delay. Several suppressors compose (OR); the largest [settleMs]
+     * wins. Like a status predicate, [predicate] may read Compose state (instant) or a plain
+     * `var`/`StateFlow.value` (resolved within a poll).
+     */
+    fun azSuppressGuide(settleMs: Long = 700, predicate: () -> Boolean)
+
+    /**
+     * Replaces the built-in guidance callout body with host-drawn content (the dim + spotlight punch-out
+     * still draw). [renderer] receives the current [AzGuidanceSnapshot] and the resolved target bounds
+     * (window-space px, or `null` when text-only) — for apps drawing bespoke callouts over a canvas.
+     */
+    fun azGuideRenderer(renderer: @Composable (AzGuidanceSnapshot, Rect?) -> Unit)
 
     /**
      * Declares a guidance **goal** — a [target] status the framework routes toward when the developer
@@ -647,6 +689,12 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     val guidanceEdges = mutableListOf<com.hereliesaz.aznavrail.tutorial.AzEdge>()
     /** Developer-declared guidance goals authored via `azGoal`. */
     val guidanceGoals = mutableListOf<com.hereliesaz.aznavrail.tutorial.AzGoal>()
+    /** Moving on-screen highlight targets authored via `azGuidanceTarget`: id → shape lambda (window px). */
+    val guidanceTargets = mutableMapOf<String, () -> AzGuideShape?>()
+    /** Host guidance suppressors authored via `azSuppressGuide`: `settleMs to predicate`. */
+    val guidanceSuppressors = mutableListOf<Pair<Long, () -> Boolean>>()
+    /** Optional host callout renderer authored via `azGuideRenderer`. */
+    var guidanceRenderer: (@Composable (AzGuidanceSnapshot, Rect?) -> Unit)? = null
 
     /**
      * Persisted reloc-item ordering keyed by `hostId`. Survives [reset] so drag-and-drop
@@ -677,6 +725,9 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         statusPredicates.clear()
         guidanceEdges.clear()
         guidanceGoals.clear()
+        guidanceTargets.clear()
+        guidanceSuppressors.clear()
+        guidanceRenderer = null
         itemBoundsCache.clear()
         // Without this, IDs registered on pass N stay in the set on pass N+1 and
         // the next recomposition crashes the moment any ID re-registers.
@@ -827,17 +878,46 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         statusPredicates[id] = predicate
     }
 
-    override fun azEdge(from: String, to: String?, text: String, title: String?, highlightItemId: String?) {
-        val highlight = if (highlightItemId != null) {
-            com.hereliesaz.aznavrail.tutorial.AzGuideHighlight.Item(highlightItemId)
+    override fun azEdge(
+        from: String,
+        to: String?,
+        text: String?,
+        title: String?,
+        highlightItemId: String?,
+        highlightTargetId: String?,
+        highlightSelector: (() -> String?)?,
+        steps: List<AzInstructionStep>,
+    ) {
+        val instruction = if (steps.isNotEmpty()) {
+            // Paged edge: the fallback instruction mirrors the first step so a non-paged renderer still
+            // shows something; the `steps` list drives the paging.
+            val first = steps.first()
+            com.hereliesaz.aznavrail.tutorial.AzInstruction(
+                text = first.text,
+                title = first.title ?: title,
+                highlight = first.toHighlight(),
+                side = first.side,
+            )
         } else {
-            com.hereliesaz.aznavrail.tutorial.AzGuideHighlight.None
+            com.hereliesaz.aznavrail.tutorial.AzInstruction(
+                text = text ?: "",
+                title = title,
+                highlight = com.hereliesaz.aznavrail.tutorial.resolveAzHighlight(highlightItemId, highlightSelector, highlightTargetId),
+            )
         }
-        guidanceEdges += com.hereliesaz.aznavrail.tutorial.AzEdge(
-            from = from,
-            to = to,
-            instruction = com.hereliesaz.aznavrail.tutorial.AzInstruction(text = text, title = title, highlight = highlight),
-        )
+        guidanceEdges += com.hereliesaz.aznavrail.tutorial.AzEdge(from = from, to = to, instruction = instruction, steps = steps)
+    }
+
+    override fun azGuidanceTarget(id: String, shape: () -> AzGuideShape?) {
+        guidanceTargets[id] = shape
+    }
+
+    override fun azSuppressGuide(settleMs: Long, predicate: () -> Boolean) {
+        guidanceSuppressors += settleMs to predicate
+    }
+
+    override fun azGuideRenderer(renderer: @Composable (AzGuidanceSnapshot, Rect?) -> Unit) {
+        guidanceRenderer = renderer
     }
 
     override fun azGoal(id: String, target: String, label: String?, autoStartWhen: String?) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzGuidance.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzGuidance.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -12,6 +13,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalContext
 import com.hereliesaz.aznavrail.model.AzNavItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 private const val PREFS_NAME = "az_tutorial_prefs"
 private const val PREF_KEY = "az_navrail_completed_goals"
@@ -35,6 +39,43 @@ class AzGuidanceController(
     private val _completed = mutableStateListOf<String>().apply { addAll(initialCompleted) }
     /** Goal ids reached at least once (persisted), so onboarding-style goals don't auto-restart. */
     val completedGoals: List<String> get() = _completed
+
+    // --- Paged-edge step cursor (transient; only goal completion persists) ---
+    private val _stepCursor = mutableStateMapOf<String, Int>()
+    /** Current step index for the paged edge identified by [key] (see `AzEdge.stepKey()`). */
+    fun stepIndex(key: String): Int = _stepCursor[key] ?: 0
+    /** Set the step cursor for [key] (used by the overlay to sync reactive auto-advance). */
+    fun setStep(key: String, index: Int) { _stepCursor[key] = index.coerceAtLeast(0) }
+    /** Advance the paged edge [key] to its next step (clamped at render against the step count). */
+    fun advance(key: String) { _stepCursor[key] = stepIndex(key) + 1 }
+    /** Alias for [advance]. */
+    fun next(key: String) = advance(key)
+    /** Step the paged edge [key] back one (never below 0). */
+    fun back(key: String) { _stepCursor[key] = (stepIndex(key) - 1).coerceAtLeast(0) }
+    /** Reset the cursor for [key] (called when its edge is reached so re-entry starts at step 0). */
+    internal fun resetSteps(key: String) { _stepCursor.remove(key) }
+
+    /** Advance the first active paged instruction (host-driven "Next" with no specific edge key). */
+    fun advance() { currentInstructions.firstOrNull { it.stepTotal > 1 && it.stepKey != null }?.stepKey?.let { advance(it) } }
+
+    // --- Observable current instruction(s) (Gap C) ---
+    /**
+     * The guidance callouts being shown right now (one per active goal, plus passive tips), published
+     * each routing pass so a host can mirror them with bespoke rendering and analytics. Empty when
+     * nothing is showing or guidance is disabled.
+     */
+    var currentInstructions by mutableStateOf<List<AzGuidanceSnapshot>>(emptyList())
+        private set
+    /** The primary (first) current instruction, a convenience for single-goal flows. */
+    val current: AzGuidanceSnapshot? get() = currentInstructions.firstOrNull()
+    private val _currentFlow = MutableStateFlow<List<AzGuidanceSnapshot>>(emptyList())
+    /** A [StateFlow] mirror of [currentInstructions] for non-Compose observers. */
+    val currentFlow: StateFlow<List<AzGuidanceSnapshot>> = _currentFlow.asStateFlow()
+    /** Publish the latest routed snapshot list. Called by the rail; not for app use. */
+    internal fun publishCurrent(snapshots: List<AzGuidanceSnapshot>) {
+        currentInstructions = snapshots
+        _currentFlow.value = snapshots
+    }
 
     fun enable() { enabled = true }
     fun disable() { enabled = false }
@@ -160,33 +201,85 @@ internal fun nextHop(edges: List<AzEdge>, activeStatuses: Set<String>, target: S
 }
 
 /**
+ * One instruction the engine has chosen to show, resolved to its current paged step. Carries the owning
+ * [edge] and [goalId] plus the active step's [stepIndex]/[stepTotal] so the overlay can page it and the
+ * controller can publish an [AzGuidanceSnapshot].
+ */
+internal data class ResolvedInstruction(
+    val instruction: AzInstruction,
+    val edge: AzEdge,
+    val goalId: String?,
+    val stepIndex: Int,
+    val stepTotal: Int,
+)
+
+/** Builds the public [AzGuidanceSnapshot] for this resolved instruction (the [shape] resolved by caller). */
+internal fun ResolvedInstruction.toSnapshot(shape: AzGuideShape?, activeItemId: String?): AzGuidanceSnapshot =
+    AzGuidanceSnapshot(
+        text = instruction.text,
+        title = instruction.title,
+        goalId = goalId,
+        highlight = instruction.highlight,
+        targetId = instruction.highlight.resolveTargetId(activeItemId),
+        resolvedShape = shape,
+        resolvedBounds = shape?.bounds(),
+        stepIndex = stepIndex,
+        stepTotal = stepTotal,
+        stepKey = edge.stepKey(),
+    )
+
+/**
  * The set of instructions to show right now: the next-hop instruction for each active goal not yet
  * reached, plus any passive edge whose `from` is currently true. Deduped by (text + highlight).
  * Returns the goal ids that are already at their target (the caller should `markReached` them).
  */
 internal data class GuidanceFrame(
-    val instructions: List<AzInstruction>,
+    val resolved: List<ResolvedInstruction>,
     val reachedGoals: Set<String>,
-)
+) {
+    /** Back-compat view: just the per-step instructions to render. */
+    val instructions: List<AzInstruction> get() = resolved.map { it.instruction }
+}
+
+/**
+ * Resolves an edge to the instruction for its **current step**. A non-paged edge resolves to its single
+ * instruction. A paged edge consults [stepIndexOf] for the manual cursor, then advances past any leading
+ * steps whose `advanceWhen` is already satisfied (reactive advance always wins over the tap cursor).
+ */
+internal fun resolveEdge(
+    edge: AzEdge,
+    goalId: String?,
+    stepIndexOf: (String) -> Int,
+    activeStatuses: Set<String>,
+): ResolvedInstruction {
+    val steps = edge.steps
+    if (steps.isEmpty()) return ResolvedInstruction(edge.instruction, edge, goalId, 0, 1)
+    var idx = stepIndexOf(edge.stepKey()).coerceIn(0, steps.lastIndex)
+    while (idx < steps.lastIndex && steps[idx].advanceWhen?.let { it in activeStatuses } == true) idx++
+    return ResolvedInstruction(steps[idx].toInstruction(edge.instruction.title), edge, goalId, idx, steps.size)
+}
 
 internal fun routeInstructions(
     edges: List<AzEdge>,
     goals: Map<String, AzGoal>,
     activeGoalIds: Collection<String>,
     activeStatuses: Set<String>,
+    stepIndexOf: (String) -> Int = { 0 },
 ): GuidanceFrame {
-    val out = LinkedHashMap<Pair<String, AzGuideHighlight>, AzInstruction>()
+    val out = LinkedHashMap<Pair<String, AzGuideHighlight>, ResolvedInstruction>()
     val reached = HashSet<String>()
     activeGoalIds.forEach { gid ->
         val goal = goals[gid] ?: return@forEach
         if (goal.target in activeStatuses) { reached.add(gid); return@forEach }
         nextHop(edges, activeStatuses, goal.target)?.let { e ->
-            out[e.instruction.text to e.instruction.highlight] = e.instruction
+            val r = resolveEdge(e, gid, stepIndexOf, activeStatuses)
+            out[r.instruction.text to r.instruction.highlight] = r
         }
     }
     // Passive tips: shown while their `from` status holds.
     edges.filter { it.to == null && it.from in activeStatuses }.forEach { e ->
-        out[e.instruction.text to e.instruction.highlight] = e.instruction
+        val r = resolveEdge(e, null, stepIndexOf, activeStatuses)
+        out[r.instruction.text to r.instruction.highlight] = r
     }
     return GuidanceFrame(out.values.toList(), reached)
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzInstructionOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzInstructionOverlay.kt
@@ -1,9 +1,13 @@
 package com.hereliesaz.aznavrail.tutorial
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -21,6 +25,8 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
@@ -30,79 +36,127 @@ import androidx.compose.ui.unit.dp
 private const val DIM_ALPHA = 0.7f
 
 /**
- * Renders the current guidance [instructions] as callouts, **each placed next to its own highlight
- * target** (so the user sees, in place, how to accomplish each active goal), over a single dim layer
- * with a spotlight punch-out per `Item`/`Area` target. There is no Next button — the app's own state
- * change advances guidance, so this composable is purely presentational.
+ * Renders the current guidance [resolved] instructions as callouts, **each placed next to its own
+ * highlight target** (so the user sees, in place, how to accomplish each active goal), over a single
+ * dim layer with a spotlight punch-out per target. Targets may be rail items (`itemBoundsCache`), the
+ * active item ([activeItemId]), or host-registered arbitrary shapes ([targets], re-resolved live in the
+ * draw scope so a moving on-screen object tracks every frame).
+ *
+ * A **paged** edge (more than one step) reveals one step at a time; an informational step (no
+ * `advanceWhen`, not the last step) is tap-advanceable — tapping its callout calls
+ * [AzGuidanceController.advance]. Reactive/actionable steps still advance only when their status flips,
+ * so the overlay never blocks the app during a real interaction. When [renderSlot] is non-null the host
+ * draws the callout body itself (the dim/punch-out still draws).
  */
 @Composable
 internal fun AzInstructionOverlay(
-    instructions: List<AzInstruction>,
+    resolved: List<ResolvedInstruction>,
     itemBoundsCache: Map<String, Rect>,
     accent: Color,
+    activeItemId: String? = null,
+    targets: Map<String, () -> AzGuideShape?> = emptyMap(),
+    controller: AzGuidanceController? = null,
+    renderSlot: (@Composable (AzGuidanceSnapshot, Rect?) -> Unit)? = null,
 ) {
-    if (instructions.isEmpty()) return
+    if (resolved.isEmpty()) return
     val density = LocalDensity.current
     val screenWidthPx = with(density) { LocalConfiguration.current.screenWidthDp.dp.toPx() }
     val screenHeightPx = with(density) { LocalConfiguration.current.screenHeightDp.dp.toPx() }
-
-    // Resolve each instruction to its target rect (null = no spotlight; floats centred).
-    val placed = instructions.map { it to it.highlight.resolveBounds(itemBoundsCache) }
+    val calloutWidthPx = with(density) { 240.dp.toPx() }
+    val gapPx = with(density) { 8.dp.toPx() }
+    val belowReservePx = with(density) { 96.dp.toPx() }
+    val cornerPx = with(density) { 16.dp.toPx() }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // One dim layer, punched out at every targeted rect.
+        // One dim layer, punched out at every resolved target. Targets are re-resolved INSIDE the draw
+        // scope, so a moving `azGuidanceTarget` shape repaints without a recomposition.
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
                 .drawBehind {
                     drawRect(Color.Black.copy(alpha = DIM_ALPHA))
-                    placed.forEach { (_, r) ->
-                        if (r != null) {
-                            drawRoundRect(
-                                color = Color.Transparent,
-                                topLeft = Offset(r.left, r.top),
-                                size = Size(r.width, r.height),
-                                cornerRadius = CornerRadius(16.dp.toPx()),
-                                blendMode = BlendMode.Clear,
-                            )
-                        }
+                    resolved.forEach { r ->
+                        r.instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)
+                            ?.let { punchShape(it, cornerPx) }
                     }
-                }
+                },
         )
 
-        placed.forEach { (instruction, r) ->
-            if (r == null) {
-                // No anchor: float bottom-centre.
-                Box(Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.BottomCenter) {
-                    Callout(instruction, accent)
+        resolved.forEach { r ->
+            val instruction = r.instruction
+            val shape = instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)
+            val tappable = r.stepTotal > 1 && r.stepIndex < r.stepTotal - 1 &&
+                r.edge.steps.getOrNull(r.stepIndex)?.advanceWhen == null
+            val stepKey = r.edge.stepKey()
+            val onTap: (() -> Unit)? =
+                if (tappable && controller != null) ({ controller.advance(stepKey) }) else null
+
+            // Position adjacent to the (live) target, or float bottom-centre when there is no anchor.
+            val boundsProvider: () -> Rect? = {
+                instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)?.bounds()
+            }
+            PlacedCallout(
+                anchored = shape != null,
+                boundsProvider = boundsProvider,
+                screenWidthPx = screenWidthPx,
+                screenHeightPx = screenHeightPx,
+                calloutWidthPx = calloutWidthPx,
+                gapPx = gapPx,
+                belowReservePx = belowReservePx,
+            ) {
+                if (renderSlot != null) {
+                    renderSlot(r.toSnapshot(shape, activeItemId), shape?.bounds())
+                } else {
+                    Callout(instruction, accent, r.stepIndex, r.stepTotal, onTap)
                 }
-            } else {
-                // Place adjacent: below the target if there's room, otherwise above; clamp horizontally.
-                // Offset in the draw phase via graphicsLayer so re-positioning during rail
-                // animation/drag never triggers a parent layout pass or recomposition.
-                val belowHasRoom = r.bottom + with(density) { 96.dp.toPx() } < screenHeightPx
-                val xPx = r.left.coerceIn(0f, (screenWidthPx - with(density) { 240.dp.toPx() }).coerceAtLeast(0f))
-                val yPx = if (belowHasRoom) r.bottom + with(density) { 8.dp.toPx() }
-                else (r.top - with(density) { 96.dp.toPx() }).coerceAtLeast(0f)
-                Box(
-                    modifier = Modifier.graphicsLayer {
-                        translationX = xPx
-                        translationY = yPx
-                    },
-                ) { Callout(instruction, accent) }
             }
         }
     }
 }
 
+/** Places [content] adjacent to the live target bounds (re-read in the draw phase) or floats it. */
 @Composable
-private fun Callout(instruction: AzInstruction, accent: Color) {
+private fun PlacedCallout(
+    anchored: Boolean,
+    boundsProvider: () -> Rect?,
+    screenWidthPx: Float,
+    screenHeightPx: Float,
+    calloutWidthPx: Float,
+    gapPx: Float,
+    belowReservePx: Float,
+    content: @Composable () -> Unit,
+) {
+    if (!anchored) {
+        Box(Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.BottomCenter) { content() }
+    } else {
+        // Offset in the draw phase via graphicsLayer so re-positioning during rail animation / a moving
+        // target never triggers a parent layout pass or recomposition.
+        Box(
+            modifier = Modifier.graphicsLayer {
+                val b = boundsProvider() ?: return@graphicsLayer
+                translationX = b.left.coerceIn(0f, (screenWidthPx - calloutWidthPx).coerceAtLeast(0f))
+                translationY = if (b.bottom + belowReservePx < screenHeightPx) b.bottom + gapPx
+                else (b.top - belowReservePx).coerceAtLeast(0f)
+            },
+        ) { content() }
+    }
+}
+
+@Composable
+private fun Callout(
+    instruction: AzInstruction,
+    accent: Color,
+    stepIndex: Int,
+    stepTotal: Int,
+    onTap: (() -> Unit)?,
+) {
     Column(
         modifier = Modifier
             .widthIn(max = 240.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surface)
+            .then(if (onTap != null) Modifier.clickable { onTap() } else Modifier)
             .padding(12.dp),
     ) {
         instruction.title?.let {
@@ -110,11 +164,59 @@ private fun Callout(instruction: AzInstruction, accent: Color) {
         }
         Text(instruction.text, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface)
         instruction.media?.let { Box(Modifier.padding(top = 8.dp)) { it() } }
+        if (stepTotal > 1) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    "${stepIndex + 1} / $stepTotal",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (onTap != null) {
+                    Text("Tap to continue ▸", style = MaterialTheme.typography.labelSmall, color = accent)
+                }
+            }
+        }
     }
 }
 
-private fun AzGuideHighlight.resolveBounds(cache: Map<String, Rect>): Rect? = when (this) {
-    is AzGuideHighlight.Item -> cache[id]
-    is AzGuideHighlight.Area -> Rect(left, top, left + width, top + height)
-    else -> null
+/** Punches a transparent hole the shape's geometry out of the dim layer (window-space px). */
+private fun DrawScope.punchShape(shape: AzGuideShape, defaultCornerPx: Float) {
+    when (shape) {
+        is AzGuideShape.Circle -> drawCircle(
+            color = Color.Transparent,
+            radius = shape.radius + shape.padding,
+            center = Offset(shape.cx, shape.cy),
+            blendMode = BlendMode.Clear,
+        )
+        is AzGuideShape.Rect -> drawRoundRect(
+            color = Color.Transparent,
+            topLeft = Offset(shape.left - shape.padding, shape.top - shape.padding),
+            size = Size(shape.width + 2f * shape.padding, shape.height + 2f * shape.padding),
+            cornerRadius = CornerRadius(if (shape.cornerRadius > 0f) shape.cornerRadius else defaultCornerPx),
+            blendMode = BlendMode.Clear,
+        )
+        is AzGuideShape.Path -> drawPath(
+            path = shape.toComposePath(),
+            color = Color.Transparent,
+            blendMode = BlendMode.Clear,
+        )
+    }
+}
+
+/** Converts an [AzGuideShape.Path]'s window-space commands into a Compose [Path]. */
+private fun AzGuideShape.Path.toComposePath(): Path {
+    val path = Path()
+    commands.forEach { cmd ->
+        when (cmd) {
+            is AzPathCmd.MoveTo -> path.moveTo(cmd.x, cmd.y)
+            is AzPathCmd.LineTo -> path.lineTo(cmd.x, cmd.y)
+            is AzPathCmd.QuadTo -> path.quadraticBezierTo(cmd.x1, cmd.y1, cmd.x, cmd.y)
+            is AzPathCmd.CubicTo -> path.cubicTo(cmd.x1, cmd.y1, cmd.x2, cmd.y2, cmd.x, cmd.y)
+            AzPathCmd.Close -> path.close()
+        }
+    }
+    return path
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzInstructionOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzInstructionOverlay.kt
@@ -134,7 +134,11 @@ private fun PlacedCallout(
         // target never triggers a parent layout pass or recomposition.
         Box(
             modifier = Modifier.graphicsLayer {
-                val b = boundsProvider() ?: return@graphicsLayer
+                // A moving/dynamic target can be momentarily unmeasured; hide (alpha 0) rather than let
+                // the callout flash at (0,0) with the default translation for that frame.
+                val b = boundsProvider()
+                if (b == null) { alpha = 0f; return@graphicsLayer }
+                alpha = 1f
                 translationX = b.left.coerceIn(0f, (screenWidthPx - calloutWidthPx).coerceAtLeast(0f))
                 translationY = if (b.bottom + belowReservePx < screenHeightPx) b.bottom + gapPx
                 else (b.top - belowReservePx).coerceAtLeast(0f)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzStatus.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzStatus.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.aznavrail.tutorial
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Rect
 
 /**
  * Reactive, status-driven guidance model — the replacement for the scripted scene/card tutorial.
@@ -17,6 +18,13 @@ import androidx.compose.runtime.Composable
  *  - a built-in `az.*` id published by AzNavHost from the rail/host/route/onscreen/sheet state.
  */
 
+/**
+ * The dynamic highlight token: when passed anywhere a `highlightItemId` is accepted, the callout
+ * spotlights whatever rail item is currently `*.active` (resolved fresh every frame), rather than a
+ * statically-named id. Degrades to text-only when no item is active. See [AzGuideHighlight.ActiveItem].
+ */
+const val AZ_ITEM_ACTIVE = "az.item.active"
+
 /** What a guidance instruction spotlights. Reused by the highlight renderer. */
 sealed interface AzGuideHighlight {
     /** No spotlight; the instruction card floats over a plain dim. */
@@ -27,6 +35,171 @@ sealed interface AzGuideHighlight {
     data class Item(val id: String) : AzGuideHighlight
     /** Spotlight an explicit window-space rectangle. */
     data class Area(val left: Float, val top: Float, val width: Float, val height: Float) : AzGuideHighlight
+    /**
+     * Spotlight whatever rail item is currently active, resolved at render time against the live
+     * active-item id (the same item that publishes `az.item.<id>.active`). Text-only when none is
+     * active. Authored by passing the [AZ_ITEM_ACTIVE] token as a `highlightItemId`.
+     */
+    data object ActiveItem : AzGuideHighlight
+    /**
+     * Spotlight the item whose id [selector] returns, resolved at render time against the live
+     * item-bounds map every frame — so an edge declared before its target exists (a runtime
+     * `layer.<uuid>` rail item, the just-created item) can still point at it. Returning `null` (or an
+     * id with no measured bounds) degrades to text-only. The [AZ_ITEM_ACTIVE] token is honored here too.
+     */
+    data class Dynamic(val selector: () -> String?) : AzGuideHighlight
+    /**
+     * Spotlight a host-registered, arbitrary on-screen target (not a rail item): a moving circle, rect,
+     * or path drawn over a camera/AR canvas. Resolved at render time against the live target registry
+     * (see `azGuidanceTarget(id) { … }`); the lambda returns the current [AzGuideShape] in window-space
+     * px. Returning `null` (or an unregistered id) degrades to text-only. Authored by passing
+     * `highlightTargetId`.
+     */
+    data class Target(val id: String) : AzGuideHighlight
+}
+
+/**
+ * A spotlight geometry in **window-space px** (the same space as `itemBoundsCache`, so it aligns with
+ * the overlay punch-out at zero offset). Returned by an `azGuidanceTarget` shape lambda and resolved
+ * fresh each frame, so a target can track a moving on-screen object. [padding] inflates the spotlight
+ * uniformly beyond the geometry.
+ */
+sealed interface AzGuideShape {
+    val padding: Float
+    /** A circle centered at ([cx], [cy]) with [radius]. */
+    data class Circle(val cx: Float, val cy: Float, val radius: Float, override val padding: Float = 0f) : AzGuideShape
+    /** An axis-aligned rounded rectangle. */
+    data class Rect(
+        val left: Float, val top: Float, val width: Float, val height: Float,
+        val cornerRadius: Float = 16f, override val padding: Float = 0f,
+    ) : AzGuideShape
+    /** An arbitrary outline described by absolute, window-space [commands] (filled even-odd). */
+    data class Path(val commands: List<AzPathCmd>, override val padding: Float = 0f) : AzGuideShape
+}
+
+/** One command of an [AzGuideShape.Path], in absolute window-space px (SVG-style). */
+sealed interface AzPathCmd {
+    data class MoveTo(val x: Float, val y: Float) : AzPathCmd
+    data class LineTo(val x: Float, val y: Float) : AzPathCmd
+    data class QuadTo(val x1: Float, val y1: Float, val x: Float, val y: Float) : AzPathCmd
+    data class CubicTo(val x1: Float, val y1: Float, val x2: Float, val y2: Float, val x: Float, val y: Float) : AzPathCmd
+    data object Close : AzPathCmd
+}
+
+/**
+ * The axis-aligned window-space bounding box of any [AzGuideShape] (inflated by [AzGuideShape.padding]).
+ * Used for callout placement and for a host's own hit-testing; the true geometry is only used by the
+ * punch-out draw. A path with no points yields [Rect.Zero].
+ */
+fun AzGuideShape.bounds(): Rect = when (this) {
+    is AzGuideShape.Circle -> Rect(cx - radius - padding, cy - radius - padding, cx + radius + padding, cy + radius + padding)
+    is AzGuideShape.Rect -> Rect(left - padding, top - padding, left + width + padding, top + height + padding)
+    is AzGuideShape.Path -> {
+        var minX = Float.POSITIVE_INFINITY; var minY = Float.POSITIVE_INFINITY
+        var maxX = Float.NEGATIVE_INFINITY; var maxY = Float.NEGATIVE_INFINITY
+        fun acc(x: Float, y: Float) { minX = minOf(minX, x); minY = minOf(minY, y); maxX = maxOf(maxX, x); maxY = maxOf(maxY, y) }
+        commands.forEach { cmd ->
+            when (cmd) {
+                is AzPathCmd.MoveTo -> acc(cmd.x, cmd.y)
+                is AzPathCmd.LineTo -> acc(cmd.x, cmd.y)
+                is AzPathCmd.QuadTo -> { acc(cmd.x1, cmd.y1); acc(cmd.x, cmd.y) }
+                is AzPathCmd.CubicTo -> { acc(cmd.x1, cmd.y1); acc(cmd.x2, cmd.y2); acc(cmd.x, cmd.y) }
+                AzPathCmd.Close -> {}
+            }
+        }
+        if (minX > maxX) Rect.Zero else Rect(minX - padding, minY - padding, maxX + padding, maxY + padding)
+    }
+}
+
+/**
+ * One paged sub-step of a multi-step edge (see [azEdge] with `steps`). A single milestone (one status
+ * hop) can carry several of these, revealed one at a time, moving the spotlight as the user reads:
+ * "your design is ready — tap a layer (point at the layer), then open Modes (point at the Modes host)".
+ *
+ * @param text The line shown for this sub-step.
+ * @param title Optional per-step title (overrides the edge title while this step shows).
+ * @param highlightItemId Item to spotlight; the [AZ_ITEM_ACTIVE] token resolves to the active item.
+ * @param highlightTargetId A host-registered [AzGuideShape] target to spotlight (see `azGuidanceTarget`);
+ *   takes precedence over [highlightItemId]/[highlightSelector] when non-null.
+ * @param side Preferred callout placement relative to the spotlight target.
+ * @param highlightSelector Resolved every frame to the id to spotlight; overrides [highlightItemId]
+ *   when non-null, so a step can point at a runtime/dynamically-created item. `null` ⇒ text-only.
+ * @param advanceWhen Optional status id; when it becomes true the overlay auto-advances past this step
+ *   (reactive advance), regardless of the manual tap cursor. `null` ⇒ this is an informational step the
+ *   user advances by tapping.
+ */
+data class AzInstructionStep(
+    val text: String,
+    val title: String? = null,
+    val highlightItemId: String? = null,
+    val highlightTargetId: String? = null,
+    val side: AzCalloutSide = AzCalloutSide.Auto,
+    val highlightSelector: (() -> String?)? = null,
+    val advanceWhen: String? = null,
+)
+
+/** Resolves a step's highlight directive into the renderer's [AzGuideHighlight]. */
+internal fun AzInstructionStep.toHighlight(): AzGuideHighlight =
+    resolveAzHighlight(highlightItemId, highlightSelector, highlightTargetId)
+
+/** This step as a standalone [AzInstruction] (used when the overlay pages a stepped edge). */
+internal fun AzInstructionStep.toInstruction(edgeTitle: String?): AzInstruction =
+    AzInstruction(text = text, title = title ?: edgeTitle, highlight = toHighlight(), side = side)
+
+/**
+ * Resolves a highlight directive into an [AzGuideHighlight] by precedence: a registered [highlightTargetId]
+ * ([AzGuideHighlight.Target]) wins, then a [highlightSelector] ([AzGuideHighlight.Dynamic]), then the
+ * [AZ_ITEM_ACTIVE] token ([AzGuideHighlight.ActiveItem]), then a literal item id ([AzGuideHighlight.Item]),
+ * else [AzGuideHighlight.None].
+ */
+internal fun resolveAzHighlight(
+    highlightItemId: String?,
+    highlightSelector: (() -> String?)?,
+    highlightTargetId: String? = null,
+): AzGuideHighlight = when {
+    highlightTargetId != null -> AzGuideHighlight.Target(highlightTargetId)
+    highlightSelector != null -> AzGuideHighlight.Dynamic(highlightSelector)
+    highlightItemId == AZ_ITEM_ACTIVE -> AzGuideHighlight.ActiveItem
+    highlightItemId != null -> AzGuideHighlight.Item(highlightItemId)
+    else -> AzGuideHighlight.None
+}
+
+/**
+ * Resolves a highlight to the **item id** it currently points at (null ⇒ no item / not item-based),
+ * folding [AzGuideHighlight.ActiveItem] and [AzGuideHighlight.Dynamic] against the live [activeItemId].
+ * Pure, so the resolution is unit-testable without a renderer. [AzGuideHighlight.Area] returns null
+ * here (it carries an explicit rect, resolved separately by the overlay).
+ */
+internal fun AzGuideHighlight.resolveItemId(activeItemId: String?): String? = when (this) {
+    is AzGuideHighlight.Item -> id
+    is AzGuideHighlight.ActiveItem -> activeItemId
+    is AzGuideHighlight.Dynamic -> selector()?.let { if (it == AZ_ITEM_ACTIVE) activeItemId else it }
+    else -> null
+}
+
+/**
+ * Resolves a highlight to the concrete [AzGuideShape] to spotlight, in window-space px: a registered
+ * [AzGuideHighlight.Target] via [targets] (the moving-target lambda), an explicit [AzGuideHighlight.Area]
+ * rect, or a rail item's cached bounds (Item/ActiveItem/Dynamic). `null` ⇒ text-only (no spotlight).
+ * Called both at composition (anchor/float decision) and live in the overlay's draw scope (so a moving
+ * target tracks every frame).
+ */
+internal fun AzGuideHighlight.resolveShape(
+    cache: Map<String, Rect>,
+    activeItemId: String?,
+    targets: Map<String, () -> AzGuideShape?>,
+): AzGuideShape? = when (this) {
+    is AzGuideHighlight.Area -> AzGuideShape.Rect(left, top, width, height)
+    is AzGuideHighlight.Target -> targets[id]?.invoke()
+    else -> resolveItemId(activeItemId)?.let { itemId ->
+        cache[itemId]?.let { AzGuideShape.Rect(it.left, it.top, it.width, it.height) }
+    }
+}
+
+/** The resolved target/item id this highlight points at (for the snapshot/analytics), if any. */
+internal fun AzGuideHighlight.resolveTargetId(activeItemId: String?): String? = when (this) {
+    is AzGuideHighlight.Target -> id
+    else -> resolveItemId(activeItemId)
 }
 
 /**
@@ -54,12 +227,25 @@ enum class AzCalloutSide { Auto, Above, Below, Start, End }
  * One edge of the flowchart: while status [from] is true, performing the [instruction] is expected to
  * make status [to] true (an interactive hop). A passive edge ([to] == `null`) just shows info while
  * [from] holds. Authored via `azEdge(...)`, or auto-generated by AzNavHost for rail affordances.
+ *
+ * When [steps] is non-empty the edge is **paged**: the overlay reveals one [AzInstructionStep] at a
+ * time (advancing on tap, or reactively when a step's `advanceWhen` becomes true), moving the spotlight
+ * per step — several sub-pointers under one milestone. The last step behaves like a single-instruction
+ * edge: the edge is reached when [to] becomes true. Empty [steps] ⇒ the classic single-callout edge.
  */
 data class AzEdge(
     val from: String,
     val to: String?,
     val instruction: AzInstruction,
+    val steps: List<AzInstructionStep> = emptyList(),
 )
+
+/**
+ * Stable key identifying this edge for the per-edge step cursor (so two goals routing through the same
+ * edge share a cursor, consistent with routing's dedup-by-(text,highlight)). Uses string fields only,
+ * so it is independent of any lambda identity.
+ */
+internal fun AzEdge.stepKey(): String = "$from ${to ?: ""} ${instruction.text}"
 
 /**
  * A developer-declared guidance target. The engine routes from the current status toward [target]; the
@@ -75,5 +261,36 @@ data class AzGoal(
     val target: String,
     val label: String? = null,
     val autoStartWhen: String? = null,
+)
+
+/**
+ * A read-only snapshot of one guidance callout currently being shown, published live on
+ * [AzGuidanceController.currentInstructions] so a host can mirror it with bespoke rendering (e.g. a
+ * pulsing highlight drawn over its own canvas) and analytics. The framework may show several at once
+ * (one per active goal), so the controller exposes a list.
+ *
+ * @param text The line currently shown (the active step's text for a paged edge).
+ * @param title The title currently shown, if any.
+ * @param goalId The owning goal, or `null` for a passive ambient tip.
+ * @param highlight The spotlight directive.
+ * @param targetId The resolved registered-target / rail-item id this points at, if any.
+ * @param resolvedShape The target geometry resolved at publish time (best-effort; the overlay
+ *   re-resolves live each frame for moving targets), or `null` when text-only.
+ * @param resolvedBounds The axis-aligned bounds of [resolvedShape], a convenience for host hit-testing.
+ * @param stepIndex Zero-based index of the active step within a paged edge (0 for a single-callout edge).
+ * @param stepTotal Total steps in the edge (1 for a single-callout edge).
+ * @param stepKey The owning edge's cursor key (pass to `AzGuidanceController.advance`/`back`).
+ */
+data class AzGuidanceSnapshot(
+    val text: String,
+    val title: String? = null,
+    val goalId: String? = null,
+    val highlight: AzGuideHighlight = AzGuideHighlight.None,
+    val targetId: String? = null,
+    val resolvedShape: AzGuideShape? = null,
+    val resolvedBounds: Rect? = null,
+    val stepIndex: Int = 0,
+    val stepTotal: Int = 1,
+    val stepKey: String? = null,
 )
 

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzStatusEngine.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzStatusEngine.kt
@@ -34,7 +34,9 @@ internal fun anySuppressorActive(suppressors: List<Pair<Long, () -> Boolean>>): 
  */
 @Composable
 internal fun rememberGuidanceSuppressed(suppressors: List<Pair<Long, () -> Boolean>>): State<Boolean> {
-    val suppressed = remember { mutableStateOf(false) }
+    // Seed from the live state (the combiner is pure) so the overlay starts hidden when it should —
+    // no one-frame flash of guidance over a gesture that is already in progress at first composition.
+    val suppressed = remember { mutableStateOf(anySuppressorActive(suppressors)) }
     val current = rememberUpdatedState(suppressors)
     // Re-launch only when crossing the empty/non-empty boundary; fresh predicates are read via `current`.
     LaunchedEffect(suppressors.isEmpty()) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzStatusEngine.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzStatusEngine.kt
@@ -6,9 +6,11 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
@@ -17,6 +19,46 @@ import kotlinx.coroutines.launch
 
 /** Poll interval for status predicates backed by non-Compose sources (StateFlow.value / a var). */
 private const val STATUS_POLL_MS = 300L
+
+/** True if any registered suppressor predicate is currently true (a throwing predicate counts false). */
+internal fun anySuppressorActive(suppressors: List<Pair<Long, () -> Boolean>>): Boolean =
+    suppressors.any { (_, predicate) -> runCatching { predicate() }.getOrDefault(false) }
+
+/**
+ * Observes the host's guidance [suppressors] (each a `settleMs to predicate` pair, registered via
+ * `azSuppressGuide`) and returns whether the guidance overlay should currently be **hidden**. While any
+ * predicate is true the result is `true` immediately; when all go false a settle delay (the largest
+ * registered `settleMs`) elapses before it flips back to `false`, so a callout never pops over the tail
+ * of an in-progress gesture. Predicates are observed with the same `snapshotFlow` + low-rate poll as
+ * [rememberActiveStatuses], so both Compose-state and plain-`var`/`StateFlow.value` sources resolve.
+ */
+@Composable
+internal fun rememberGuidanceSuppressed(suppressors: List<Pair<Long, () -> Boolean>>): State<Boolean> {
+    val suppressed = remember { mutableStateOf(false) }
+    val current = rememberUpdatedState(suppressors)
+    // Re-launch only when crossing the empty/non-empty boundary; fresh predicates are read via `current`.
+    LaunchedEffect(suppressors.isEmpty()) {
+        if (current.value.isEmpty()) { suppressed.value = false; return@LaunchedEffect }
+        val rawOf = { anySuppressorActive(current.value) }
+        val settleOf = { current.value.maxOfOrNull { it.first }?.coerceAtLeast(0L) ?: 0L }
+        var settleJob: Job? = null
+        merge(
+            snapshotFlow { rawOf() },
+            flow { while (true) { emit(rawOf()); delay(STATUS_POLL_MS) } },
+        ).distinctUntilChanged().collect { on ->
+            if (on) {
+                settleJob?.cancel(); settleJob = null
+                suppressed.value = true
+            } else {
+                // Falling edge: keep hidden for the settle window before re-showing (cancelable so a
+                // new suppression that arrives mid-settle re-hides immediately).
+                settleJob?.cancel()
+                settleJob = launch { delay(settleOf()); suppressed.value = false }
+            }
+        }
+    }
+    return suppressed
+}
 
 /**
  * Observes the app's full status set reactively and returns the ids currently **true**. Statuses come

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -762,12 +762,13 @@ val controller = AzHostActivityLayout(
         highlightItemId = "feature-a"
     )
 
-    // 3. Declare goals. autoStartWhen self-activates the onboarding goal once.
+    // 3. Declare goals. autoStartWhen is a STATUS ID (not a lambda): the goal self-activates once that
+    //    status becomes true, and only if it hasn't already been completed (completion is tracked for you).
     azGoal(
         id = "onboarding",
         target = "profileComplete",
         label = "Finish onboarding",
-        autoStartWhen = { !guidance.isCompleted("onboarding") }
+        autoStartWhen = "az.app.ready"
     )
     azGoal(id = "find-features", target = "az.host.features.expanded", label = "Discover Features")
 }
@@ -833,12 +834,12 @@ function AppRail() {
                 highlightItemId="feature-a"
             />
 
-            {/* 3. Goals; autoStartWhen self-activates onboarding */}
+            {/* 3. Goals; autoStartWhen is a STATUS ID (not a function) that self-activates onboarding once */}
             <AzGoal
                 id="onboarding"
                 target="profileComplete"
                 label="Finish onboarding"
-                autoStartWhen={() => !done.includes('onboarding')}
+                autoStartWhen="az.app.ready"
             />
             <AzGoal id="find-features" target="az.host.features.expanded" label="Discover Features" />
         </AzNavRail>
@@ -872,7 +873,131 @@ a light dim — it does **not** punch a true spotlight hole out of the dim layer
 `BlendMode.Clear` punch-out). This is a minor visual difference; routing and advancement behave
 identically.
 
-### 9.6 Migration from the old scripted tutorial framework
+### 9.6 Highlighting arbitrary on-screen targets (`azGuidanceTarget`)
+
+`highlightItemId` points at a **rail item**. To spotlight **arbitrary on-screen content that is not a
+rail item** — a ball drawn over a camera/AR canvas, an aiming line, an on-screen slider — register a
+**guidance target**: an id mapped to a function returning the current shape in **window-space px**
+(circle, rounded-rect, or path), recomputed every frame so the spotlight tracks a moving object. Then
+reference it from an edge (or a step) with `highlightTargetId`. If the function returns `null` (target
+absent), the callout gracefully degrades to text-only.
+
+The library both **draws a default spotlight** for the shape (circle/rect/path punch-out) **and**
+publishes the resolved shape on the controller (see §9.8) so a host can draw its own highlight.
+
+```kotlin
+// Window-space shape, recomputed each frame (read Compose state inside for smooth tracking).
+azGuidanceTarget("target.ball") {
+    val b = ballBounds.value ?: return@azGuidanceTarget null   // null ⇒ text-only
+    AzGuideShape.Circle(b.center.x, b.center.y, b.minDimension / 2f, padding = 8f)
+}
+azEdge(from = "az.app.ready", to = "ball.aimed", text = "Aim at the ball", highlightTargetId = "target.ball")
+```
+
+`AzGuideShape` is `Circle(cx, cy, radius, padding)`, `Rect(left, top, width, height, cornerRadius,
+padding)`, or `Path(commands, padding)` where `commands` are absolute `AzPathCmd` (`MoveTo`/`LineTo`/
+`QuadTo`/`CubicTo`/`Close`). React mirrors this as `{ type: 'Circle' | 'Rect' | 'Path', … }`:
+
+```tsx
+<AzGuidanceTarget id="target.ball" shape={() => ball ? { type: 'Circle', cx: ball.x, cy: ball.y, radius: ball.r, padding: 8 } : null} />
+<AzEdge from="az.app.ready" to="ball.aimed" text="Aim at the ball" highlightTargetId="target.ball" />
+```
+
+You can also point at the **currently-active rail item** without naming a static id by passing the
+`az.item.active` token (`AZ_ITEM_ACTIVE`) as `highlightItemId`, or resolve a runtime item id every frame
+with `highlightSelector = { viewModel.activeLayerId }` (React: `highlightSelector={() => activeLayerId}`)
+— useful for dynamically-created rail items (e.g. `layer.<uuid>`).
+
+### 9.7 Paged steps & manual advance
+
+A single edge can carry an ordered list of **steps** — several sub-pointers under one milestone,
+revealed one at a time, moving the spotlight as the user reads. A step with no `advanceWhen` is
+**informational**: its callout shows a *“Tap to continue”* affordance and advances on tap. A step with
+`advanceWhen = "<statusId>"` is **actionable**: it auto-advances the instant that status becomes true
+(reactive advance always wins over the tap cursor). The whole edge still completes when its `to`
+status becomes true — so a single goal can mix “read this” steps with “now do this” steps.
+
+```kotlin
+azGuidanceTarget("target.ball") { ballShape() }
+azStatus("ball.dragged") { gesture.value.dragged }
+azEdge(
+    from = "az.app.ready",
+    to = "ball.dragged",
+    title = "Meet the coach",
+    steps = listOf(
+        AzInstructionStep("This is a protractor."),                                  // info: tap to advance
+        AzInstructionStep("This handle sets the angle.", highlightTargetId = "target.ball"), // info on a moving target
+        AzInstructionStep("Drag the handle to rotate.", highlightTargetId = "target.ball",
+                          advanceWhen = "ball.dragged"),                              // actionable: reactive
+    ),
+)
+azGoal(id = "learnProtractor", target = "ball.dragged", autoStartWhen = "az.app.ready")
+```
+
+```tsx
+<AzGuidanceTarget id="target.ball" shape={ballShape} />
+<AzStatus id="ball.dragged" predicate={() => gesture.dragged} />
+<AzEdge from="az.app.ready" to="ball.dragged" title="Meet the coach" steps={[
+    { text: 'This is a protractor.' },
+    { text: 'This handle sets the angle.', highlightTargetId: 'target.ball' },
+    { text: 'Drag the handle to rotate.', highlightTargetId: 'target.ball', advanceWhen: 'ball.dragged' },
+]} />
+<AzGoal id="learnProtractor" target="ball.dragged" autoStartWhen="az.app.ready" />
+```
+
+`AzInstructionStep(text, title?, highlightItemId?, highlightTargetId?, side?, highlightSelector?,
+advanceWhen?)` — each step can spotlight its own target. To drive paging yourself (e.g. a host “Next”
+button), the controller exposes `advance(stepKey)` / `next(stepKey)` / `back(stepKey)` (and a no-arg
+`advance()` that advances the first active paged instruction); read the `stepKey` from the snapshot
+(§9.8). Step cursors are transient — only **goal completion** persists.
+
+### 9.8 Observing the current instruction
+
+The controller publishes the callouts it is currently showing, so a host can mirror them with bespoke
+rendering (e.g. a pulsing highlight drawn over its own canvas) and analytics. The framework can show
+several at once (one per active goal), so it is a list with a singular convenience.
+
+```kotlin
+val snap = controller.current                  // AzGuidanceSnapshot? (the primary one)
+val all = controller.currentInstructions       // List<AzGuidanceSnapshot>
+// Or observe reactively (non-Compose): controller.currentFlow: StateFlow<List<AzGuidanceSnapshot>>
+// Inside composition: LocalAzGuidanceController.current?.currentInstructions
+```
+
+`AzGuidanceSnapshot` carries `text`, `title`, `goalId`, `highlight`, `targetId`, `resolvedShape` /
+`resolvedBounds` (window-space, when available), `stepIndex` / `stepTotal`, and `stepKey`. React mirrors
+this on the controller from `useAzGuidanceController()` (`current`, `currentInstructions`).
+
+### 9.9 Suppressing guidance during gestures
+
+Drive suppression from your own gesture state so a callout never pops over an in-progress pinch/drag.
+While the predicate is true the overlay hides; when it flips back to false, guidance re-shows after a
+configurable **settle delay** (default ~700 ms). Several suppressors compose (OR); the largest settle
+wins.
+
+```kotlin
+azSuppressGuide(settleMs = 700) { gesture.inProgress }
+```
+
+```tsx
+<AzSuppressGuide predicate={() => gesture.inProgress} settleMs={700} />
+```
+
+### 9.10 Custom callout rendering (optional)
+
+To draw the callout body yourself (over a camera/canvas), register a renderer; the dim + spotlight
+punch-out still draw, but the callout content is yours. It receives the current snapshot and the
+resolved target bounds.
+
+```kotlin
+azGuideRenderer { snapshot, bounds -> MyCallout(snapshot, bounds) }
+```
+
+```tsx
+<AzGuideRenderer render={(snapshot, bounds) => <MyCallout snapshot={snapshot} bounds={bounds} />} />
+```
+
+### 9.11 Migration from the old scripted tutorial framework
 
 The scripted scene/card framework was removed. Map old constructs to the new ones:
 

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/tutorial/AzGuidanceExpansionTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/tutorial/AzGuidanceExpansionTest.kt
@@ -1,0 +1,125 @@
+package com.hereliesaz.aznavrail.tutorial
+
+import androidx.compose.ui.geometry.Rect
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the guidance-framework expansion: paged steps + reactive/manual advance, arbitrary-shape
+ * highlight resolution, the highlight-directive precedence, and the suppression predicate combiner.
+ */
+class AzGuidanceExpansionTest {
+
+    // a --(3 paged steps)--> done
+    private val stepped = AzEdge(
+        from = "a",
+        to = "done",
+        instruction = AzInstruction("step0"),
+        steps = listOf(
+            AzInstructionStep("step0"),
+            AzInstructionStep("step1", highlightTargetId = "ball", advanceWhen = "x"),
+            AzInstructionStep("step2"),
+        ),
+    )
+    private val goals = mapOf("g" to AzGoal(id = "g", target = "done"))
+
+    @Test
+    fun `paged edge shows the step at the cursor`() {
+        val f0 = routeInstructions(listOf(stepped), goals, listOf("g"), setOf("a"), stepIndexOf = { 0 })
+        assertEquals("step0", f0.instructions.single().text)
+        assertEquals(0, f0.resolved.single().stepIndex)
+        assertEquals(3, f0.resolved.single().stepTotal)
+
+        val f1 = routeInstructions(listOf(stepped), goals, listOf("g"), setOf("a"), stepIndexOf = { 1 })
+        assertEquals("step1", f1.instructions.single().text)
+        assertEquals(AzGuideHighlight.Target("ball"), f1.resolved.single().instruction.highlight)
+    }
+
+    @Test
+    fun `reactive advanceWhen wins over the tap cursor`() {
+        // Cursor parked on step1, whose advanceWhen ("x") is satisfied -> the overlay shows step2.
+        val f = routeInstructions(listOf(stepped), goals, listOf("g"), setOf("a", "x"), stepIndexOf = { 1 })
+        assertEquals("step2", f.instructions.single().text)
+        assertEquals(2, f.resolved.single().stepIndex)
+    }
+
+    @Test
+    fun `an informational step is not skipped when a later step's status is already true`() {
+        // step0 has no advanceWhen, so it stays even though "x" (step1's trigger) is true.
+        val f = routeInstructions(listOf(stepped), goals, listOf("g"), setOf("a", "x"), stepIndexOf = { 0 })
+        assertEquals("step0", f.instructions.single().text)
+    }
+
+    @Test
+    fun `a paged goal is reached when its target status becomes true`() {
+        val f = routeInstructions(listOf(stepped), goals, listOf("g"), setOf("a", "done"), stepIndexOf = { 1 })
+        assertTrue("g" in f.reachedGoals)
+        assertTrue(f.instructions.isEmpty())
+    }
+
+    @Test
+    fun `single-callout edges still route unchanged (stepTotal 1)`() {
+        val edge = AzEdge("a", "b", AzInstruction("Do A", highlight = AzGuideHighlight.Item("ia")))
+        val g = mapOf("g" to AzGoal("g", "b"))
+        val f = routeInstructions(listOf(edge), g, listOf("g"), setOf("a"))
+        assertEquals("Do A", f.instructions.single().text)
+        assertEquals(1, f.resolved.single().stepTotal)
+    }
+
+    @Test
+    fun `resolveAzHighlight precedence is target, selector, active token, item, none`() {
+        assertEquals(AzGuideHighlight.Target("t"), resolveAzHighlight("item", { "sel" }, "t"))
+        assertTrue(resolveAzHighlight("item", { "sel" }, null) is AzGuideHighlight.Dynamic)
+        assertEquals(AzGuideHighlight.ActiveItem, resolveAzHighlight(AZ_ITEM_ACTIVE, null, null))
+        assertEquals(AzGuideHighlight.Item("item"), resolveAzHighlight("item", null, null))
+        assertEquals(AzGuideHighlight.None, resolveAzHighlight(null, null, null))
+    }
+
+    @Test
+    fun `resolveItemId folds ActiveItem and Dynamic against the live active id`() {
+        assertEquals("home", AzGuideHighlight.ActiveItem.resolveItemId("home"))
+        assertEquals("layer.1", AzGuideHighlight.Dynamic { "layer.1" }.resolveItemId(null))
+        assertEquals("home", AzGuideHighlight.Dynamic { AZ_ITEM_ACTIVE }.resolveItemId("home"))
+        assertNull(AzGuideHighlight.Target("t").resolveItemId("home"))
+    }
+
+    @Test
+    fun `resolveShape resolves targets, areas and items, degrading to null`() {
+        val circle = AzGuideShape.Circle(1f, 2f, 3f)
+        val targets = mapOf<String, () -> AzGuideShape?>("t" to { circle }, "gone" to { null })
+        assertEquals(circle, AzGuideHighlight.Target("t").resolveShape(emptyMap(), null, targets))
+        assertNull(AzGuideHighlight.Target("gone").resolveShape(emptyMap(), null, targets))
+        assertNull(AzGuideHighlight.Target("missing").resolveShape(emptyMap(), null, targets))
+        assertTrue(AzGuideHighlight.Area(5f, 6f, 7f, 8f).resolveShape(emptyMap(), null, emptyMap()) is AzGuideShape.Rect)
+
+        val cache = mapOf("home" to Rect(0f, 0f, 10f, 10f))
+        assertTrue(AzGuideHighlight.Item("home").resolveShape(cache, null, emptyMap()) is AzGuideShape.Rect)
+        assertNull(AzGuideHighlight.Item("nope").resolveShape(cache, null, emptyMap()))
+        assertTrue(AzGuideHighlight.ActiveItem.resolveShape(cache, "home", emptyMap()) is AzGuideShape.Rect)
+        assertNull(AzGuideHighlight.ActiveItem.resolveShape(cache, null, emptyMap()))
+    }
+
+    @Test
+    fun `AzGuideShape bounds wraps each geometry with padding`() {
+        val c = AzGuideShape.Circle(100f, 50f, 10f, padding = 5f).bounds()
+        assertEquals(Rect(85f, 35f, 115f, 65f), c)
+        val r = AzGuideShape.Rect(10f, 20f, 30f, 40f).bounds()
+        assertEquals(Rect(10f, 20f, 40f, 60f), r)
+        val p = AzGuideShape.Path(
+            listOf(AzPathCmd.MoveTo(0f, 0f), AzPathCmd.QuadTo(5f, 30f, 10f, 20f), AzPathCmd.Close),
+        ).bounds()
+        assertEquals(Rect(0f, 0f, 10f, 30f), p)
+    }
+
+    @Test
+    fun `anySuppressorActive ORs predicates and treats a throw as false`() {
+        assertFalse(anySuppressorActive(emptyList()))
+        assertTrue(anySuppressorActive(listOf(700L to { true })))
+        assertFalse(anySuppressorActive(listOf(700L to { false })))
+        assertTrue(anySuppressorActive(listOf(0L to { false }, 0L to { true })))
+        assertFalse(anySuppressorActive(listOf(0L to { throw RuntimeException("boom") })))
+    }
+}

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -762,12 +762,13 @@ val controller = AzHostActivityLayout(
         highlightItemId = "feature-a"
     )
 
-    // 3. Declare goals. autoStartWhen self-activates the onboarding goal once.
+    // 3. Declare goals. autoStartWhen is a STATUS ID (not a lambda): the goal self-activates once that
+    //    status becomes true, and only if it hasn't already been completed (completion is tracked for you).
     azGoal(
         id = "onboarding",
         target = "profileComplete",
         label = "Finish onboarding",
-        autoStartWhen = { !guidance.isCompleted("onboarding") }
+        autoStartWhen = "az.app.ready"
     )
     azGoal(id = "find-features", target = "az.host.features.expanded", label = "Discover Features")
 }
@@ -833,12 +834,12 @@ function AppRail() {
                 highlightItemId="feature-a"
             />
 
-            {/* 3. Goals; autoStartWhen self-activates onboarding */}
+            {/* 3. Goals; autoStartWhen is a STATUS ID (not a function) that self-activates onboarding once */}
             <AzGoal
                 id="onboarding"
                 target="profileComplete"
                 label="Finish onboarding"
-                autoStartWhen={() => !done.includes('onboarding')}
+                autoStartWhen="az.app.ready"
             />
             <AzGoal id="find-features" target="az.host.features.expanded" label="Discover Features" />
         </AzNavRail>
@@ -872,7 +873,131 @@ a light dim — it does **not** punch a true spotlight hole out of the dim layer
 `BlendMode.Clear` punch-out). This is a minor visual difference; routing and advancement behave
 identically.
 
-### 9.6 Migration from the old scripted tutorial framework
+### 9.6 Highlighting arbitrary on-screen targets (`azGuidanceTarget`)
+
+`highlightItemId` points at a **rail item**. To spotlight **arbitrary on-screen content that is not a
+rail item** — a ball drawn over a camera/AR canvas, an aiming line, an on-screen slider — register a
+**guidance target**: an id mapped to a function returning the current shape in **window-space px**
+(circle, rounded-rect, or path), recomputed every frame so the spotlight tracks a moving object. Then
+reference it from an edge (or a step) with `highlightTargetId`. If the function returns `null` (target
+absent), the callout gracefully degrades to text-only.
+
+The library both **draws a default spotlight** for the shape (circle/rect/path punch-out) **and**
+publishes the resolved shape on the controller (see §9.8) so a host can draw its own highlight.
+
+```kotlin
+// Window-space shape, recomputed each frame (read Compose state inside for smooth tracking).
+azGuidanceTarget("target.ball") {
+    val b = ballBounds.value ?: return@azGuidanceTarget null   // null ⇒ text-only
+    AzGuideShape.Circle(b.center.x, b.center.y, b.minDimension / 2f, padding = 8f)
+}
+azEdge(from = "az.app.ready", to = "ball.aimed", text = "Aim at the ball", highlightTargetId = "target.ball")
+```
+
+`AzGuideShape` is `Circle(cx, cy, radius, padding)`, `Rect(left, top, width, height, cornerRadius,
+padding)`, or `Path(commands, padding)` where `commands` are absolute `AzPathCmd` (`MoveTo`/`LineTo`/
+`QuadTo`/`CubicTo`/`Close`). React mirrors this as `{ type: 'Circle' | 'Rect' | 'Path', … }`:
+
+```tsx
+<AzGuidanceTarget id="target.ball" shape={() => ball ? { type: 'Circle', cx: ball.x, cy: ball.y, radius: ball.r, padding: 8 } : null} />
+<AzEdge from="az.app.ready" to="ball.aimed" text="Aim at the ball" highlightTargetId="target.ball" />
+```
+
+You can also point at the **currently-active rail item** without naming a static id by passing the
+`az.item.active` token (`AZ_ITEM_ACTIVE`) as `highlightItemId`, or resolve a runtime item id every frame
+with `highlightSelector = { viewModel.activeLayerId }` (React: `highlightSelector={() => activeLayerId}`)
+— useful for dynamically-created rail items (e.g. `layer.<uuid>`).
+
+### 9.7 Paged steps & manual advance
+
+A single edge can carry an ordered list of **steps** — several sub-pointers under one milestone,
+revealed one at a time, moving the spotlight as the user reads. A step with no `advanceWhen` is
+**informational**: its callout shows a *“Tap to continue”* affordance and advances on tap. A step with
+`advanceWhen = "<statusId>"` is **actionable**: it auto-advances the instant that status becomes true
+(reactive advance always wins over the tap cursor). The whole edge still completes when its `to`
+status becomes true — so a single goal can mix “read this” steps with “now do this” steps.
+
+```kotlin
+azGuidanceTarget("target.ball") { ballShape() }
+azStatus("ball.dragged") { gesture.value.dragged }
+azEdge(
+    from = "az.app.ready",
+    to = "ball.dragged",
+    title = "Meet the coach",
+    steps = listOf(
+        AzInstructionStep("This is a protractor."),                                  // info: tap to advance
+        AzInstructionStep("This handle sets the angle.", highlightTargetId = "target.ball"), // info on a moving target
+        AzInstructionStep("Drag the handle to rotate.", highlightTargetId = "target.ball",
+                          advanceWhen = "ball.dragged"),                              // actionable: reactive
+    ),
+)
+azGoal(id = "learnProtractor", target = "ball.dragged", autoStartWhen = "az.app.ready")
+```
+
+```tsx
+<AzGuidanceTarget id="target.ball" shape={ballShape} />
+<AzStatus id="ball.dragged" predicate={() => gesture.dragged} />
+<AzEdge from="az.app.ready" to="ball.dragged" title="Meet the coach" steps={[
+    { text: 'This is a protractor.' },
+    { text: 'This handle sets the angle.', highlightTargetId: 'target.ball' },
+    { text: 'Drag the handle to rotate.', highlightTargetId: 'target.ball', advanceWhen: 'ball.dragged' },
+]} />
+<AzGoal id="learnProtractor" target="ball.dragged" autoStartWhen="az.app.ready" />
+```
+
+`AzInstructionStep(text, title?, highlightItemId?, highlightTargetId?, side?, highlightSelector?,
+advanceWhen?)` — each step can spotlight its own target. To drive paging yourself (e.g. a host “Next”
+button), the controller exposes `advance(stepKey)` / `next(stepKey)` / `back(stepKey)` (and a no-arg
+`advance()` that advances the first active paged instruction); read the `stepKey` from the snapshot
+(§9.8). Step cursors are transient — only **goal completion** persists.
+
+### 9.8 Observing the current instruction
+
+The controller publishes the callouts it is currently showing, so a host can mirror them with bespoke
+rendering (e.g. a pulsing highlight drawn over its own canvas) and analytics. The framework can show
+several at once (one per active goal), so it is a list with a singular convenience.
+
+```kotlin
+val snap = controller.current                  // AzGuidanceSnapshot? (the primary one)
+val all = controller.currentInstructions       // List<AzGuidanceSnapshot>
+// Or observe reactively (non-Compose): controller.currentFlow: StateFlow<List<AzGuidanceSnapshot>>
+// Inside composition: LocalAzGuidanceController.current?.currentInstructions
+```
+
+`AzGuidanceSnapshot` carries `text`, `title`, `goalId`, `highlight`, `targetId`, `resolvedShape` /
+`resolvedBounds` (window-space, when available), `stepIndex` / `stepTotal`, and `stepKey`. React mirrors
+this on the controller from `useAzGuidanceController()` (`current`, `currentInstructions`).
+
+### 9.9 Suppressing guidance during gestures
+
+Drive suppression from your own gesture state so a callout never pops over an in-progress pinch/drag.
+While the predicate is true the overlay hides; when it flips back to false, guidance re-shows after a
+configurable **settle delay** (default ~700 ms). Several suppressors compose (OR); the largest settle
+wins.
+
+```kotlin
+azSuppressGuide(settleMs = 700) { gesture.inProgress }
+```
+
+```tsx
+<AzSuppressGuide predicate={() => gesture.inProgress} settleMs={700} />
+```
+
+### 9.10 Custom callout rendering (optional)
+
+To draw the callout body yourself (over a camera/canvas), register a renderer; the dim + spotlight
+punch-out still draw, but the callout content is yours. It receives the current snapshot and the
+resolved target bounds.
+
+```kotlin
+azGuideRenderer { snapshot, bounds -> MyCallout(snapshot, bounds) }
+```
+
+```tsx
+<AzGuideRenderer render={(snapshot, bounds) => <MyCallout snapshot={snapshot} bounds={bounds} />} />
+```
+
+### 9.11 Migration from the old scripted tutorial framework
 
 The scripted scene/card framework was removed. Map old constructs to the new ones:
 

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -361,9 +361,28 @@ The three DSL functions are declared inside the `AzHostActivityLayout { ... }` c
 
 ~~~kotlin
 fun azStatus(id: String, predicate: () -> Boolean)
-fun azEdge(from: String, to: String? = null, text: String, title: String? = null, highlightItemId: String? = null)
+fun azEdge(
+    from: String, to: String? = null, text: String? = null, title: String? = null,
+    highlightItemId: String? = null,      // a rail item, or the AZ_ITEM_ACTIVE token
+    highlightTargetId: String? = null,    // a registered arbitrary shape (azGuidanceTarget)
+    highlightSelector: (() -> String?)? = null,   // a rail item id resolved each frame
+    steps: List<AzInstructionStep> = emptyList(), // paged sub-pointers (tap / advanceWhen)
+)
 fun azGoal(id: String, target: String, label: String? = null, autoStartWhen: String? = null)
+
+// Arbitrary on-screen highlight target (window-space px shape, recomputed each frame; null ⇒ text-only).
+fun azGuidanceTarget(id: String, shape: () -> AzGuideShape?)
+// Hide guidance while `predicate` is true; re-show after `settleMs` once it clears.
+fun azSuppressGuide(settleMs: Long = 700, predicate: () -> Boolean)
+// Draw the callout body yourself (the dim/spotlight still draw).
+fun azGuideRenderer(renderer: @Composable (AzGuidanceSnapshot, Rect?) -> Unit)
 ~~~
+
+`AzGuideShape` is `Circle` / `Rect` / `Path` in window-space px (see §9.6 of the Complete Guide); a step
+is `AzInstructionStep(text, title?, highlightItemId?, highlightTargetId?, side?, highlightSelector?,
+advanceWhen?)`. An informational step (no `advanceWhen`) advances on tap; an actionable one advances
+when its status flips. The React port mirrors these as `<AzGuidanceTarget>`, `<AzSuppressGuide>`,
+`<AzGuideRenderer>`, and `steps` / `highlightTargetId` props on `<AzEdge>`.
 
 ~~~kotlin
 import com.hereliesaz.aznavrail.tutorial.*
@@ -438,8 +457,10 @@ function Launcher() {
 
 `AzGuidanceController` (both platforms): `enabled`, `activeGoals`, `completedGoals`, `enable()`,
 `disable()`, `activate(goalId)`, `deactivate(goalId)`, `markReached(goalId)`, `isCompleted(goalId)`.
-Completed goals persist under key `az_navrail_completed_goals` (Android `SharedPreferences` file
-`az_tutorial_prefs`; React `localStorage` / RN `AsyncStorage`).
+For paged edges it also exposes `advance(stepKey)` / `next(stepKey)` / `back(stepKey)` and a no-arg
+`advance()`, and for observation `currentInstructions` / `current` (an `AzGuidanceSnapshot` list; Kotlin
+also has `currentFlow`). Completed goals persist under key `az_navrail_completed_goals` (Android
+`SharedPreferences` file `az_tutorial_prefs`; React `localStorage` / RN `AsyncStorage`).
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-aznavrail = "9.10"
+aznavrail = "9.11"
 # Android & Jetpack
 composeBom = "2026.05.00"
 coreKtx = "1.18.0"


### PR DESCRIPTION
## Why

The 10.x status-driven guidance framework could only anchor highlights to **rail items**, only auto-advance when a **status flips**, and never exposed **what it was currently showing**. Two real consumers were blocked:

- **CueDetat** (Compose pool-aiming/AR app) needs to highlight arbitrary, moving on-screen content drawn over a camera/AR canvas (ball = circle, aiming line = path, slider = rect), advance informational steps by tap (no app-state change to flip), and read the current instruction to draw its own pulsing highlight.
- **GraffitiXR** needs paged sub-pointers within one milestone, dynamic highlight of runtime rail items, and gesture-time suppression.

This PR adds those capabilities (Android Kotlin first, mirrored in the React/Web TS port) and updates the docs.

## What changed

**Gap A — arbitrary moving highlight targets**
- `AzGuideShape` (`Circle` / `Rect` / `Path`, window-space px) + `azGuidanceTarget(id) { shape }` registry, resolved **live in the overlay draw scope** so the spotlight tracks a moving object without recomposition.
- New `AzGuideHighlight.Target`; reference from an edge/step via `highlightTargetId`. `null`/unregistered ⇒ graceful text-only fallback.
- The overlay punches the real geometry **and** publishes the resolved shape, so a host can also draw its own highlight.

**Gap B — paged steps + manual advance**
- `AzInstructionStep` list on an edge. Informational steps (no `advanceWhen`) show a *Tap to continue* affordance; steps with `advanceWhen` auto-advance when that status flips (**reactive wins** over the tap cursor). One goal mixes "read this" and "now do this" steps.
- Controller gains `advance/next/back/setStep`; step cursors are transient (only goal completion persists).

**Dynamic rail highlights** now actually render: the `az.item.active` token and `highlightSelector` resolve the active/runtime rail item each frame.

**Gap C — observability**
- `AzGuidanceController.currentInstructions` / `current` / `currentFlow` (`AzGuidanceSnapshot`: text/title/goalId/highlight/targetId/resolvedShape/resolvedBounds/stepIndex/stepTotal/stepKey), published each routing pass (off the composition path).

**Suppression & custom rendering**
- `azSuppressGuide(settleMs = 700) { predicate }` — hides guidance while true; re-shows after a settle delay (suppressors OR; largest settle wins).
- Optional `azGuideRenderer { snapshot, bounds -> }` slot for host-drawn callouts.

**React/Web parity**
- `<AzGuidanceTarget>`, `<AzSuppressGuide>`, `<AzGuideRenderer>`, and `steps` / `highlightTargetId` / `highlightSelector` on `<AzEdge>`; controller + overlay mirror Android. Parity note: a `Path` target is ringed by its bounding box (RN can't path-mask) — the exact shape is still published for host rendering.

**Docs, versions, example**
- `AZNAVRAIL_COMPLETE_GUIDE.md` §9 expanded (subsections 9.6–9.11) with examples for each capability; the two embedded copies are kept byte-identical. `DSL.md` updated.
- Fixed the `autoStartWhen` example: it is a **status id**, not a lambda (`autoStartWhen = "az.app.ready"`).
- Versions bumped: `aznavrail` 9.10 → 9.11; `aznavrail-react` 0.3.0 → 0.5.0 (+ CHANGELOG).
- SampleApp tutorial gains a worked example: a draggable circle target + a mixed manual/reactive paged goal + a live `current` readout + a suppression toggle.

## Worked example

```kotlin
azGuidanceTarget("ball") { ballBounds.value?.let { AzGuideShape.Circle(it.center.x, it.center.y, it.minDimension / 2f, padding = 8f) } }
azStatus("ball.dragged") { gesture.value.dragged }
azEdge(from = "az.app.ready", to = "ball.dragged", title = "Meet the coach", steps = listOf(
    AzInstructionStep("This is a protractor."),
    AzInstructionStep("This handle sets the angle.", highlightTargetId = "ball"),
    AzInstructionStep("Drag the handle to rotate.", highlightTargetId = "ball", advanceWhen = "ball.dragged"),
))
azGoal(id = "learnProtractor", target = "ball.dragged", autoStartWhen = "az.app.ready")
```

## Backward compatibility

Existing single-`highlightItemId` / single-`text` edges keep working (all new params are optional; `text` is now nullable). The in-repo call sites (`SampleApp`, `sample-pwa`) compile unchanged.

## Verification

- `:aznavrail:compileDebugKotlin` and `:SampleApp:compileDebugKotlin` — green.
- New `AzGuidanceExpansionTest` (Kotlin) + existing routing/engine tests — pass.
- React `tsc --noEmit` — clean; `AzGuidanceExpansion.test.ts` + existing routing tests — 19/19 pass.
- Embedded guide copies verified byte-identical to `docs/`.
- The 11 failing tests in the full Android suite (About-parsing, compose-UI, bottom-sheet-window) were confirmed **pre-existing** via a clean-tree run — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EeG55c7AAcPtbr8fJWFvG

---
_Generated by [Claude Code](https://claude.ai/code/session_012EeG55c7AAcPtbr8fJWFvG)_