### PR TITLE
Guidance: non-blocking coach — no dim, smart placement, swipe-to-skip…

### DIFF
--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/TutorialDemoScreen.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/TutorialDemoScreen.kt
@@ -186,10 +186,17 @@ fun TutorialDemoScreen(
         )
         AzButton(onClick = onToggleSuppress, text = if (suppressed) "Suppression: ON (tap to clear)" else "Suppression: off (tap to suppress)")
 
-        Text("Stop guiding", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text("Stop / skip / replay", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text(
+            "Swipe any callout away to cancel tutorial mode (the skip is remembered). A skipped or " +
+                "completed goal won't re-activate until you reset.",
+            style = MaterialTheme.typography.bodySmall,
+        )
         AzButton(
             onClick = { guidance.activeGoals.toList().forEach { guidance.deactivate(it) } },
             text = "Deactivate all goals",
         )
+        AzButton(onClick = { guidance.skip() }, text = "Skip (cancel tutorial mode)")
+        AzButton(onClick = { guidance.resetGuidance() }, text = "Reset guidance (replay)")
     }
 }

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.6.0
+
+Guidance is now a **non-blocking coach** instead of a modal tutorial.
+
+### Changed
+- **No dimming, no blocking.** The overlay no longer draws a full-screen dim. It outlines each step's
+  target and places a small callout *near* (never on) it with a connector line; nothing outside a
+  callout consumes input, so the app stays fully interactive while guidance is up.
+- **Smart placement.** Callouts are positioned near their own target and kept off the target, other
+  known UI (rail items / registered targets), each other, and the screen edges — they no longer stack at
+  the bottom or clip. New exports: `placeCallout`, `overlapArea`.
+- **Developer-driven start.** `autoStartWhen` still works but is discouraged; it now also honours the
+  user's skip. Prefer `controller.activate(...)`.
+
+### Added
+- **Swipe-to-cancel.** Swiping a callout away cancels tutorial mode. New controller surface:
+  `skip(goalId?)`, `dismissedGoals`, `isDismissed(id)`, `resetGuidance(goalId?)`. Skips persist to
+  `localStorage` / `AsyncStorage` under `az_navrail_dismissed_goals`; a skipped or completed goal is not
+  shown again until `resetGuidance(...)`.
+- **No repeats.** A step that has been shown and acted on is consumed for the session and never re-shown,
+  even if the user undoes the action and the router would otherwise re-route to it.
+
+### Notes
+- Parity: React rings the target's bounding box and draws a plain connector (Android strokes the true
+  shape + an arrowhead) — see `KNOWN_GAPS.md`.
+
 ## 0.5.0
 
 ### Added

--- a/aznavrail-react/KNOWN_GAPS.md
+++ b/aznavrail-react/KNOWN_GAPS.md
@@ -44,23 +44,19 @@ has a meaningful web analog. The closest web primitive is `env(safe-area-inset-b
 applied by `AzBottomSheetInsetAware`, which is `0` on devices without a home indicator. No
 `drawBehindNavBar` flag is exposed on the React `AzSheetConfig`.
 
-## Guidance overlay: accent ring vs. punch-out spotlight
+## Guidance overlay: outline + connector (non-blocking)
 
 The status-driven guidance framework reaches behavioural parity across platforms — the same
 `AzStatus` / `AzEdge` / `AzGoal` DSL, the same built-in `az.*` statuses and auto-edges, the same
-auto-advancing routing, and the same `az_navrail_completed_goals` persistence key. One **minor visual**
-difference remains: the Android instruction overlay punches a true spotlight hole out of the dim layer
-(`BlendMode.Clear`), while the **React/web** `AzInstructionOverlay` draws an **accent ring** around
-each target over a light dim instead of a real punch-out. Routing, callouts, and advancement are
-identical; only the highlight rendering differs. There is no plan to emulate a pixel-perfect punch-out
-on web.
-
-The same applies to **arbitrary shape targets** (`AzGuidanceTarget` / `highlightTargetId`): Android
-punches the actual `Circle` / `Rect` / `Path` geometry out of the dim, while React rings the target's
-**bounding box** (a `Path` target is therefore approximated by its AABB, not its true outline). The
-resolved shape is still published on the controller (`currentInstructions[i].resolvedShape`), so a host
-that wants a pixel-accurate highlight can draw it itself via `<AzGuideRenderer>` or by observing the
-snapshot.
+auto-advancing routing, near-target collision-avoiding callout placement, swipe-to-cancel, the no-repeat
+rule, and the same persistence keys (`az_navrail_completed_goals`, `az_navrail_dismissed_goals`).
+**Neither platform dims the screen or blocks input.** One **minor visual** difference remains in how the
+target is outlined: **Android** strokes the target's true geometry (`Circle` / `Rect` / `Path`) and
+draws an **arrowhead** on the connector; **React/web** rings the target's **bounding box** and draws a
+plain **connector line** (so a `Path` target is approximated by its AABB, and there is no arrowhead —
+per-shape masking and arrowheads aren't portable on React Native). The resolved shape is still published
+on the controller (`currentInstructions[i].resolvedShape`), so a host that wants a pixel-accurate
+highlight can draw it itself via `<AzGuideRenderer>` or by observing the snapshot.
 
 ## `AzActivity` / `AzGraphInterface`
 

--- a/aznavrail-react/package.json
+++ b/aznavrail-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@HereLiesAz/aznavrail-react",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A contemptably stubborn navigation rail for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -963,30 +963,34 @@ const AzGuidanceLayer: React.FC<{
   const activeStatuses = useActiveStatuses(guidance.statusPredicates, activeClassifiers, builtins);
   const edges = useMemo(() => [...guidance.edges, ...computeAutoEdges(items)], [guidance.edges, items]);
   const frame = useMemo(
-    () => routeInstructions(edges, guidance.goals, guidance.activeGoals, activeStatuses, (k) => guidance.stepIndex(k)),
-    [edges, guidance.goals, guidance.activeGoals, activeStatuses, guidance.stepIndex],
+    () => routeInstructions(edges, guidance.goals, guidance.activeGoals, activeStatuses, (k) => guidance.stepIndex(k), guidance.consumedStatuses),
+    [edges, guidance.goals, guidance.activeGoals, activeStatuses, guidance.stepIndex, guidance.consumedStatuses],
   );
-  // Self-arming onboarding goals: activate once their trigger status holds (unless already completed).
+  // Self-arming onboarding goals: `autoStartWhen` is discouraged; it honours both completion and the
+  // user's skip, so a finished or dismissed tutorial never auto-restarts.
   useEffect(() => {
     Object.values(guidance.goals).forEach((goal) => {
       if (goal.autoStartWhen && activeStatuses.has(goal.autoStartWhen) &&
-          !guidance.isCompleted(goal.id) && !guidance.activeGoals.includes(goal.id)) {
+          !guidance.isCompleted(goal.id) && !guidance.isDismissed(goal.id) && !guidance.activeGoals.includes(goal.id)) {
         guidance.activate(goal.id);
       }
     });
   }, [activeStatuses, guidance]);
-  // Auto-advance: a goal whose target is now true is reached → deactivate it and persist. Persist
-  // reactive step advances into the cursor so a later tap continues from the shown step.
+  // Auto-advance + reactive step-cursor sync; and de-dup: once a shown hop's `to` is reached, consume it
+  // so that hop is never re-shown (even if the user later undoes the action).
+  const pendingConsume = useRef<Set<string>>(new Set());
   useEffect(() => {
     if (!guidance.enabled) return;
     frame.reachedGoals.forEach((g) => guidance.markReached(g));
     frame.resolved.forEach((r) => {
+      if (r.edge.to != null) pendingConsume.current.add(r.edge.to);
       if (r.stepTotal > 1) {
         const key = edgeStepKey(r.edge);
         if (guidance.stepIndex(key) < r.stepIndex) guidance.setStep(key, r.stepIndex);
       }
     });
-  }, [frame, guidance]);
+    pendingConsume.current.forEach((to) => { if (activeStatuses.has(to)) guidance.consume(to); });
+  }, [frame, activeStatuses, guidance]);
   // Publish the observable snapshot (while enabled) so a host can mirror it with bespoke rendering.
   const snapshots = useMemo(
     () => (guidance.enabled ? snapshotsOf(frame.resolved, itemBounds, activeItemId) : []),
@@ -1008,6 +1012,7 @@ const AzGuidanceLayer: React.FC<{
       activeItemId={activeItemId}
       targets={guidance.targets}
       onAdvance={(k) => guidance.advance(k)}
+      onSkip={() => guidance.skip()}
       renderSlot={guidance.renderer}
     />
   );

--- a/aznavrail-react/src/__tests__/AzCalloutPlacement.test.ts
+++ b/aznavrail-react/src/__tests__/AzCalloutPlacement.test.ts
@@ -1,0 +1,51 @@
+import { placeCallout, overlapArea } from '../guidance/AzCalloutPlacement';
+import type { AzShapeBounds } from '../guidance/AzStatus';
+
+/** Parity with the Kotlin AzCalloutPlacementTest. */
+
+const safe: AzShapeBounds = { left: 0, top: 0, width: 1000, height: 2000 };
+const size = { width: 240, height: 100 };
+
+describe('placeCallout', () => {
+  it('overlapArea computes the intersection', () => {
+    expect(overlapArea({ left: 0, top: 0, width: 10, height: 10 }, { left: 5, top: 5, width: 10, height: 10 })).toBe(25);
+    expect(overlapArea({ left: 0, top: 0, width: 10, height: 10 }, { left: 20, top: 20, width: 10, height: 10 })).toBe(0);
+  });
+
+  it('prefers below the target when there is room', () => {
+    const r = placeCallout({ left: 400, top: 400, width: 200, height: 100 }, size, [], safe);
+    expect(r.left).toBe(400);
+    expect(r.top).toBe(508);
+  });
+
+  it('never covers the target', () => {
+    const t = { left: 400, top: 400, width: 200, height: 100 };
+    expect(overlapArea(placeCallout(t, size, [], safe), t)).toBe(0);
+  });
+
+  it('flips above when below would leave the safe area', () => {
+    const r = placeCallout({ left: 400, top: 1850, width: 200, height: 100 }, size, [], safe);
+    expect(r.top).toBe(1742);
+    expect(r.top + r.height).toBeLessThanOrEqual(safe.height);
+  });
+
+  it('avoids an obstacle blocking the preferred side', () => {
+    const t = { left: 400, top: 400, width: 200, height: 100 };
+    const ob = { left: 380, top: 500, width: 300, height: 200 };
+    const r = placeCallout(t, size, [ob], safe);
+    expect(overlapArea(r, ob)).toBe(0);
+    expect(overlapArea(r, t)).toBe(0);
+  });
+
+  it('stays fully inside the safe area', () => {
+    const r = placeCallout({ left: 950, top: 50, width: 49, height: 49 }, size, [], safe);
+    expect(r.left >= 0 && r.left + r.width <= 1000).toBe(true);
+    expect(r.top >= 0 && r.top + r.height <= 2000).toBe(true);
+  });
+
+  it('untargeted callouts spread off each other', () => {
+    const placed = { left: 0, top: 0, width: 240, height: 100 };
+    const r = placeCallout(null, size, [placed], safe);
+    expect(overlapArea(r, placed)).toBe(0);
+  });
+});

--- a/aznavrail-react/src/__tests__/AzGuidanceDedup.test.ts
+++ b/aznavrail-react/src/__tests__/AzGuidanceDedup.test.ts
@@ -1,0 +1,18 @@
+import { routeInstructions } from '../guidance/AzGuidance';
+import type { AzEdge, AzGoal } from '../guidance/AzStatus';
+
+/** The no-repeat rule: a status consumed (a shown hop's target that was reached) is never re-shown. */
+
+const edge = (from: string, to: string | null, text: string): AzEdge => ({ from, to, instruction: { text } });
+
+describe('routeInstructions de-dup', () => {
+  it('does not re-show a consumed hop', () => {
+    const edges = [edge('a', 'b', 'Open menu'), edge('b', 'c', 'Tap X')];
+    const goals: Record<string, AzGoal> = { g: { id: 'g', target: 'c' } };
+    // From {a}: the first hop shows.
+    expect(routeInstructions(edges, goals, ['g'], new Set(['a'])).instructions[0].text).toBe('Open menu');
+    // With "b" consumed, routing skips that hop even though we're back at {a}.
+    const f = routeInstructions(edges, goals, ['g'], new Set(['a']), () => 0, new Set(['b']));
+    expect(f.instructions[0].text).toBe('Tap X');
+  });
+});

--- a/aznavrail-react/src/components/AzInstructionOverlay.tsx
+++ b/aznavrail-react/src/components/AzInstructionOverlay.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Text, StyleSheet, Dimensions, Pressable } from 'react-native';
+import React, { useRef, useState } from 'react';
+import { View, Text, StyleSheet, Dimensions, PanResponder, type LayoutChangeEvent, type ViewStyle } from 'react-native';
 import type {
   AzGuidanceRenderer,
   AzGuideShape,
@@ -10,6 +10,7 @@ import type {
 import { resolveShape, shapeBounds } from '../guidance/AzStatus';
 import type { ResolvedInstruction } from '../guidance/AzGuidance';
 import { edgeStepKey } from '../guidance/AzGuidance';
+import { placeCallout } from '../guidance/AzCalloutPlacement';
 
 interface Props {
   resolved: ResolvedInstruction[];
@@ -17,23 +18,27 @@ interface Props {
   accent?: string;
   activeItemId?: string | null;
   targets?: Record<string, () => AzGuideShape | null>;
-  /** Called when a tap-advanceable step's callout is pressed. */
+  /** Called when a tap-advanceable info-step callout is tapped. */
   onAdvance?: (key: string) => void;
+  /** Called when a callout is swiped away (cancels tutorial mode). */
+  onSkip?: () => void;
   /** Host renderer replacing the built-in callout body. */
   renderSlot?: AzGuidanceRenderer | null;
 }
 
 const CALLOUT_W = 240;
+const DEFAULT_H = 84;
+const SWIPE_PX = 48;
+const TAP_PX = 8;
 
 /**
- * Renders the current guidance instructions as callouts, **each placed next to its own highlight
- * target** (so the user sees, in place, how to accomplish each active goal). Targets may be rail items,
- * the active item, or host-registered arbitrary shapes (circle / rect / path). The overlay never blocks
- * input except on a tap-advanceable info-step callout, which advances the paged edge on press.
+ * Renders guidance as a **non-blocking coach**: a thin accent outline around each step's target and a
+ * small callout placed *near* (never on) that target, with a connector to it. It never dims the screen
+ * and never intercepts input outside a callout. **Swiping a callout cancels tutorial mode**; tapping an
+ * informational step advances it. Callouts avoid the target, other known UI, each other, and the edges.
  *
- * (Parity note: where the Android overlay punches a true spotlight hole per target, the React overlay
- * draws an accent ring around each target over a light dim. A `Path` target is ringed by its bounding
- * box — multi-hole / path masking isn't portable across React Native primitives.)
+ * (Parity note: Android strokes the true shape and draws an arrowhead; React rings the target's bounding
+ * box and draws a plain connector line — multi-shape masking / arrowheads aren't portable on RN.)
  */
 export const AzInstructionOverlay: React.FC<Props> = ({
   resolved,
@@ -42,45 +47,59 @@ export const AzInstructionOverlay: React.FC<Props> = ({
   activeItemId = null,
   targets = {},
   onAdvance,
+  onSkip,
   renderSlot,
 }) => {
+  const [sizes, setSizes] = useState<Record<number, { width: number; height: number }>>({});
   if (!resolved || resolved.length === 0) return null;
   const screen = Dimensions.get('window');
+  const safe: AzShapeBounds = { left: 8, top: 8, width: screen.width - 16, height: screen.height - 16 - 24 };
+
+  const shapes = resolved.map((r) => resolveShape(r.instruction.highlight ?? { type: 'None' }, itemBounds, activeItemId, targets));
+  const targetBounds = shapes.map((s) => (s ? shapeBounds(s) : null));
+  const itemObstacles: AzShapeBounds[] = Object.values(itemBounds).map((b) => ({ left: b.x, top: b.y, width: b.width, height: b.height }));
+
+  const placedRects: AzShapeBounds[] = [];
+  const placements = resolved.map((_, i) => {
+    const size = sizes[i] ?? { width: CALLOUT_W, height: DEFAULT_H };
+    const obstacles = [
+      ...itemObstacles,
+      ...(targetBounds.filter((b, j) => j !== i && b != null) as AzShapeBounds[]),
+      ...placedRects,
+    ];
+    const rect = placeCallout(targetBounds[i], size, obstacles, safe);
+    placedRects.push(rect);
+    return rect;
+  });
 
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
-      <View style={[StyleSheet.absoluteFill, styles.dim]} pointerEvents="none" />
       {resolved.map((r, i) => {
-        const ins = r.instruction;
-        const highlight = ins.highlight ?? { type: 'None' };
-        const shape = resolveShape(highlight, itemBounds, activeItemId, targets);
-        const b: AzShapeBounds | null = shape ? shapeBounds(shape) : null;
+        const shape = shapes[i];
+        const b = targetBounds[i];
+        const rect = placements[i];
+        const measured = sizes[i] != null;
         const stepKey = edgeStepKey(r.edge);
         const currentStep = r.edge.steps?.[r.stepIndex];
         const tappable = r.stepTotal > 1 && r.stepIndex < r.stepTotal - 1 && currentStep?.advanceWhen == null;
-        const onPress = tappable && onAdvance ? () => onAdvance(stepKey) : undefined;
-
         const body = renderSlot
           ? renderSlot(toSnapshotLite(r, shape, b), b)
-          : <Callout ins={ins} accent={accent} stepIndex={r.stepIndex} stepTotal={r.stepTotal} tappable={!!onPress} />;
-
-        if (!b) {
-          return (
-            <View key={i} style={styles.floatWrap} pointerEvents="box-none">
-              <Tappable onPress={onPress}>{body}</Tappable>
-            </View>
-          );
-        }
-        const ring = ringStyle(shape!, b, accent);
-        const belowHasRoom = b.top + b.height + 96 < screen.height;
-        const top = belowHasRoom ? b.top + b.height + 8 : Math.max(0, b.top - 96);
-        const left = Math.max(8, Math.min(b.left, screen.width - CALLOUT_W - 8));
+          : <Callout ins={r.instruction} accent={accent} stepIndex={r.stepIndex} stepTotal={r.stepTotal} tappable={tappable} />;
         return (
           <React.Fragment key={i}>
-            <View pointerEvents="none" style={ring} />
-            <View pointerEvents="box-none" style={[styles.calloutWrap, { left, top }]}>
-              <Tappable onPress={onPress}>{body}</Tappable>
-            </View>
+            {shape && b ? <View pointerEvents="none" style={ringStyle(shape, b, accent)} /> : null}
+            {b ? <Connector from={center(rect)} to={center(b)} color={accent} /> : null}
+            <CalloutGesture
+              onSwipe={() => onSkip?.()}
+              onTap={tappable && onAdvance ? () => onAdvance(stepKey) : undefined}
+              style={{ position: 'absolute', left: rect.left, top: rect.top, maxWidth: CALLOUT_W, opacity: measured ? 1 : 0 }}
+              onLayout={(e: LayoutChangeEvent) => {
+                const { width, height } = e.nativeEvent.layout;
+                setSizes((prev) => (prev[i] && prev[i].width === width && prev[i].height === height ? prev : { ...prev, [i]: { width, height } }));
+              }}
+            >
+              {body}
+            </CalloutGesture>
           </React.Fragment>
         );
       })}
@@ -88,16 +107,60 @@ export const AzInstructionOverlay: React.FC<Props> = ({
   );
 };
 
-const Tappable: React.FC<{ onPress?: () => void; children: React.ReactNode }> = ({ onPress, children }) => {
-  if (!onPress) return <View pointerEvents="none">{children}</View>;
-  return <Pressable onPress={onPress}>{children}</Pressable>;
+const center = (r: AzShapeBounds) => ({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
+
+/** A callout wrapper: a swipe past a threshold cancels guidance; a clean tap advances an info step. */
+const CalloutGesture: React.FC<{
+  onSwipe: () => void;
+  onTap?: () => void;
+  style: ViewStyle;
+  onLayout: (e: LayoutChangeEvent) => void;
+  children: React.ReactNode;
+}> = ({ onSwipe, onTap, style, onLayout, children }) => {
+  const onSwipeRef = useRef(onSwipe);
+  onSwipeRef.current = onSwipe;
+  const onTapRef = useRef(onTap);
+  onTapRef.current = onTap;
+  const handlers = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dx) + Math.abs(g.dy) > 4,
+      onPanResponderRelease: (_, g) => {
+        const dist = Math.hypot(g.dx, g.dy);
+        if (dist > SWIPE_PX) onSwipeRef.current();
+        else if (dist < TAP_PX) onTapRef.current?.();
+      },
+    }),
+  ).current;
+  return (
+    <View {...handlers.panHandlers} style={style} onLayout={onLayout}>
+      {children}
+    </View>
+  );
 };
 
-/** A bounding ring around the shape (circle gets a circular border; rect/path get a rounded box). */
-function ringStyle(shape: AzGuideShape, b: AzShapeBounds, accent: string) {
+/** A connector line from the callout to its target (no arrowhead — see the parity note). */
+const Connector: React.FC<{ from: { x: number; y: number }; to: { x: number; y: number }; color: string }> = ({ from, to, color }) => {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const len = Math.hypot(dx, dy);
+  if (len < 1) return null;
+  const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
+  const mx = (from.x + to.x) / 2;
+  const my = (from.y + to.y) / 2;
+  return (
+    <View
+      pointerEvents="none"
+      style={{ position: 'absolute', left: mx - len / 2, top: my - 1, width: len, height: 2, backgroundColor: color, transform: [{ rotate: `${angle}deg` }] }}
+    />
+  );
+};
+
+/** A bounding ring around the shape (circle → circular border; rect/path → rounded box). */
+function ringStyle(shape: AzGuideShape, b: AzShapeBounds, accent: string): ViewStyle {
   const radius = shape.type === 'Circle' ? Math.min(b.width, b.height) / 2 : shape.type === 'Rect' ? (shape.cornerRadius ?? 12) : 12;
   return {
-    position: 'absolute' as const,
+    position: 'absolute',
     left: b.left - 4,
     top: b.top - 4,
     width: b.width + 8,
@@ -136,19 +199,14 @@ const Callout: React.FC<{ ins: AzInstruction; accent: string; stepIndex: number;
     {ins.title ? <Text style={[styles.title, { color: accent }]}>{ins.title}</Text> : null}
     <Text style={styles.text}>{ins.text}</Text>
     {ins.media ? <View style={styles.media}>{ins.media()}</View> : null}
-    {stepTotal > 1 ? (
-      <View style={styles.stepRow}>
-        <Text style={styles.stepCount}>{`${stepIndex + 1} / ${stepTotal}`}</Text>
-        {tappable ? <Text style={[styles.tapHint, { color: accent }]}>Tap to continue ▸</Text> : null}
-      </View>
-    ) : null}
+    <View style={styles.stepRow}>
+      <Text style={styles.stepCount}>{stepTotal > 1 ? `${stepIndex + 1} / ${stepTotal}` : 'swipe to dismiss'}</Text>
+      {tappable ? <Text style={[styles.tapHint, { color: accent }]}>Tap to continue ▸</Text> : null}
+    </View>
   </View>
 );
 
 const styles = StyleSheet.create({
-  dim: { backgroundColor: 'rgba(0,0,0,0.35)' },
-  calloutWrap: { position: 'absolute', maxWidth: CALLOUT_W },
-  floatWrap: { position: 'absolute', left: 0, right: 0, bottom: 24, alignItems: 'center' },
   callout: {
     maxWidth: CALLOUT_W,
     backgroundColor: '#ffffff',

--- a/aznavrail-react/src/guidance/AzCalloutPlacement.ts
+++ b/aznavrail-react/src/guidance/AzCalloutPlacement.ts
@@ -1,0 +1,72 @@
+import type { AzShapeBounds } from './AzStatus';
+
+/**
+ * Pure geometry for placing a guidance callout near its target but never on top of it, off the known
+ * obstacles, and inside the safe area. Window-space px. Mirrors the Kotlin `AzCalloutPlacement`.
+ */
+
+/** Area of the intersection of two rects (0 when disjoint). */
+export function overlapArea(a: AzShapeBounds, b: AzShapeBounds): number {
+  const w = Math.max(0, Math.min(a.left + a.width, b.left + b.width) - Math.max(a.left, b.left));
+  const h = Math.max(0, Math.min(a.top + a.height, b.top + b.height) - Math.max(a.top, b.top));
+  return w * h;
+}
+
+function clampToSafe(x: number, y: number, w: number, h: number, safe: AzShapeBounds): AzShapeBounds {
+  const maxLeft = Math.max(safe.left, safe.left + safe.width - w);
+  const maxTop = Math.max(safe.top, safe.top + safe.height - h);
+  const left = Math.min(Math.max(x, safe.left), maxLeft);
+  const top = Math.min(Math.max(y, safe.top), maxTop);
+  return { left, top, width: w, height: h };
+}
+
+function penalty(rect: AzShapeBounds, obstacles: AzShapeBounds[], target: AzShapeBounds | null): number {
+  let p = 0;
+  if (target) p += overlapArea(rect, target) * 2;
+  for (const o of obstacles) p += overlapArea(rect, o);
+  return p;
+}
+
+/**
+ * Choose the best window-space rect for a `size` callout: the four sides of `target` (with `gap`), or a
+ * grid scan of `safe` when there is no target. Lowest obstacle-overlap wins (ties prefer the earlier
+ * candidate — below first), then it is clamped fully into `safe`.
+ */
+export function placeCallout(
+  target: AzShapeBounds | null,
+  size: { width: number; height: number },
+  obstacles: AzShapeBounds[],
+  safe: AzShapeBounds,
+  gap = 8,
+): AzShapeBounds {
+  const w = size.width;
+  const h = size.height;
+  const candidates: AzShapeBounds[] = [];
+  if (target) {
+    candidates.push(clampToSafe(target.left, target.top + target.height + gap, w, h, safe)); // below
+    candidates.push(clampToSafe(target.left, target.top - h - gap, w, h, safe)); // above
+    candidates.push(clampToSafe(target.left + target.width + gap, target.top, w, h, safe)); // end
+    candidates.push(clampToSafe(target.left - w - gap, target.top, w, h, safe)); // start
+  } else {
+    const stepX = Math.max(1, w * 0.5);
+    const stepY = Math.max(1, h * 0.5);
+    const maxY = Math.max(safe.top, safe.top + safe.height - h);
+    const maxX = Math.max(safe.left, safe.left + safe.width - w);
+    for (let y = safe.top; y <= maxY; y += stepY) {
+      for (let x = safe.left; x <= maxX; x += stepX) {
+        candidates.push(clampToSafe(x, y, w, h, safe));
+      }
+    }
+    if (candidates.length === 0) candidates.push(clampToSafe(safe.left, safe.top, w, h, safe));
+  }
+  let best = candidates[0];
+  let bestP = penalty(best, obstacles, target);
+  for (let i = 1; i < candidates.length; i++) {
+    const p = penalty(candidates[i], obstacles, target);
+    if (p < bestP) {
+      best = candidates[i];
+      bestP = p;
+    }
+  }
+  return best;
+}

--- a/aznavrail-react/src/guidance/AzGuidance.ts
+++ b/aznavrail-react/src/guidance/AzGuidance.ts
@@ -108,26 +108,30 @@ export function routeInstructions(
   activeGoalIds: string[],
   activeStatuses: Set<string>,
   stepIndexOf: (key: string) => number = () => 0,
+  consumedStatuses: Set<string> = new Set(),
 ): GuidanceFrame {
+  // De-dup: a status that was a shown hop's target and has since been reached is treated as
+  // permanently true, so its hop is never re-shown.
+  const effective = consumedStatuses.size === 0 ? activeStatuses : new Set([...activeStatuses, ...consumedStatuses]);
   const out = new Map<string, ResolvedInstruction>();
   const reached = new Set<string>();
   const keyOf = (ins: AzInstruction) => `${ins.text}|${highlightKey(ins.highlight)}`;
   for (const gid of activeGoalIds) {
     const goal = goals[gid];
     if (!goal) continue;
-    if (activeStatuses.has(goal.target)) {
+    if (effective.has(goal.target)) {
       reached.add(gid);
       continue;
     }
-    const e = nextHop(edges, activeStatuses, goal.target);
+    const e = nextHop(edges, effective, goal.target);
     if (e) {
-      const r = resolveEdge(e, gid, stepIndexOf, activeStatuses);
+      const r = resolveEdge(e, gid, stepIndexOf, effective);
       out.set(keyOf(r.instruction), r);
     }
   }
   for (const e of edges) {
-    if (e.to == null && activeStatuses.has(e.from)) {
-      const r = resolveEdge(e, null, stepIndexOf, activeStatuses);
+    if (e.to == null && effective.has(e.from)) {
+      const r = resolveEdge(e, null, stepIndexOf, effective);
       out.set(keyOf(r.instruction), r);
     }
   }

--- a/aznavrail-react/src/guidance/AzGuidanceController.tsx
+++ b/aznavrail-react/src/guidance/AzGuidanceController.tsx
@@ -9,6 +9,7 @@ import type {
 } from './AzStatus';
 
 const STORAGE_KEY = 'az_navrail_completed_goals';
+const DISMISSED_KEY = 'az_navrail_dismissed_goals';
 
 // Optional AsyncStorage (React Native) — used if installed, no-op otherwise.
 let AsyncStorage: { setItem: (k: string, v: string) => Promise<void> } | null = null;
@@ -19,10 +20,10 @@ try {
   /* not installed — fall back to localStorage / no-op */
 }
 
-function loadCompleted(): string[] {
+function loadIds(key: string): string[] {
   try {
     if (typeof localStorage !== 'undefined') {
-      const raw = localStorage.getItem(STORAGE_KEY);
+      const raw = localStorage.getItem(key);
       if (raw) return JSON.parse(raw) as string[];
     }
   } catch {
@@ -31,14 +32,14 @@ function loadCompleted(): string[] {
   return [];
 }
 
-function saveCompleted(ids: string[]): void {
+function saveIds(key: string, ids: string[]): void {
   const json = JSON.stringify(ids);
   try {
-    if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, json);
+    if (typeof localStorage !== 'undefined') localStorage.setItem(key, json);
   } catch {
     /* ignore */
   }
-  AsyncStorage?.setItem(STORAGE_KEY, json).catch(() => {});
+  AsyncStorage?.setItem(key, json).catch(() => {});
 }
 
 /**
@@ -62,6 +63,13 @@ export interface AzGuidanceController {
   /** Mark a goal reached: deactivate it and persist completion. */
   markReached: (goalId: string) => void;
   isCompleted: (goalId: string) => boolean;
+  /** Goal ids the user skipped (persisted) — a skipped tutorial is never shown again until reset. */
+  dismissedGoals: string[];
+  isDismissed: (goalId: string) => boolean;
+  /** The user skipped a goal (omit `goalId` to cancel tutorial mode: skip all active goals + disable). */
+  skip: (goalId?: string) => void;
+  /** Clear completion + dismissal (+ de-dup) for `goalId` (or all) so a tutorial can be shown again. */
+  resetGuidance: (goalId?: string) => void;
   // --- Paged-edge step cursor (transient; only goal completion persists) ---
   /** Current step index for the paged edge identified by `key` (see `edgeStepKey`). */
   stepIndex: (key: string) => number;
@@ -101,6 +109,10 @@ interface AzGuidanceContextValue extends AzGuidanceController {
   setRenderer: (renderer: AzGuidanceRenderer | null) => void;
   /** Publish the latest routed snapshot list. Called by the rail; not for app use. */
   publishCurrent: (snapshots: AzGuidanceSnapshot[]) => void;
+  /** Statuses consumed this session (a shown step whose action was taken). */
+  consumedStatuses: Set<string>;
+  /** Mark a status consumed (a shown hop's `to` that became true). Called by the rail. */
+  consume: (status: string) => void;
 }
 
 const AzGuidanceContext = createContext<AzGuidanceContextValue | null>(null);
@@ -119,7 +131,9 @@ interface AzGuidanceProviderProps {
 export const AzGuidanceProvider: React.FC<AzGuidanceProviderProps> = ({ children, initialCompleted }) => {
   const [enabled, setEnabled] = useState(false);
   const [activeGoals, setActiveGoals] = useState<string[]>([]);
-  const [completedGoals, setCompletedGoals] = useState<string[]>(() => initialCompleted ?? loadCompleted());
+  const [completedGoals, setCompletedGoals] = useState<string[]>(() => initialCompleted ?? loadIds(STORAGE_KEY));
+  const [dismissedGoals, setDismissedGoals] = useState<string[]>(() => loadIds(DISMISSED_KEY));
+  const [consumed, setConsumed] = useState<string[]>([]);
 
   // Registry kept in refs (predicate identities churn every render); a version bump notifies consumers.
   const statusRef = useRef<Record<string, AzStatusPredicate>>({});
@@ -164,11 +178,13 @@ export const AzGuidanceProvider: React.FC<AzGuidanceProviderProps> = ({ children
   const next = advance;
 
   const enable = useCallback(() => setEnabled(true), []);
-  const disable = useCallback(() => setEnabled(false), []);
+  const disable = useCallback(() => { setEnabled(false); setConsumed([]); }, []);
   const activate = useCallback((goalId: string) => {
+    // No-op for a completed or skipped goal — it is never re-shown until resetGuidance.
+    if (completedGoals.includes(goalId) || dismissedGoals.includes(goalId)) return;
     setEnabled(true);
     setActiveGoals((prev) => (prev.includes(goalId) ? prev : [...prev, goalId]));
-  }, []);
+  }, [completedGoals, dismissedGoals]);
   const deactivate = useCallback((goalId: string) => {
     setActiveGoals((prev) => prev.filter((g) => g !== goalId));
   }, []);
@@ -177,11 +193,47 @@ export const AzGuidanceProvider: React.FC<AzGuidanceProviderProps> = ({ children
     setCompletedGoals((prev) => {
       if (prev.includes(goalId)) return prev;
       const next = [...prev, goalId];
-      saveCompleted(next);
+      saveIds(STORAGE_KEY, next);
       return next;
     });
   }, []);
   const isCompleted = useCallback((goalId: string) => completedGoals.includes(goalId), [completedGoals]);
+  const isDismissed = useCallback((goalId: string) => dismissedGoals.includes(goalId), [dismissedGoals]);
+  const skip = useCallback((goalId?: string) => {
+    if (goalId != null) {
+      setActiveGoals((prev) => prev.filter((g) => g !== goalId));
+      setDismissedGoals((prev) => {
+        if (prev.includes(goalId)) return prev;
+        const next = [...prev, goalId];
+        saveIds(DISMISSED_KEY, next);
+        return next;
+      });
+    } else {
+      // Cancel tutorial mode: skip every active goal (persisted), then turn guidance off.
+      setDismissedGoals((prev) => {
+        const next = Array.from(new Set([...prev, ...activeGoals]));
+        saveIds(DISMISSED_KEY, next);
+        return next;
+      });
+      setActiveGoals([]);
+      setEnabled(false);
+      setConsumed([]);
+    }
+  }, [activeGoals]);
+  const resetGuidance = useCallback((goalId?: string) => {
+    if (goalId != null) {
+      setCompletedGoals((prev) => { const next = prev.filter((g) => g !== goalId); saveIds(STORAGE_KEY, next); return next; });
+      setDismissedGoals((prev) => { const next = prev.filter((g) => g !== goalId); saveIds(DISMISSED_KEY, next); return next; });
+    } else {
+      setCompletedGoals(() => { saveIds(STORAGE_KEY, []); return []; });
+      setDismissedGoals(() => { saveIds(DISMISSED_KEY, []); return []; });
+    }
+    setConsumed([]);
+  }, []);
+  const consume = useCallback((status: string) => {
+    setConsumed((prev) => (prev.includes(status) ? prev : [...prev, status]));
+  }, []);
+  const consumedStatuses = useMemo(() => new Set(consumed), [consumed]);
 
   // Live registry views, recomputed when the registry version changes.
   const edges = useMemo(() => Object.values(edgeRef.current), [version]);
@@ -195,12 +247,14 @@ export const AzGuidanceProvider: React.FC<AzGuidanceProviderProps> = ({ children
   const value = useMemo<AzGuidanceContextValue>(
     () => ({
       enabled, activeGoals, completedGoals, enable, disable, activate, deactivate, markReached, isCompleted,
+      dismissedGoals, isDismissed, skip, resetGuidance, consumedStatuses, consume,
       stepIndex, setStep, advance, next, back, currentInstructions, current,
       statusPredicates, edges, goals, targets, suppressors, renderer,
       registerStatus, unregisterStatus, registerEdge, unregisterEdge, registerGoal, unregisterGoal,
       registerTarget, unregisterTarget, registerSuppressor, unregisterSuppressor, setRenderer, publishCurrent,
     }),
     [enabled, activeGoals, completedGoals, enable, disable, activate, deactivate, markReached, isCompleted,
+     dismissedGoals, isDismissed, skip, resetGuidance, consumedStatuses, consume,
      stepIndex, setStep, advance, next, back, currentInstructions, current,
      statusPredicates, edges, goals, targets, suppressors, renderer,
      registerStatus, unregisterStatus, registerEdge, unregisterEdge, registerGoal, unregisterGoal,
@@ -214,6 +268,7 @@ export const AzGuidanceProvider: React.FC<AzGuidanceProviderProps> = ({ children
 const NOOP: AzGuidanceContextValue = {
   enabled: false, activeGoals: [], completedGoals: [],
   enable: () => {}, disable: () => {}, activate: () => {}, deactivate: () => {}, markReached: () => {}, isCompleted: () => false,
+  dismissedGoals: [], isDismissed: () => false, skip: () => {}, resetGuidance: () => {}, consumedStatuses: new Set(), consume: () => {},
   stepIndex: () => 0, setStep: () => {}, advance: () => {}, next: () => {}, back: () => {},
   currentInstructions: [], current: null,
   statusPredicates: {}, edges: [], goals: {}, targets: {}, suppressors: [], renderer: null,

--- a/aznavrail-react/src/index.tsx
+++ b/aznavrail-react/src/index.tsx
@@ -69,3 +69,4 @@ export { AzInstructionOverlay } from './components/AzInstructionOverlay';
 export { useActiveStatuses, computeBuiltinStatuses, useGuidanceSuppressed, anySuppressorActive } from './guidance/AzStatusEngine';
 export { nextHop, routeInstructions, computeAutoEdges, resolveEdge, toSnapshot, snapshotsOf } from './guidance/AzGuidance';
 export type { ResolvedInstruction, GuidanceFrame } from './guidance/AzGuidance';
+export { placeCallout, overlapArea } from './guidance/AzCalloutPlacement';

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -706,6 +706,20 @@ taps at all. Instead it observes **status predicates** and reacts:
 - **Every active goal at once.** If several goals are active, each shows its own instruction
   simultaneously as a callout next to the control that satisfies its next hop.
 
+**Presentation is non-blocking and never dims.** Guidance draws a thin **outline** around the step's
+target and a small **callout placed near (never on) that target**, with a **pointer/arrow** connecting
+them. It **never darkens the screen** and **never intercepts input outside a callout** — the app stays
+fully usable while guidance is up, so the user can actually perform the action the step teaches.
+Callouts are positioned to avoid covering the target, other known UI (rail items / registered targets),
+each other, and the screen's safe-area edges; several callouts can share the screen, each by its own
+target. A step that has been shown and acted on is **never shown again**, even if the user later undoes
+the action and the router would otherwise re-route to it.
+
+**Skipping & replay.** The user can **swipe a callout away to cancel tutorial mode** — that skip is
+persisted (`SharedPreferences` / `localStorage`), so a skipped tutorial is **not** shown again. To let
+it run again, call `controller.resetGuidance(goalId)` (or `resetGuidance()` for all). Completed and
+skipped goals are both ignored by `activate()` until reset.
+
 **Predicate observation timing.** Predicates that read Compose/React state (a `mutableStateOf`,
 a React state value, a derived value) are observed **instantly**. Predicates that read
 **non-reactive** sources — a `StateFlow.value`, a plain `var`, a `ref`, an external store — are
@@ -716,9 +730,11 @@ control passes `highlightItemId`; the callout anchors next to that item's measur
 any item-anchored UI, the item must be laid out — if it lives inside a collapsed host, use the host's
 `expandWhen` (see §4) so the item's bounds are known when the callout needs to anchor.
 
-**Goal activation is developer-driven.** There is no built-in end-user picker. You activate goals
-imperatively through the `AzGuidanceController` (`activate(id)`), or declare `autoStartWhen` on a
-goal so it self-activates (typically for onboarding) when its condition becomes true.
+**Goal activation is developer-driven.** There is no built-in end-user picker — **starting is always
+your decision**. You activate goals imperatively through the `AzGuidanceController` (`activate(id)`).
+`autoStartWhen` (a status id that self-activates a goal) still exists but is **discouraged**; prefer an
+explicit `activate(...)`. Either way, a goal that the user has **completed or skipped never (re)starts**
+until you call `resetGuidance(...)`.
 
 ### 9.3 Help/Info Overlay Integration
 
@@ -788,6 +804,12 @@ val finished = controller.isCompleted("onboarding")
 // Mark a status reached manually (e.g. from an external success callback):
 controller.markReached("profileComplete")
 
+// Skip (usually driven by the swipe-to-cancel gesture) and replay:
+controller.skip("onboarding")      // dismiss one goal (persisted)
+controller.skip()                  // cancel tutorial mode: skip all active goals + disable
+controller.resetGuidance("onboarding") // clear completion + dismissal so it can run again
+controller.resetGuidance()         // clear all
+
 // Turn the whole framework on/off:
 controller.disable()
 controller.enable()
@@ -795,9 +817,10 @@ controller.enable()
 
 You can also obtain a controller via `rememberAzGuidanceController()` and read it through
 `LocalAzGuidanceController.current`. `AzGuidanceController` lives in package
-`com.hereliesaz.aznavrail.tutorial` and exposes: `enabled`, `activeGoals: List<String>`,
-`completedGoals: List<String>`, `enable()`, `disable()`, `activate(id)`, `deactivate(id)`,
-`markReached(id)`, `isCompleted(id)`.
+`com.hereliesaz.aznavrail.tutorial` and exposes: `enabled`, `activeGoals`, `completedGoals`,
+`dismissedGoals`, `enable()`, `disable()`, `activate(id)`, `deactivate(id)`, `markReached(id)`,
+`isCompleted(id)`, `isDismissed(id)`, `skip(id?)`, `resetGuidance(id?)`, and (for paged edges)
+`advance`/`next`/`back` plus the observable `currentInstructions`/`current`/`currentFlow`.
 
 Persistence: completed goals persist in `SharedPreferences` under key
 `az_navrail_completed_goals`.
@@ -868,10 +891,10 @@ Also exported for advanced use: `AzGuidanceProvider`, `AzInstructionOverlay`, `u
 Persistence: completed goals persist to `localStorage` (and `AsyncStorage` on React Native) under key
 `az_navrail_completed_goals`.
 
-**React overlay parity note:** the React/web overlay draws an **accent ring** around each target over
-a light dim — it does **not** punch a true spotlight hole out of the dim layer (no Android-style
-`BlendMode.Clear` punch-out). This is a minor visual difference; routing and advancement behave
-identically.
+**Platform parity note:** neither platform dims the screen. Android strokes the target's true geometry
+(circle/rect/path) and draws an arrowhead to the callout; React rings the target's bounding box and
+draws a plain connector line (per-shape masking / arrowheads aren't portable on React Native). Routing,
+placement, and advancement behave identically.
 
 ### 9.6 Highlighting arbitrary on-screen targets (`azGuidanceTarget`)
 
@@ -882,8 +905,9 @@ rail item** — a ball drawn over a camera/AR canvas, an aiming line, an on-scre
 reference it from an edge (or a step) with `highlightTargetId`. If the function returns `null` (target
 absent), the callout gracefully degrades to text-only.
 
-The library both **draws a default spotlight** for the shape (circle/rect/path punch-out) **and**
-publishes the resolved shape on the controller (see §9.8) so a host can draw its own highlight.
+The library both **draws a non-blocking outline** around the shape (circle/rect/path) **and** publishes
+the resolved shape on the controller (see §9.8) so a host can draw its own highlight. It never dims or
+covers the target.
 
 ```kotlin
 // Window-space shape, recomputed each frame (read Compose state inside for smooth tracking).
@@ -985,9 +1009,9 @@ azSuppressGuide(settleMs = 700) { gesture.inProgress }
 
 ### 9.10 Custom callout rendering (optional)
 
-To draw the callout body yourself (over a camera/canvas), register a renderer; the dim + spotlight
-punch-out still draw, but the callout content is yours. It receives the current snapshot and the
-resolved target bounds.
+To draw the callout body yourself (over a camera/canvas), register a renderer; the outline + connector
+still draw, but the callout content is yours. It receives the current snapshot and the resolved target
+bounds.
 
 ```kotlin
 azGuideRenderer { snapshot, bounds -> MyCallout(snapshot, bounds) }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -909,13 +909,15 @@ fun AzNavRail(
     val guidanceGoalsMap = remember(scope.guidanceGoals.toList()) {
         scope.guidanceGoals.associateBy { it.id }
     }
-    // Self-arming onboarding goals: activate once their trigger status holds (unless already completed).
-    // Keyed on the controller too, so it re-binds if the host-provided instance replaces the fallback.
+    // Self-arming onboarding goals: activate once their trigger status holds. `autoStartWhen` is
+    // discouraged (starting should be the developer's explicit `activate(...)` call); it honours both
+    // completion and the user's skip, so a finished or dismissed tutorial never auto-restarts.
     LaunchedEffect(activeStatuses, guidanceGoalsMap, guidanceController) {
         guidanceGoalsMap.values.forEach { goal ->
             val trigger = goal.autoStartWhen
             if (trigger != null && trigger in activeStatuses &&
-                !guidanceController.isCompleted(goal.id) && goal.id !in guidanceController.activeGoals
+                !guidanceController.isCompleted(goal.id) && !guidanceController.isDismissed(goal.id) &&
+                goal.id !in guidanceController.activeGoals
             ) {
                 guidanceController.activate(goal.id)
             }
@@ -950,12 +952,20 @@ fun AzNavRail(
                     activeGoalIds = guidanceController.activeGoals,
                     activeStatuses = activeStatuses,
                     stepIndexOf = { guidanceController.stepIndex(it) },
+                    consumedStatuses = guidanceController.consumedStatuses,
                 )
             }
         }.value
         // Auto-advance: a goal whose target is now true is reached → deactivate it and persist.
         LaunchedEffect(frame.reachedGoals, guidanceController) {
             frame.reachedGoals.forEach { guidanceController.markReached(it) }
+        }
+        // De-dup: once a status that was a shown hop's `to` is reached, consume it so that hop never
+        // re-shows (even if the user later undoes the action and the router would otherwise re-route to it).
+        val pendingConsume = remember(guidanceController) { mutableSetOf<String>() }
+        LaunchedEffect(frame.resolved, activeStatuses, guidanceController) {
+            frame.resolved.forEach { r -> r.edge.to?.let { if (it !in pendingConsume) pendingConsume.add(it) } }
+            pendingConsume.forEach { if (it in activeStatuses) guidanceController.consume(it) }
         }
         // Persist reactive step advances into the cursor so a later tap continues from the shown step.
         LaunchedEffect(frame.resolved, guidanceController) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzCalloutPlacement.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzCalloutPlacement.kt
@@ -1,0 +1,83 @@
+package com.hereliesaz.aznavrail.tutorial
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+
+/**
+ * Pure geometry for placing a guidance callout so it sits **near its target but never on top of it**,
+ * avoids the known [obstacles] (other rail items / targets / already-placed callouts), and stays fully
+ * inside the [safe] area (so text is never clipped and nothing lands in the system-bar zone). All values
+ * are window-space px. Kept pure so it is unit-testable without a renderer; mirrored in the React port.
+ */
+
+/** Area of the intersection of two rects (0 when disjoint). */
+internal fun overlapArea(a: Rect, b: Rect): Float {
+    val w = (minOf(a.right, b.right) - maxOf(a.left, b.left)).coerceAtLeast(0f)
+    val h = (minOf(a.bottom, b.bottom) - maxOf(a.top, b.top)).coerceAtLeast(0f)
+    return w * h
+}
+
+/** Shift a [width]×[height] rect anchored at ([x],[y]) so it lies fully within [safe] (best effort). */
+private fun clampToSafe(x: Float, y: Float, width: Float, height: Float, safe: Rect): Rect {
+    val left = x.coerceIn(safe.left, (safe.right - width).coerceAtLeast(safe.left))
+    val top = y.coerceIn(safe.top, (safe.bottom - height).coerceAtLeast(safe.top))
+    return Rect(left, top, left + width, top + height)
+}
+
+/** Total overlap of [rect] against every obstacle plus the [target] it must not cover. */
+private fun penalty(rect: Rect, obstacles: List<Rect>, target: Rect?): Float {
+    var p = 0f
+    if (target != null) p += overlapArea(rect, target) * 2f // weigh covering the target itself heaviest
+    obstacles.forEach { p += overlapArea(rect, it) }
+    return p
+}
+
+/**
+ * Choose the best window-space rect for a [size] callout. When [target] is non-null the four sides
+ * (below, above, end, start, with [gap]) are tried; otherwise a coarse grid of [safe] is scanned so
+ * untargeted callouts spread out instead of stacking. The lowest-overlap candidate wins (ties resolve in
+ * the listed order — below is preferred), then it is clamped into [safe].
+ */
+internal fun placeCallout(
+    target: Rect?,
+    size: Size,
+    obstacles: List<Rect>,
+    safe: Rect,
+    gap: Float = 8f,
+): Rect {
+    val w = size.width
+    val h = size.height
+    val candidates = ArrayList<Rect>()
+    if (target != null) {
+        // Below, above, end, start — anchored to the target, then clamped into the safe area.
+        candidates += clampToSafe(target.left, target.bottom + gap, w, h, safe)
+        candidates += clampToSafe(target.left, target.top - h - gap, w, h, safe)
+        candidates += clampToSafe(target.right + gap, target.top, w, h, safe)
+        candidates += clampToSafe(target.left - w - gap, target.top, w, h, safe)
+    } else {
+        // No anchor: scan a grid of the safe area (so multiple untargeted callouts don't collide).
+        val stepX = (w * 0.5f).coerceAtLeast(1f)
+        val stepY = (h * 0.5f).coerceAtLeast(1f)
+        var y = safe.top
+        while (y <= (safe.bottom - h).coerceAtLeast(safe.top)) {
+            var x = safe.left
+            while (x <= (safe.right - w).coerceAtLeast(safe.left)) {
+                candidates += clampToSafe(x, y, w, h, safe)
+                x += stepX
+            }
+            y += stepY
+        }
+        if (candidates.isEmpty()) candidates += clampToSafe(safe.left, safe.top, w, h, safe)
+    }
+    // Pick the minimum-penalty candidate; the first listed wins ties (stable preference order).
+    var best = candidates.first()
+    var bestPenalty = penalty(best, obstacles, target)
+    for (i in 1 until candidates.size) {
+        val p = penalty(candidates[i], obstacles, target)
+        if (p < bestPenalty) {
+            best = candidates[i]
+            bestPenalty = p
+        }
+    }
+    return best
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzGuidance.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzGuidance.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.asStateFlow
 
 private const val PREFS_NAME = "az_tutorial_prefs"
 private const val PREF_KEY = "az_navrail_completed_goals"
+private const val PREF_KEY_DISMISSED = "az_navrail_dismissed_goals"
 
 /**
  * Runtime for the status-driven guidance framework. The developer activates one or more goals; the
@@ -27,6 +28,7 @@ private const val PREF_KEY = "az_navrail_completed_goals"
 class AzGuidanceController(
     initialCompleted: List<String> = emptyList(),
     private val prefs: SharedPreferences? = null,
+    initialDismissed: List<String> = emptyList(),
 ) {
     /** Master switch — guidance only renders while enabled. */
     var enabled by mutableStateOf(false)
@@ -39,6 +41,19 @@ class AzGuidanceController(
     private val _completed = mutableStateListOf<String>().apply { addAll(initialCompleted) }
     /** Goal ids reached at least once (persisted), so onboarding-style goals don't auto-restart. */
     val completedGoals: List<String> get() = _completed
+
+    private val _dismissed = mutableStateListOf<String>().apply { addAll(initialDismissed) }
+    /** Goal ids the user skipped (persisted), so a skipped tutorial is never shown again until reset. */
+    val dismissedGoals: List<String> get() = _dismissed
+    fun isDismissed(goalId: String): Boolean = goalId in _dismissed
+
+    // Session-scoped de-dup: statuses that were a shown next-hop's target and have since been reached.
+    // Routing treats them as permanently traversed, so a step shown + acted on never re-appears.
+    private val _consumed = mutableStateListOf<String>()
+    /** Statuses consumed this session (a shown step whose action was taken). Reactive. */
+    val consumedStatuses: Set<String> get() = _consumed.toHashSet()
+    /** Mark [status] consumed (idempotent). Called by the rail when a shown hop's `to` becomes true. */
+    internal fun consume(status: String) { if (status !in _consumed) _consumed.add(status) }
 
     // --- Paged-edge step cursor (transient; only goal completion persists) ---
     private val _stepCursor = mutableStateMapOf<String, Int>()
@@ -78,16 +93,40 @@ class AzGuidanceController(
     }
 
     fun enable() { enabled = true }
-    fun disable() { enabled = false }
+    fun disable() { enabled = false; _consumed.clear() }
 
-    /** Begin guiding toward [goalId]. */
+    /**
+     * Begin guiding toward [goalId]. **No-op if the goal was already completed or skipped** — a finished
+     * or dismissed tutorial is never re-shown until the developer calls [resetGuidance]. (This is also why
+     * starting is always the developer's explicit decision.)
+     */
     fun activate(goalId: String) {
+        if (goalId in _completed || goalId in _dismissed) return
         enabled = true
         if (goalId !in _activeGoals) _activeGoals.add(goalId)
     }
 
-    /** Stop guiding toward [goalId]. */
+    /** Stop guiding toward [goalId] (without recording it as skipped). */
     fun deactivate(goalId: String) { _activeGoals.remove(goalId) }
+
+    /**
+     * The user **skipped** [goalId]: deactivate and persist the dismissal so it is never shown again
+     * until [resetGuidance]. Driven by the swipe-to-cancel gesture on a callout.
+     */
+    fun skip(goalId: String) {
+        _activeGoals.remove(goalId)
+        if (goalId !in _dismissed) {
+            _dismissed.add(goalId)
+            prefs?.edit()?.putStringSet(PREF_KEY_DISMISSED, _dismissed.toSet())?.apply()
+        }
+    }
+
+    /** Cancel tutorial mode entirely: skip every active goal (persisted) and turn guidance off. */
+    fun skip() {
+        _activeGoals.toList().forEach { skip(it) }
+        enabled = false
+        _consumed.clear()
+    }
 
     /** Mark a goal reached: deactivate it and persist completion. */
     fun markReached(goalId: String) {
@@ -100,14 +139,34 @@ class AzGuidanceController(
 
     fun isCompleted(goalId: String): Boolean = goalId in _completed
 
+    /** Clear [goalId]'s completion + dismissal (+ session de-dup) so it can be guided again. */
+    fun resetGuidance(goalId: String) {
+        val wasCompleted = _completed.remove(goalId)
+        val wasDismissed = _dismissed.remove(goalId)
+        prefs?.edit()?.apply {
+            if (wasCompleted) putStringSet(PREF_KEY, _completed.toSet())
+            if (wasDismissed) putStringSet(PREF_KEY_DISMISSED, _dismissed.toSet())
+        }?.apply()
+        _consumed.clear()
+    }
+
+    /** Clear all completion + dismissal (+ session de-dup). */
+    fun resetGuidance() {
+        _completed.clear()
+        _dismissed.clear()
+        _consumed.clear()
+        prefs?.edit()?.putStringSet(PREF_KEY, emptySet())?.putStringSet(PREF_KEY_DISMISSED, emptySet())?.apply()
+    }
+
     companion object {
         fun Saver(context: Context): Saver<AzGuidanceController, List<Any?>> = Saver(
-            save = { listOf(ArrayList(it._activeGoals), ArrayList(it._completed), it.enabled) },
+            save = { listOf(ArrayList(it._activeGoals), ArrayList(it._completed), it.enabled, ArrayList(it._dismissed)) },
             restore = { list ->
                 val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
                 AzGuidanceController(
                     initialCompleted = (list[1] as List<*>).filterIsInstance<String>(),
                     prefs = prefs,
+                    initialDismissed = (list.getOrNull(3) as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
                 ).apply {
                     (list[0] as List<*>).filterIsInstance<String>().forEach { _activeGoals.add(it) }
                     if (list[2] as Boolean) enabled = true
@@ -123,7 +182,8 @@ fun rememberAzGuidanceController(): AzGuidanceController {
     return rememberSaveable(saver = AzGuidanceController.Saver(context)) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val done = prefs.getStringSet(PREF_KEY, emptySet())?.toList() ?: emptyList()
-        AzGuidanceController(initialCompleted = done, prefs = prefs)
+        val dismissed = prefs.getStringSet(PREF_KEY_DISMISSED, emptySet())?.toList() ?: emptyList()
+        AzGuidanceController(initialCompleted = done, prefs = prefs, initialDismissed = dismissed)
     }
 }
 
@@ -265,20 +325,24 @@ internal fun routeInstructions(
     activeGoalIds: Collection<String>,
     activeStatuses: Set<String>,
     stepIndexOf: (String) -> Int = { 0 },
+    consumedStatuses: Set<String> = emptySet(),
 ): GuidanceFrame {
+    // De-dup: a status that was a shown hop's target and has since been reached is treated as
+    // permanently true, so its hop is never routed to (or re-shown) again.
+    val effective = if (consumedStatuses.isEmpty()) activeStatuses else activeStatuses + consumedStatuses
     val out = LinkedHashMap<Pair<String, AzGuideHighlight>, ResolvedInstruction>()
     val reached = HashSet<String>()
     activeGoalIds.forEach { gid ->
         val goal = goals[gid] ?: return@forEach
-        if (goal.target in activeStatuses) { reached.add(gid); return@forEach }
-        nextHop(edges, activeStatuses, goal.target)?.let { e ->
-            val r = resolveEdge(e, gid, stepIndexOf, activeStatuses)
+        if (goal.target in effective) { reached.add(gid); return@forEach }
+        nextHop(edges, effective, goal.target)?.let { e ->
+            val r = resolveEdge(e, gid, stepIndexOf, effective)
             out[r.instruction.text to r.instruction.highlight] = r
         }
     }
     // Passive tips: shown while their `from` status holds.
-    edges.filter { it.to == null && it.from in activeStatuses }.forEach { e ->
-        val r = resolveEdge(e, null, stepIndexOf, activeStatuses)
+    edges.filter { it.to == null && it.from in effective }.forEach { e ->
+        val r = resolveEdge(e, null, stepIndexOf, effective)
         out[r.instruction.text to r.instruction.highlight] = r
     }
     return GuidanceFrame(out.values.toList(), reached)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzInstructionOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/tutorial/AzInstructionOverlay.kt
@@ -1,7 +1,8 @@
 package com.hereliesaz.aznavrail.tutorial
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,7 +15,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
@@ -22,31 +24,31 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-
-private const val DIM_ALPHA = 0.7f
+import com.hereliesaz.aznavrail.LocalAzSafeZones
+import kotlin.math.abs
+import kotlin.math.hypot
+import kotlin.math.min
 
 /**
- * Renders the current guidance [resolved] instructions as callouts, **each placed next to its own
- * highlight target** (so the user sees, in place, how to accomplish each active goal), over a single
- * dim layer with a spotlight punch-out per target. Targets may be rail items (`itemBoundsCache`), the
- * active item ([activeItemId]), or host-registered arbitrary shapes ([targets], re-resolved live in the
- * draw scope so a moving on-screen object tracks every frame).
+ * Renders guidance as a **non-blocking coach**: a thin accent **outline** around each step's target and
+ * a small **callout** placed *near* (never on) that target, with a **pointer/arrow** connecting them.
  *
- * A **paged** edge (more than one step) reveals one step at a time; an informational step (no
- * `advanceWhen`, not the last step) is tap-advanceable — tapping its callout calls
- * [AzGuidanceController.advance]. Reactive/actionable steps still advance only when their status flips,
- * so the overlay never blocks the app during a real interaction. When [renderSlot] is non-null the host
- * draws the callout body itself (the dim/punch-out still draws).
+ * It never dims the screen and never intercepts input outside a callout — the app stays fully usable.
+ * Callouts avoid covering the target, other known UI (rail items / targets), each other, and the
+ * screen/safe-area edges. **Swiping a callout cancels tutorial mode** ([AzGuidanceController.skip]);
+ * tapping an informational step advances it ([AzGuidanceController.advance]). When [renderSlot] is
+ * non-null the host draws the callout body itself.
  */
 @Composable
 internal fun AzInstructionOverlay(
@@ -60,90 +62,112 @@ internal fun AzInstructionOverlay(
 ) {
     if (resolved.isEmpty()) return
     val density = LocalDensity.current
+    val safeZones = LocalAzSafeZones.current
     val screenWidthPx = with(density) { LocalConfiguration.current.screenWidthDp.dp.toPx() }
     val screenHeightPx = with(density) { LocalConfiguration.current.screenHeightDp.dp.toPx() }
-    val calloutWidthPx = with(density) { 240.dp.toPx() }
-    val gapPx = with(density) { 8.dp.toPx() }
-    val belowReservePx = with(density) { 96.dp.toPx() }
-    val cornerPx = with(density) { 16.dp.toPx() }
+    val marginPx = with(density) { 8.dp.toPx() }
+    val safe = Rect(
+        left = marginPx,
+        top = with(density) { safeZones.top.toPx() } + marginPx,
+        right = screenWidthPx - marginPx,
+        bottom = screenHeightPx - with(density) { safeZones.bottom.toPx() } - marginPx,
+    )
+    val maxCalloutWidthPx = with(density) { 240.dp.toPx() }
+    val defaultCalloutHeightPx = with(density) { 84.dp.toPx() }
+    val gapPx = with(density) { 12.dp.toPx() }
+    val strokePx = with(density) { 2.dp.toPx() }
+    val outlinePadPx = with(density) { 4.dp.toPx() }
+    val arrowPx = with(density) { 12.dp.toPx() }
+    val swipeThresholdPx = with(density) { 48.dp.toPx() }
+
+    // Measured callout sizes (filled after first layout); a second pass re-places with the real size.
+    val sizes = remember { mutableStateMapOf<Int, Size>() }
+
+    // Resolve every step's target shape + bounds (re-runs if a target moves and is Compose-backed).
+    val targetRects: List<Rect?> = resolved.map {
+        it.instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)?.bounds()
+    }
+    val itemRects = itemBoundsCache.values.toList()
+
+    // Greedy placement: each callout near its own target, off obstacles (items + other targets +
+    // already-placed callouts), clamped fully into the safe area.
+    val placed = ArrayList<Rect>(resolved.size)
+    val placements: List<Rect> = resolved.indices.map { i ->
+        val size = sizes[i] ?: Size(maxCalloutWidthPx, defaultCalloutHeightPx)
+        val obstacles = ArrayList<Rect>(itemRects.size + resolved.size)
+        obstacles.addAll(itemRects)
+        targetRects.forEachIndexed { j, r -> if (j != i && r != null) obstacles.add(r) }
+        obstacles.addAll(placed)
+        val rect = placeCallout(targetRects[i], size, obstacles, safe, gapPx)
+        placed.add(rect)
+        rect
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // One dim layer, punched out at every resolved target. Targets are re-resolved INSIDE the draw
-        // scope, so a moving `azGuidanceTarget` shape repaints without a recomposition.
+        // Draw-only layer: outline each target and the connector to its callout. Re-resolved live in the
+        // draw scope so a moving target's outline tracks every frame. NO dim, NO input.
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
                 .drawBehind {
-                    drawRect(Color.Black.copy(alpha = DIM_ALPHA))
-                    resolved.forEach { r ->
-                        r.instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)
-                            ?.let { punchShape(it, cornerPx) }
+                    resolved.forEachIndexed { i, r ->
+                        val shape = r.instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)
+                        if (shape != null) {
+                            strokeOutline(shape, accent, strokePx, outlinePadPx)
+                            drawConnector(placements[i], shape.bounds(), accent, strokePx, arrowPx)
+                        }
                     }
                 },
         )
 
-        resolved.forEach { r ->
-            val instruction = r.instruction
-            val shape = instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)
+        resolved.forEachIndexed { i, r ->
+            val rect = placements[i]
+            val measured = sizes.containsKey(i)
+            val stepKey = r.edge.stepKey()
             val tappable = r.stepTotal > 1 && r.stepIndex < r.stepTotal - 1 &&
                 r.edge.steps.getOrNull(r.stepIndex)?.advanceWhen == null
-            val stepKey = r.edge.stepKey()
-            val onTap: (() -> Unit)? =
-                if (tappable && controller != null) ({ controller.advance(stepKey) }) else null
 
-            // Position adjacent to the (live) target, or float bottom-centre when there is no anchor.
-            val boundsProvider: () -> Rect? = {
-                instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)?.bounds()
-            }
-            PlacedCallout(
-                anchored = shape != null,
-                boundsProvider = boundsProvider,
-                screenWidthPx = screenWidthPx,
-                screenHeightPx = screenHeightPx,
-                calloutWidthPx = calloutWidthPx,
-                gapPx = gapPx,
-                belowReservePx = belowReservePx,
+            Box(
+                modifier = Modifier
+                    .graphicsLayer {
+                        translationX = rect.left
+                        translationY = rect.top
+                        alpha = if (measured) 1f else 0f // hide until measured to avoid a first-frame jump
+                    }
+                    .widthIn(max = 240.dp)
+                    .onSizeChanged { sizes[i] = Size(it.width.toFloat(), it.height.toFloat()) }
+                    // Swipe a callout away → cancel tutorial mode (persisted skip). The callout is the
+                    // only input-consuming element; everything else on screen passes through.
+                    .pointerInput(controller) {
+                        var total = Offset.Zero
+                        var fired = false
+                        detectDragGestures(
+                            onDragStart = { total = Offset.Zero; fired = false },
+                            onDragEnd = { total = Offset.Zero; fired = false },
+                            onDragCancel = { total = Offset.Zero; fired = false },
+                        ) { change, drag ->
+                            change.consume()
+                            total += drag
+                            if (!fired && hypot(total.x, total.y) > swipeThresholdPx) {
+                                fired = true
+                                controller?.skip()
+                            }
+                        }
+                    }
+                    .then(
+                        if (tappable && controller != null) {
+                            Modifier.pointerInput(stepKey) { detectTapGestures { controller.advance(stepKey) } }
+                        } else Modifier,
+                    ),
             ) {
                 if (renderSlot != null) {
-                    renderSlot(r.toSnapshot(shape, activeItemId), shape?.bounds())
+                    val shape = r.instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)
+                    renderSlot(r.toSnapshot(shape, activeItemId), rect)
                 } else {
-                    Callout(instruction, accent, r.stepIndex, r.stepTotal, onTap)
+                    Callout(r.instruction, accent, r.stepIndex, r.stepTotal, tappable)
                 }
             }
         }
-    }
-}
-
-/** Places [content] adjacent to the live target bounds (re-read in the draw phase) or floats it. */
-@Composable
-private fun PlacedCallout(
-    anchored: Boolean,
-    boundsProvider: () -> Rect?,
-    screenWidthPx: Float,
-    screenHeightPx: Float,
-    calloutWidthPx: Float,
-    gapPx: Float,
-    belowReservePx: Float,
-    content: @Composable () -> Unit,
-) {
-    if (!anchored) {
-        Box(Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.BottomCenter) { content() }
-    } else {
-        // Offset in the draw phase via graphicsLayer so re-positioning during rail animation / a moving
-        // target never triggers a parent layout pass or recomposition.
-        Box(
-            modifier = Modifier.graphicsLayer {
-                // A moving/dynamic target can be momentarily unmeasured; hide (alpha 0) rather than let
-                // the callout flash at (0,0) with the default translation for that frame.
-                val b = boundsProvider()
-                if (b == null) { alpha = 0f; return@graphicsLayer }
-                alpha = 1f
-                translationX = b.left.coerceIn(0f, (screenWidthPx - calloutWidthPx).coerceAtLeast(0f))
-                translationY = if (b.bottom + belowReservePx < screenHeightPx) b.bottom + gapPx
-                else (b.top - belowReservePx).coerceAtLeast(0f)
-            },
-        ) { content() }
     }
 }
 
@@ -153,14 +177,13 @@ private fun Callout(
     accent: Color,
     stepIndex: Int,
     stepTotal: Int,
-    onTap: (() -> Unit)?,
+    tappable: Boolean,
 ) {
     Column(
         modifier = Modifier
             .widthIn(max = 240.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surface)
-            .then(if (onTap != null) Modifier.clickable { onTap() } else Modifier)
             .padding(12.dp),
     ) {
         instruction.title?.let {
@@ -168,46 +191,72 @@ private fun Callout(
         }
         Text(instruction.text, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface)
         instruction.media?.let { Box(Modifier.padding(top = 8.dp)) { it() } }
-        if (stepTotal > 1) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    "${stepIndex + 1} / $stepTotal",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                if (onTap != null) {
-                    Text("Tap to continue ▸", style = MaterialTheme.typography.labelSmall, color = accent)
-                }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                if (stepTotal > 1) "${stepIndex + 1} / $stepTotal" else "swipe to dismiss",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (tappable) {
+                Text("Tap to continue ▸", style = MaterialTheme.typography.labelSmall, color = accent)
             }
         }
     }
 }
 
-/** Punches a transparent hole the shape's geometry out of the dim layer (window-space px). */
-private fun DrawScope.punchShape(shape: AzGuideShape, defaultCornerPx: Float) {
+/** Strokes the target's geometry (no fill, no dim) so the control stays visible and usable. */
+private fun DrawScope.strokeOutline(shape: AzGuideShape, color: Color, strokeWidth: Float, pad: Float) {
+    val style = Stroke(width = strokeWidth)
     when (shape) {
         is AzGuideShape.Circle -> drawCircle(
-            color = Color.Transparent,
-            radius = shape.radius + shape.padding,
+            color = color,
+            radius = shape.radius + shape.padding + pad,
             center = Offset(shape.cx, shape.cy),
-            blendMode = BlendMode.Clear,
+            style = style,
         )
         is AzGuideShape.Rect -> drawRoundRect(
-            color = Color.Transparent,
-            topLeft = Offset(shape.left - shape.padding, shape.top - shape.padding),
-            size = Size(shape.width + 2f * shape.padding, shape.height + 2f * shape.padding),
-            cornerRadius = CornerRadius(if (shape.cornerRadius > 0f) shape.cornerRadius else defaultCornerPx),
-            blendMode = BlendMode.Clear,
+            color = color,
+            topLeft = Offset(shape.left - shape.padding - pad, shape.top - shape.padding - pad),
+            size = Size(shape.width + 2f * (shape.padding + pad), shape.height + 2f * (shape.padding + pad)),
+            cornerRadius = CornerRadius(if (shape.cornerRadius > 0f) shape.cornerRadius else 12f),
+            style = style,
         )
-        is AzGuideShape.Path -> drawPath(
-            path = shape.toComposePath(),
-            color = Color.Transparent,
-            blendMode = BlendMode.Clear,
-        )
+        is AzGuideShape.Path -> drawPath(shape.toComposePath(), color, style = style)
     }
+}
+
+/** Draws a line from the [callout]'s edge to the [target]'s edge with a small arrowhead at the target. */
+private fun DrawScope.drawConnector(callout: Rect, target: Rect, color: Color, strokeWidth: Float, arrow: Float) {
+    val start = edgePoint(callout, target.center)
+    val end = edgePoint(target, callout.center)
+    val dx = end.x - start.x
+    val dy = end.y - start.y
+    val len = hypot(dx, dy)
+    if (len < 1f) return // callout overlaps the target (shouldn't happen) — skip the connector
+    drawLine(color, start, end, strokeWidth = strokeWidth)
+    val ux = dx / len
+    val uy = dy / len
+    val leftWing = Offset(end.x - arrow * (ux * 0.86f - uy * 0.5f), end.y - arrow * (uy * 0.86f + ux * 0.5f))
+    val rightWing = Offset(end.x - arrow * (ux * 0.86f + uy * 0.5f), end.y - arrow * (uy * 0.86f - ux * 0.5f))
+    drawLine(color, end, leftWing, strokeWidth = strokeWidth)
+    drawLine(color, end, rightWing, strokeWidth = strokeWidth)
+}
+
+/** The point on [rect]'s border along the ray from its centre toward [towards]. */
+private fun edgePoint(rect: Rect, towards: Offset): Offset {
+    val c = rect.center
+    val dx = towards.x - c.x
+    val dy = towards.y - c.y
+    if (dx == 0f && dy == 0f) return c
+    val hw = rect.width / 2f
+    val hh = rect.height / 2f
+    val sx = if (dx != 0f) hw / abs(dx) else Float.MAX_VALUE
+    val sy = if (dy != 0f) hh / abs(dy) else Float.MAX_VALUE
+    val scale = min(sx, sy).coerceIn(0f, 1f)
+    return Offset(c.x + dx * scale, c.y + dy * scale)
 }
 
 /** Converts an [AzGuideShape.Path]'s window-space commands into a Compose [Path]. */

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -706,6 +706,20 @@ taps at all. Instead it observes **status predicates** and reacts:
 - **Every active goal at once.** If several goals are active, each shows its own instruction
   simultaneously as a callout next to the control that satisfies its next hop.
 
+**Presentation is non-blocking and never dims.** Guidance draws a thin **outline** around the step's
+target and a small **callout placed near (never on) that target**, with a **pointer/arrow** connecting
+them. It **never darkens the screen** and **never intercepts input outside a callout** — the app stays
+fully usable while guidance is up, so the user can actually perform the action the step teaches.
+Callouts are positioned to avoid covering the target, other known UI (rail items / registered targets),
+each other, and the screen's safe-area edges; several callouts can share the screen, each by its own
+target. A step that has been shown and acted on is **never shown again**, even if the user later undoes
+the action and the router would otherwise re-route to it.
+
+**Skipping & replay.** The user can **swipe a callout away to cancel tutorial mode** — that skip is
+persisted (`SharedPreferences` / `localStorage`), so a skipped tutorial is **not** shown again. To let
+it run again, call `controller.resetGuidance(goalId)` (or `resetGuidance()` for all). Completed and
+skipped goals are both ignored by `activate()` until reset.
+
 **Predicate observation timing.** Predicates that read Compose/React state (a `mutableStateOf`,
 a React state value, a derived value) are observed **instantly**. Predicates that read
 **non-reactive** sources — a `StateFlow.value`, a plain `var`, a `ref`, an external store — are
@@ -716,9 +730,11 @@ control passes `highlightItemId`; the callout anchors next to that item's measur
 any item-anchored UI, the item must be laid out — if it lives inside a collapsed host, use the host's
 `expandWhen` (see §4) so the item's bounds are known when the callout needs to anchor.
 
-**Goal activation is developer-driven.** There is no built-in end-user picker. You activate goals
-imperatively through the `AzGuidanceController` (`activate(id)`), or declare `autoStartWhen` on a
-goal so it self-activates (typically for onboarding) when its condition becomes true.
+**Goal activation is developer-driven.** There is no built-in end-user picker — **starting is always
+your decision**. You activate goals imperatively through the `AzGuidanceController` (`activate(id)`).
+`autoStartWhen` (a status id that self-activates a goal) still exists but is **discouraged**; prefer an
+explicit `activate(...)`. Either way, a goal that the user has **completed or skipped never (re)starts**
+until you call `resetGuidance(...)`.
 
 ### 9.3 Help/Info Overlay Integration
 
@@ -788,6 +804,12 @@ val finished = controller.isCompleted("onboarding")
 // Mark a status reached manually (e.g. from an external success callback):
 controller.markReached("profileComplete")
 
+// Skip (usually driven by the swipe-to-cancel gesture) and replay:
+controller.skip("onboarding")      // dismiss one goal (persisted)
+controller.skip()                  // cancel tutorial mode: skip all active goals + disable
+controller.resetGuidance("onboarding") // clear completion + dismissal so it can run again
+controller.resetGuidance()         // clear all
+
 // Turn the whole framework on/off:
 controller.disable()
 controller.enable()
@@ -795,9 +817,10 @@ controller.enable()
 
 You can also obtain a controller via `rememberAzGuidanceController()` and read it through
 `LocalAzGuidanceController.current`. `AzGuidanceController` lives in package
-`com.hereliesaz.aznavrail.tutorial` and exposes: `enabled`, `activeGoals: List<String>`,
-`completedGoals: List<String>`, `enable()`, `disable()`, `activate(id)`, `deactivate(id)`,
-`markReached(id)`, `isCompleted(id)`.
+`com.hereliesaz.aznavrail.tutorial` and exposes: `enabled`, `activeGoals`, `completedGoals`,
+`dismissedGoals`, `enable()`, `disable()`, `activate(id)`, `deactivate(id)`, `markReached(id)`,
+`isCompleted(id)`, `isDismissed(id)`, `skip(id?)`, `resetGuidance(id?)`, and (for paged edges)
+`advance`/`next`/`back` plus the observable `currentInstructions`/`current`/`currentFlow`.
 
 Persistence: completed goals persist in `SharedPreferences` under key
 `az_navrail_completed_goals`.
@@ -868,10 +891,10 @@ Also exported for advanced use: `AzGuidanceProvider`, `AzInstructionOverlay`, `u
 Persistence: completed goals persist to `localStorage` (and `AsyncStorage` on React Native) under key
 `az_navrail_completed_goals`.
 
-**React overlay parity note:** the React/web overlay draws an **accent ring** around each target over
-a light dim — it does **not** punch a true spotlight hole out of the dim layer (no Android-style
-`BlendMode.Clear` punch-out). This is a minor visual difference; routing and advancement behave
-identically.
+**Platform parity note:** neither platform dims the screen. Android strokes the target's true geometry
+(circle/rect/path) and draws an arrowhead to the callout; React rings the target's bounding box and
+draws a plain connector line (per-shape masking / arrowheads aren't portable on React Native). Routing,
+placement, and advancement behave identically.
 
 ### 9.6 Highlighting arbitrary on-screen targets (`azGuidanceTarget`)
 
@@ -882,8 +905,9 @@ rail item** — a ball drawn over a camera/AR canvas, an aiming line, an on-scre
 reference it from an edge (or a step) with `highlightTargetId`. If the function returns `null` (target
 absent), the callout gracefully degrades to text-only.
 
-The library both **draws a default spotlight** for the shape (circle/rect/path punch-out) **and**
-publishes the resolved shape on the controller (see §9.8) so a host can draw its own highlight.
+The library both **draws a non-blocking outline** around the shape (circle/rect/path) **and** publishes
+the resolved shape on the controller (see §9.8) so a host can draw its own highlight. It never dims or
+covers the target.
 
 ```kotlin
 // Window-space shape, recomputed each frame (read Compose state inside for smooth tracking).
@@ -985,9 +1009,9 @@ azSuppressGuide(settleMs = 700) { gesture.inProgress }
 
 ### 9.10 Custom callout rendering (optional)
 
-To draw the callout body yourself (over a camera/canvas), register a renderer; the dim + spotlight
-punch-out still draw, but the callout content is yours. It receives the current snapshot and the
-resolved target bounds.
+To draw the callout body yourself (over a camera/canvas), register a renderer; the outline + connector
+still draw, but the callout content is yours. It receives the current snapshot and the resolved target
+bounds.
 
 ```kotlin
 azGuideRenderer { snapshot, bounds -> MyCallout(snapshot, bounds) }

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/tutorial/AzCalloutPlacementTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/tutorial/AzCalloutPlacementTest.kt
@@ -1,0 +1,69 @@
+package com.hereliesaz.aznavrail.tutorial
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Verifies the non-blocking callout placement: near the target, off obstacles, inside the safe area. */
+class AzCalloutPlacementTest {
+
+    private val safe = Rect(0f, 0f, 1000f, 2000f)
+    private val size = Size(240f, 100f)
+
+    @Test
+    fun `overlapArea computes the intersection`() {
+        assertEquals(25f, overlapArea(Rect(0f, 0f, 10f, 10f), Rect(5f, 5f, 15f, 15f)))
+        assertEquals(0f, overlapArea(Rect(0f, 0f, 10f, 10f), Rect(20f, 20f, 30f, 30f)))
+    }
+
+    @Test
+    fun `prefers below the target when there is room`() {
+        val target = Rect(400f, 400f, 600f, 500f)
+        val r = placeCallout(target, size, obstacles = emptyList(), safe = safe)
+        assertEquals(400f, r.left)
+        assertEquals(508f, r.top) // target.bottom + gap(8)
+    }
+
+    @Test
+    fun `never covers the target`() {
+        val target = Rect(400f, 400f, 600f, 500f)
+        val r = placeCallout(target, size, obstacles = emptyList(), safe = safe)
+        assertEquals(0f, overlapArea(r, target))
+    }
+
+    @Test
+    fun `flips above when below would leave the safe area`() {
+        val target = Rect(400f, 1850f, 600f, 1950f)
+        val r = placeCallout(target, size, obstacles = emptyList(), safe = safe)
+        assertEquals(1742f, r.top) // target.top - height - gap
+        assertTrue(r.bottom <= safe.bottom)
+        assertEquals(0f, overlapArea(r, target))
+    }
+
+    @Test
+    fun `avoids an obstacle blocking the preferred side`() {
+        val target = Rect(400f, 400f, 600f, 500f)
+        val obstacleBelow = Rect(380f, 500f, 680f, 700f)
+        val r = placeCallout(target, size, obstacles = listOf(obstacleBelow), safe = safe)
+        assertEquals(0f, overlapArea(r, obstacleBelow))
+        assertEquals(0f, overlapArea(r, target))
+    }
+
+    @Test
+    fun `stays fully inside the safe area`() {
+        val target = Rect(950f, 50f, 999f, 99f) // hard against the right edge
+        val r = placeCallout(target, size, obstacles = emptyList(), safe = safe)
+        assertTrue(r.left >= safe.left && r.right <= safe.right)
+        assertTrue(r.top >= safe.top && r.bottom <= safe.bottom)
+    }
+
+    @Test
+    fun `untargeted callouts spread off each other`() {
+        val placed = Rect(0f, 0f, 240f, 100f) // a callout already placed top-left
+        val r = placeCallout(target = null, size = size, obstacles = listOf(placed), safe = safe)
+        assertEquals(0f, overlapArea(r, placed))
+        assertTrue(r.left >= safe.left && r.right <= safe.right && r.top >= safe.top && r.bottom <= safe.bottom)
+    }
+}

--- a/aznavrail/src/test/java/com/hereliesaz/aznavrail/tutorial/AzGuidanceLifecycleTest.kt
+++ b/aznavrail/src/test/java/com/hereliesaz/aznavrail/tutorial/AzGuidanceLifecycleTest.kt
@@ -1,0 +1,74 @@
+package com.hereliesaz.aznavrail.tutorial
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Verifies skip/dismiss persistence, replay reset, and the no-repeat (consumed-status) routing. */
+class AzGuidanceLifecycleTest {
+
+    private fun edge(from: String, to: String?, text: String) = AzEdge(from, to, AzInstruction(text))
+
+    @Test
+    fun `a consumed hop is not re-shown`() {
+        val edges = listOf(edge("a", "b", "Open menu"), edge("b", "c", "Tap X"))
+        val goals = mapOf("g" to AzGoal("g", "c"))
+        // From {a}: the first hop "Open menu" shows.
+        assertEquals("Open menu", routeInstructions(edges, goals, listOf("g"), setOf("a")).instructions.single().text)
+        // Once "b" is consumed (its hop was shown + taken), routing skips it even though we're back at {a}.
+        val f = routeInstructions(edges, goals, listOf("g"), setOf("a"), consumedStatuses = setOf("b"))
+        assertEquals("Tap X", f.instructions.single().text)
+    }
+
+    @Test
+    fun `skip deactivates, persists dismissal, and blocks re-activation until reset`() {
+        val c = AzGuidanceController()
+        c.activate("g")
+        assertTrue("g" in c.activeGoals)
+        assertTrue(c.enabled)
+
+        c.skip("g")
+        assertFalse("g" in c.activeGoals)
+        assertTrue(c.isDismissed("g"))
+
+        c.activate("g") // respected: a skipped tutorial does not re-show
+        assertFalse("g" in c.activeGoals)
+
+        c.resetGuidance("g")
+        assertFalse(c.isDismissed("g"))
+        c.activate("g") // now it can replay
+        assertTrue("g" in c.activeGoals)
+    }
+
+    @Test
+    fun `global skip cancels tutorial mode`() {
+        val c = AzGuidanceController()
+        c.activate("g1"); c.activate("g2")
+        c.skip()
+        assertTrue(c.activeGoals.isEmpty())
+        assertFalse(c.enabled)
+        assertTrue(c.isDismissed("g1") && c.isDismissed("g2"))
+    }
+
+    @Test
+    fun `completed goals are not re-activated until reset`() {
+        val c = AzGuidanceController()
+        c.activate("g"); c.markReached("g")
+        assertTrue(c.isCompleted("g"))
+        c.activate("g")
+        assertFalse("g" in c.activeGoals)
+        c.resetGuidance()
+        c.activate("g")
+        assertTrue("g" in c.activeGoals)
+    }
+
+    @Test
+    fun `consume accumulates and disable clears it`() {
+        val c = AzGuidanceController()
+        c.consume("x")
+        assertTrue("x" in c.consumedStatuses)
+        c.disable()
+        assertTrue(c.consumedStatuses.isEmpty())
+    }
+}

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -706,6 +706,20 @@ taps at all. Instead it observes **status predicates** and reacts:
 - **Every active goal at once.** If several goals are active, each shows its own instruction
   simultaneously as a callout next to the control that satisfies its next hop.
 
+**Presentation is non-blocking and never dims.** Guidance draws a thin **outline** around the step's
+target and a small **callout placed near (never on) that target**, with a **pointer/arrow** connecting
+them. It **never darkens the screen** and **never intercepts input outside a callout** — the app stays
+fully usable while guidance is up, so the user can actually perform the action the step teaches.
+Callouts are positioned to avoid covering the target, other known UI (rail items / registered targets),
+each other, and the screen's safe-area edges; several callouts can share the screen, each by its own
+target. A step that has been shown and acted on is **never shown again**, even if the user later undoes
+the action and the router would otherwise re-route to it.
+
+**Skipping & replay.** The user can **swipe a callout away to cancel tutorial mode** — that skip is
+persisted (`SharedPreferences` / `localStorage`), so a skipped tutorial is **not** shown again. To let
+it run again, call `controller.resetGuidance(goalId)` (or `resetGuidance()` for all). Completed and
+skipped goals are both ignored by `activate()` until reset.
+
 **Predicate observation timing.** Predicates that read Compose/React state (a `mutableStateOf`,
 a React state value, a derived value) are observed **instantly**. Predicates that read
 **non-reactive** sources — a `StateFlow.value`, a plain `var`, a `ref`, an external store — are
@@ -716,9 +730,11 @@ control passes `highlightItemId`; the callout anchors next to that item's measur
 any item-anchored UI, the item must be laid out — if it lives inside a collapsed host, use the host's
 `expandWhen` (see §4) so the item's bounds are known when the callout needs to anchor.
 
-**Goal activation is developer-driven.** There is no built-in end-user picker. You activate goals
-imperatively through the `AzGuidanceController` (`activate(id)`), or declare `autoStartWhen` on a
-goal so it self-activates (typically for onboarding) when its condition becomes true.
+**Goal activation is developer-driven.** There is no built-in end-user picker — **starting is always
+your decision**. You activate goals imperatively through the `AzGuidanceController` (`activate(id)`).
+`autoStartWhen` (a status id that self-activates a goal) still exists but is **discouraged**; prefer an
+explicit `activate(...)`. Either way, a goal that the user has **completed or skipped never (re)starts**
+until you call `resetGuidance(...)`.
 
 ### 9.3 Help/Info Overlay Integration
 
@@ -788,6 +804,12 @@ val finished = controller.isCompleted("onboarding")
 // Mark a status reached manually (e.g. from an external success callback):
 controller.markReached("profileComplete")
 
+// Skip (usually driven by the swipe-to-cancel gesture) and replay:
+controller.skip("onboarding")      // dismiss one goal (persisted)
+controller.skip()                  // cancel tutorial mode: skip all active goals + disable
+controller.resetGuidance("onboarding") // clear completion + dismissal so it can run again
+controller.resetGuidance()         // clear all
+
 // Turn the whole framework on/off:
 controller.disable()
 controller.enable()
@@ -795,9 +817,10 @@ controller.enable()
 
 You can also obtain a controller via `rememberAzGuidanceController()` and read it through
 `LocalAzGuidanceController.current`. `AzGuidanceController` lives in package
-`com.hereliesaz.aznavrail.tutorial` and exposes: `enabled`, `activeGoals: List<String>`,
-`completedGoals: List<String>`, `enable()`, `disable()`, `activate(id)`, `deactivate(id)`,
-`markReached(id)`, `isCompleted(id)`.
+`com.hereliesaz.aznavrail.tutorial` and exposes: `enabled`, `activeGoals`, `completedGoals`,
+`dismissedGoals`, `enable()`, `disable()`, `activate(id)`, `deactivate(id)`, `markReached(id)`,
+`isCompleted(id)`, `isDismissed(id)`, `skip(id?)`, `resetGuidance(id?)`, and (for paged edges)
+`advance`/`next`/`back` plus the observable `currentInstructions`/`current`/`currentFlow`.
 
 Persistence: completed goals persist in `SharedPreferences` under key
 `az_navrail_completed_goals`.
@@ -868,10 +891,10 @@ Also exported for advanced use: `AzGuidanceProvider`, `AzInstructionOverlay`, `u
 Persistence: completed goals persist to `localStorage` (and `AsyncStorage` on React Native) under key
 `az_navrail_completed_goals`.
 
-**React overlay parity note:** the React/web overlay draws an **accent ring** around each target over
-a light dim — it does **not** punch a true spotlight hole out of the dim layer (no Android-style
-`BlendMode.Clear` punch-out). This is a minor visual difference; routing and advancement behave
-identically.
+**Platform parity note:** neither platform dims the screen. Android strokes the target's true geometry
+(circle/rect/path) and draws an arrowhead to the callout; React rings the target's bounding box and
+draws a plain connector line (per-shape masking / arrowheads aren't portable on React Native). Routing,
+placement, and advancement behave identically.
 
 ### 9.6 Highlighting arbitrary on-screen targets (`azGuidanceTarget`)
 
@@ -882,8 +905,9 @@ rail item** — a ball drawn over a camera/AR canvas, an aiming line, an on-scre
 reference it from an edge (or a step) with `highlightTargetId`. If the function returns `null` (target
 absent), the callout gracefully degrades to text-only.
 
-The library both **draws a default spotlight** for the shape (circle/rect/path punch-out) **and**
-publishes the resolved shape on the controller (see §9.8) so a host can draw its own highlight.
+The library both **draws a non-blocking outline** around the shape (circle/rect/path) **and** publishes
+the resolved shape on the controller (see §9.8) so a host can draw its own highlight. It never dims or
+covers the target.
 
 ```kotlin
 // Window-space shape, recomputed each frame (read Compose state inside for smooth tracking).
@@ -985,9 +1009,9 @@ azSuppressGuide(settleMs = 700) { gesture.inProgress }
 
 ### 9.10 Custom callout rendering (optional)
 
-To draw the callout body yourself (over a camera/canvas), register a renderer; the dim + spotlight
-punch-out still draw, but the callout content is yours. It receives the current snapshot and the
-resolved target bounds.
+To draw the callout body yourself (over a camera/canvas), register a renderer; the outline + connector
+still draw, but the callout content is yours. It receives the current snapshot and the resolved target
+bounds.
 
 ```kotlin
 azGuideRenderer { snapshot, bounds -> MyCallout(snapshot, bounds) }

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -374,7 +374,7 @@ fun azGoal(id: String, target: String, label: String? = null, autoStartWhen: Str
 fun azGuidanceTarget(id: String, shape: () -> AzGuideShape?)
 // Hide guidance while `predicate` is true; re-show after `settleMs` once it clears.
 fun azSuppressGuide(settleMs: Long = 700, predicate: () -> Boolean)
-// Draw the callout body yourself (the dim/spotlight still draw).
+// Draw the callout body yourself (the non-blocking outline + connector still draw).
 fun azGuideRenderer(renderer: @Composable (AzGuidanceSnapshot, Rect?) -> Unit)
 ~~~
 
@@ -455,12 +455,20 @@ function Launcher() {
 }
 ~~~
 
-`AzGuidanceController` (both platforms): `enabled`, `activeGoals`, `completedGoals`, `enable()`,
-`disable()`, `activate(goalId)`, `deactivate(goalId)`, `markReached(goalId)`, `isCompleted(goalId)`.
-For paged edges it also exposes `advance(stepKey)` / `next(stepKey)` / `back(stepKey)` and a no-arg
-`advance()`, and for observation `currentInstructions` / `current` (an `AzGuidanceSnapshot` list; Kotlin
-also has `currentFlow`). Completed goals persist under key `az_navrail_completed_goals` (Android
-`SharedPreferences` file `az_tutorial_prefs`; React `localStorage` / RN `AsyncStorage`).
+Guidance is presented as a **non-blocking coach**: a thin outline around each step's target and a small
+callout placed near it (with a connector), never dimming the screen or intercepting input outside a
+callout. The user **swipes a callout away to cancel** (persisted); a step shown + acted on is never
+re-shown. **Starting is always developer-driven** — call `activate(...)` (the `autoStartWhen` status-id
+self-start still exists but is discouraged, and honours completion + skip).
+
+`AzGuidanceController` (both platforms): `enabled`, `activeGoals`, `completedGoals`, `dismissedGoals`,
+`enable()`, `disable()`, `activate(goalId)`, `deactivate(goalId)`, `markReached(goalId)`,
+`isCompleted(goalId)`, `isDismissed(goalId)`, `skip(goalId?)` (cancel one or, with no arg, all),
+`resetGuidance(goalId?)` (replay). For paged edges it also exposes `advance(stepKey)` / `next(stepKey)`
+/ `back(stepKey)` and a no-arg `advance()`, and for observation `currentInstructions` / `current` (an
+`AzGuidanceSnapshot` list; Kotlin also has `currentFlow`). Completion persists under
+`az_navrail_completed_goals` and skips under `az_navrail_dismissed_goals` (Android `SharedPreferences`
+file `az_tutorial_prefs`; React `localStorage` / RN `AsyncStorage`).
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-aznavrail = "9.11"
+aznavrail = "9.12"
 # Android & Jetpack
 composeBom = "2026.05.00"
 coreKtx = "1.18.0"


### PR DESCRIPTION
…, no repeats

Reworks the status-driven guidance overlay from a modal tutorial into a lightweight, pass-through coach, per product feedback.

- Never dims or blocks: removed the full-screen dim + spotlight punch-out (Android) and the dim layer (React). Each step now draws a thin outline around its target with a connector to the callout; nothing outside a callout consumes input, so the app stays fully interactive.
- Smart placement: new pure `placeCallout` solver positions each callout near its own target and off the target, other known UI (rail items / registered targets), sibling callouts, and the safe-area edges — no more bottom-stacking or clipped text. Mirrored in Kotlin + TS with unit tests.
- Swipe-to-cancel: swiping a callout cancels tutorial mode. New controller surface `skip(id?)` / `dismissedGoals` / `isDismissed` / `resetGuidance(id?)`; skips persist (`az_navrail_dismissed_goals`). A completed or skipped goal is never (re)shown until `resetGuidance`, and `activate()` respects that.
- No repeats: a step shown + acted on is consumed for the session and never re-shown, even if the user undoes the action (routing over active ∪ consumed).
- Start stays developer-driven; `autoStartWhen` kept but discouraged and now honors skip/completion.

Docs (§9, DSL.md, KNOWN_GAPS), embedded guides synced, versions bumped (aznavrail 9.12, aznavrail-react 0.6.0), SampleApp replay controls.


Claude-Session: https://claude.ai/code/session_012EeG55c7AAcPtbr8fJWFvG