### PR TITLE
WP7 kinetic fidelity: 90° hinged swing, accordion footer, split About, drawer knobs

### DIFF
--- a/.github/scripts/bake_more_from_az.py
+++ b/.github/scripts/bake_more_from_az.py
@@ -166,6 +166,102 @@ def resolve_web(url):
     }
 
 
+def _head_ok(url):
+    """True if `url` is reachable with a 200-class status. Uses GET (some CDNs 405 on HEAD)."""
+    status, _ = http_get(url)
+    return status == 200
+
+
+# Standard Android launcher-icon paths, densities from highest to lowest, webp first for size.
+_LAUNCHER_ICON_PATHS = [
+    "app/src/main/res/mipmap-xxxhdpi/ic_launcher.webp",
+    "app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+    "app/src/main/res/mipmap-xxhdpi/ic_launcher.webp",
+    "app/src/main/res/mipmap-xxhdpi/ic_launcher.png",
+    "app/src/main/res/mipmap-xhdpi/ic_launcher.webp",
+    "app/src/main/res/mipmap-xhdpi/ic_launcher.png",
+    "app/src/main/res/mipmap-hdpi/ic_launcher.png",
+]
+
+# Common banner names (either / or). Case-sensitive lookup — GitHub raw is case-sensitive.
+_BANNER_NAMES = [
+    "docs/banner.png", "docs/banner.webp", "docs/banner.jpg", "docs/banner.jpeg",
+    "docs/Banner.png", "docs/Banner.webp",
+    "docs/hero.png", "docs/hero.webp",
+]
+
+
+def resolve_repo_icon(owner, repo, branch):
+    """Try to find an app-launcher icon in a GitHub repo. Returns a raw.githubusercontent URL or None.
+
+    Order: standard mipmap paths → GitHub contents API tree walk for `ic_launcher*.{png,webp}` under
+    any `res/mipmap-*` dir → adaptive-icon xml parse → repo social preview as a last resort."""
+    raw_root = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}"
+    for path in _LAUNCHER_ICON_PATHS:
+        url = f"{raw_root}/{path}"
+        if _head_ok(url):
+            return url
+
+    # Tree-walk the contents API — cheap when the standard paths miss (Compose Multiplatform layouts,
+    # non-`app/` roots).  We ask for the whole tree once.
+    status, body = http_get(
+        f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1", token=True,
+    )
+    if status == 200:
+        try:
+            tree = json.loads(body).get("tree") or []
+        except Exception:
+            tree = []
+        candidates = []
+        for entry in tree:
+            path = (entry.get("path") or "") if isinstance(entry, dict) else ""
+            if not path or entry.get("type") != "blob":
+                continue
+            lower = path.lower()
+            if "/mipmap-" in lower and lower.rsplit("/", 1)[-1].startswith("ic_launcher") and (
+                lower.endswith(".png") or lower.endswith(".webp")
+            ):
+                candidates.append(path)
+        # Prefer highest density.
+        def density_key(p):
+            for i, d in enumerate(("xxxhdpi", "xxhdpi", "xhdpi", "hdpi", "mdpi")):
+                if d in p:
+                    return i
+            return 99
+        candidates.sort(key=density_key)
+        if candidates:
+            return f"{raw_root}/{candidates[0]}"
+
+        # Adaptive-icon fallback: parse foreground drawable name from the XML.
+        for entry in tree:
+            path = (entry.get("path") or "") if isinstance(entry, dict) else ""
+            if path.endswith("mipmap-anydpi-v26/ic_launcher.xml"):
+                status2, xml = http_get(f"{raw_root}/{path}")
+                if status2 == 200:
+                    m = re.search(r'android:drawable="@(?:mipmap|drawable)/([^"]+)"', xml or "")
+                    if m:
+                        name = m.group(1)
+                        base = path.rsplit("mipmap-anydpi-v26", 1)[0]
+                        for ext in ("png", "webp"):
+                            for kind in ("drawable", "mipmap-xxxhdpi", "mipmap-xxhdpi"):
+                                candidate = f"{base}{kind}/{name}.{ext}"
+                                if _head_ok(f"{raw_root}/{candidate}"):
+                                    return f"{raw_root}/{candidate}"
+
+    # Last resort: repo social preview (always 200, but is the repo card, not the app icon).
+    return f"https://opengraph.githubassets.com/1/{owner}/{repo}"
+
+
+def resolve_repo_banner(owner, repo, branch):
+    """Return a URL for docs/banner.* (or docs/hero.*) if the repo has one, else None."""
+    raw_root = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}"
+    for name in _BANNER_NAMES:
+        url = f"{raw_root}/{name}"
+        if _head_ok(url):
+            return url
+    return None
+
+
 def resolve_github(github_url):
     parsed = parse_repo(github_url)
     if not parsed:
@@ -191,7 +287,8 @@ def resolve_github(github_url):
             break
 
     # Icon must be THAT APP's icon — never the owner's GitHub avatar. Sourced (in order) from the
-    # Play listing's og:image, else the app website's og:image; blank falls back to initials in-app.
+    # Play listing's og:image, else the app website's og:image, else the launcher icon shipped in the
+    # repo itself; blank falls back to initials in-app.
     app = {
         "name": meta.get("name") or repo,
         "iconUrl": "",
@@ -218,6 +315,19 @@ def resolve_github(github_url):
         app["isPwa"] = detect_pwa(whtml) if ws == 200 else False
         if not app["iconUrl"] and ws == 200:
             app["iconUrl"] = og(whtml, "image") or ""
+
+    # Repo fallback for the icon — walk the launcher-icon paths and adaptive-icon xml. Runs whenever
+    # Play/website resolvers left the iconUrl blank; also runs when the current value is the owner's
+    # avatar (which the runtime blocks) so we replace it with something usable.
+    if not app["iconUrl"] or "avatars.githubusercontent.com" in app["iconUrl"]:
+        repo_icon = resolve_repo_icon(owner, repo, branch)
+        if repo_icon:
+            app["iconUrl"] = repo_icon
+
+    # Banner from the repo's docs folder — displayed at the top of the app's info in the About page.
+    banner = resolve_repo_banner(owner, repo, branch)
+    if banner:
+        app["bannerUrl"] = banner
 
     return app
 

--- a/README.md
+++ b/README.md
@@ -497,10 +497,16 @@ neighbouring widgets.
 ### Kinetic Typography (Windows-Phone-7 style)
 
 AzNavRail can animate its menu words natively — a staggered **turnstile** entrance/exit (each item
-swings in around the docked edge), a 3D **tilt-on-press**, and an **`itemTextStyle`** override so the
-words can be big/light/wide Metro type. It's config-driven (preset enums, no free-composable escape
-hatch). In **FAB / floating** mode, where there's no docked edge to hinge on, the cascade degrades to
-a vertical up/down slide.
+swings 90° around the docked edge, edge-on → flat, **no fade, no vertical slide**), a 3D
+**tilt-on-press**, and an **`itemTextStyle`** override so the words can be big/light/wide Metro
+type. It's config-driven (preset enums, no free-composable escape hatch). In **FAB / floating**
+mode, where there's no docked edge to hinge on, the cascade degrades to a vertical up/down slide.
+
+Default timing lets items **overlap heavily**: `entranceDurationMs = 720` and
+`entranceStaggerMs = 60` mean the next item begins ~60 ms after the previous begins *while* the
+previous is still animating. Once the last item begins, the **footer** (About / Feedback / @HereLiesAz)
+**unfolds like an accordion** from the top edge, so the whole rail-open motion completes in one
+continuous beat.
 
 Three surfaces animate:
 
@@ -550,6 +556,34 @@ AzDropdownMenu {
 `AzEntrance` is `None | Fade | SlideUp | Turnstile`; `AzExit` is `None | Fade | Turnstile`;
 `AzEasing.Wp7Decelerate` is the signature snappy curve (the default easing).
 
+### Menu-drawer look-and-feel (dim / side-alignment / kerning-justify)
+
+Three developer knobs on `azConfig` (and on the standalone `AzDropdownMenu`'s `azConfig`) shape the
+drawer itself. They only affect the **expanded-menu drawer** labels — small rail-button labels are
+unaffected.
+
+- **`dimBehindMenu`** (default `false`) plus **`dimBehindMenuAlpha`** (default `0.4`) — draws a
+  dim scrim over the rest of the app while the drawer is open. Tapping the scrim collapses it.
+- **`menuItemAlignment`** (`SIDE` default | `CENTER`) — labels hug the docked edge instead of
+  center-aligning. `SIDE` = `TextAlign.Start` when docked LEFT, `TextAlign.End` when RIGHT.
+- **`justifyMenuItems`** (default `true`) — measures each label's natural width and applies a
+  computed `letterSpacing` so it fills the row edge-to-edge (Word-style justify). Single-character
+  labels and labels wider than the row are skipped.
+
+```kotlin
+azConfig(
+    dimBehindMenu = true,
+    menuItemAlignment = AzMenuItemAlignment.SIDE, // default
+    justifyMenuItems = true,                       // default
+)
+```
+
+React:
+
+```tsx
+<AzNavRail settings={{ dimBehindMenu: true, menuItemAlignment: 'side', justifyMenuItems: true }} … />
+```
+
 ### Sizable Header Icon
 
 By default the app icon in the header sizes itself to the rail width. To pin it to an **exact
@@ -568,12 +602,16 @@ const settings: AzNavRailSettings = { headerIconSize: 48 };
 
 ### In-App About Reader
 
-The footer **About** item can open a built-in, themed **in-app documentation reader** instead of
-launching the browser. It **auto-discovers** your app's markdown docs — every `.md` file in the repo
-**root** and the **`docs/`** folder of the resolved repository — via the GitHub API, builds
-a table of contents, and renders each doc inline with a markdown renderer themed to the rail
-(`activeColor` links, `translucentBackground` surfaces). A **View on GitHub** button is pinned at the
-bottom with extra spacing.
+The footer **About** item opens a built-in, themed **in-app reader** split into two halves:
+
+- **Top half — docs TOC.** Auto-discovers every `.md` file in the resolved repo's root and `docs/`
+  folder via the GitHub API, builds a table of contents, and renders each doc inline with a markdown
+  renderer themed to the rail (`activeColor` links, `translucentBackground` surfaces).
+- **Bottom half — focused-hero More-from-Az carousel.** A horizontal carousel of the author's
+  other apps with a size pattern `small · medium · LARGE · medium · small`. The LARGE (center) item
+  is the currently active app; its **banner** (when the repo has `docs/banner.png` / `.webp` /
+  `.jpg`, or `docs/hero.*`), name, description, and link buttons (Play / Website / GitHub) render
+  below the carousel. Scroll the row to change the active app.
 
 **Repo resolution differs by platform:**
 

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/MainApp.kt
@@ -185,6 +185,10 @@ fun MainApp() {
             collapsedWidth = customization.collapsedWidth,
             showFooter = customization.showFooter,
             appRepositoryUrl = customization.appRepositoryUrl,
+            // WP7 menu-drawer knobs.
+            dimBehindMenu = customization.dimBehindMenu,
+            menuItemAlignment = customization.menuItemAlignment,
+            justifyMenuItems = customization.justifyMenuItems,
         )
 
         azTheme(

--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/CustomizationDemoScreen.kt
@@ -33,6 +33,7 @@ import com.hereliesaz.aznavrail.model.AzDropdownDesign
 import com.hereliesaz.aznavrail.model.AzEntrance
 import com.hereliesaz.aznavrail.model.AzExit
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
+import com.hereliesaz.aznavrail.model.AzMenuItemAlignment
 
 /** Live theme/config state surfaced from MainApp so the rail can re-key on each change. */
 data class CustomizationState(
@@ -47,6 +48,10 @@ data class CustomizationState(
     val helpLineColors: List<Color>,
     val vibrate: Boolean,
     val headerIconSize: Dp = Dp.Unspecified,
+    // New WP7 menu-drawer knobs.
+    val dimBehindMenu: Boolean = false,
+    val menuItemAlignment: AzMenuItemAlignment = AzMenuItemAlignment.SIDE,
+    val justifyMenuItems: Boolean = true,
 )
 
 private val headerIconShapes = AzHeaderIconShape.values().toList()
@@ -208,6 +213,37 @@ fun CustomizationDemoScreen(
             onToggle = { onChange(state.copy(vibrate = !state.vibrate)) },
             toggleOnText = "Haptics On",
             toggleOffText = "Haptics Off",
+            shape = AzButtonShape.RECTANGLE,
+        )
+
+        // --- WP7 menu-drawer knobs (new in this release) ---
+        SectionLabel("dimBehindMenu — dim the rest of the app when the drawer expands")
+        AzToggle(
+            isChecked = state.dimBehindMenu,
+            onToggle = { onChange(state.copy(dimBehindMenu = !state.dimBehindMenu)) },
+            toggleOnText = "Dim: On (40%)",
+            toggleOffText = "Dim: Off",
+            shape = AzButtonShape.RECTANGLE,
+        )
+
+        SectionLabel("menuItemAlignment — SIDE (default) hugs the docked edge; CENTER is legacy")
+        AzCycler(
+            options = AzMenuItemAlignment.values().map { it.name },
+            selectedOption = state.menuItemAlignment.name,
+            onCycle = {
+                val vals = AzMenuItemAlignment.values()
+                val next = vals[(state.menuItemAlignment.ordinal + 1) % vals.size]
+                onChange(state.copy(menuItemAlignment = next))
+            },
+            shape = AzButtonShape.RECTANGLE,
+        )
+
+        SectionLabel("justifyMenuItems — full-justify labels via computed letter-spacing")
+        AzToggle(
+            isChecked = state.justifyMenuItems,
+            onToggle = { onChange(state.copy(justifyMenuItems = !state.justifyMenuItems)) },
+            toggleOnText = "Justify: On",
+            toggleOffText = "Justify: Off",
             shape = AzButtonShape.RECTANGLE,
         )
 

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## Unreleased
+
+Windows-Phone-7 fidelity pass: the signature kinetic-typography entrance is redesigned end-to-end,
+the About page becomes a docs-TOC + focused-hero-carousel split, and three long-missing menu-drawer
+knobs (dim, side-alignment, kerning-justify) land as first-class options.
+
+### Added
+- **Menu-drawer look-and-feel options** on `AzNavRailSettings` (and mirrored on `AzDropdownMenu`):
+  - **`dimBehindMenu`** (default `false`) plus **`dimBehindMenuAlpha`** (default `0.4`) — draws a
+    dim scrim behind the expanded drawer; tap-to-collapse preserved.
+  - **`menuItemAlignment`** (`'center' | 'side'`, default **`'side'`**) — labels hug the docked
+    edge (`Start` when docked LEFT, `End` when RIGHT) instead of the legacy center-align.
+  - **`justifyMenuItems`** (default **`true`**) — measures the natural width of each label and
+    applies computed `letterSpacing` so the label fills the row edge-to-edge (Word-style justify).
+- **`AzMoreFromApp.bannerUrl`.** When the app's repo has `docs/banner.png` / `.webp` / `.jpg`
+  (or `docs/hero.*`), it is displayed at the top of that app's info panel under the About-page
+  hero carousel. Resolved both at CI-bake time and at runtime.
+
+### Changed
+- **Kinetic typography redesigned.** Item entrance/exit is now a pure 90° `rotateY` sweep hinged on
+  the docked edge — no fade, no vertical slide. New defaults:
+  `entranceStartAngle = 90` (was 70), `entranceDurationMs = 720` (was 360),
+  `entranceStaggerMs = 60` (was 55). Items now overlap heavily — the next item starts ~60 ms
+  after the previous begins while the previous is still animating.
+- **On native React Native**, `AzKineticItem` now applies a `translateX ±(width/2)` pivot correction
+  around the `rotateY` so the hinge visibly sits on the docked side (was center-pivoted because
+  React Native ignores `transformOrigin`). No change on web (CSS `transform-origin` was already
+  correct).
+- **Footer unfolds like an accordion.** The rail and dropdown footer (About/Feedback/@HereLiesAz)
+  now animate in with `scaleY 0→1` + `opacity 0→1` hinged at the top edge, starting when the
+  **last** menu item starts its own kinetic entrance (delay = `(count - 1) * staggerMs`). Same
+  Wp7Decelerate easing; the whole footer unfolds as one unit.
+- **About page split into two halves.** The top half is the existing docs TOC (unchanged internals),
+  and the bottom half is a **focused-hero More-from-Az carousel** with a size pattern
+  `small · medium · LARGE · medium · small` — the LARGE (center) item is the active one, and its
+  banner (when present), name, description, and link buttons render below the carousel. The old
+  pinned "More from Az" and "View on GitHub" buttons at the bottom of About are removed.
+- **`fetchMoreFromAz` now enriches missing icons at runtime.** When the manifest's `iconUrl` is
+  blank (or points at the owner's GH avatar), the runtime walks standard Android launcher-icon
+  paths on `raw.githubusercontent.com` (`mipmap-xxxhdpi/ic_launcher.webp` / `.png`, then xxhdpi,
+  xhdpi, hdpi) and falls back to the repo's OpenGraph social preview.
+
+### CI
+- **`.github/scripts/bake_more_from_az.py` walks the app's launcher icons and banner.** When
+  Play/website `og:image` resolvers leave `iconUrl` blank, the bake now looks for
+  `app/src/main/res/mipmap-*hdpi/ic_launcher.{png,webp}` (with a Contents-API tree walk fallback and
+  adaptive-icon XML parse) and fills the manifest. It also probes each repo for `docs/banner.*` /
+  `docs/hero.*` and stores it as `bannerUrl`.
+
 ## 0.6.0
 
 Guidance is now a **non-blocking coach** instead of a modal tutorial.

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -15,6 +15,8 @@ import {
 import { AzNavRailContext } from './AzNavRailScope';
 import { AzNavItem, AzNavRailSettings, AzButtonShape, AzDockingSide, AzHeaderIconShape, AzNestedRailAlignment, AzEntrance, AzExit } from './types';
 import { AzKineticItem, useAzClosing } from './components/AzKinetics';
+import { Easing as RNEasing } from 'react-native';
+import { AzEasing } from './types';
 import { AzNavRailDefaults } from './AzNavRailDefaults';
 import { AzButton } from './components/AzButton';
 import { AzToggle } from './components/AzToggle';
@@ -51,6 +53,47 @@ interface AzNavRailProps extends AzNavRailSettings {
   /** Called whenever any rail item is interacted with. Receives the action name, an optional detail string, and the interacted item (if applicable). */
   onInteraction?: (action: string, details?: string, item?: AzNavItem) => void;
 }
+
+/**
+ * Unfolds children downward (scaleY 0→1 + fade) with an accordion motion. Kicks off when the LAST
+ * menu item starts its own kinetic entrance, i.e. after `(menuItemCount - 1) * staggerMs`.
+ */
+const FooterAccordion: React.FC<{
+  visible: boolean;
+  menuItemCount: number;
+  staggerMs: number;
+  durationMs: number;
+  children?: React.ReactNode;
+}> = ({ visible, menuItemCount, staggerMs, durationMs, children }) => {
+  const anim = useRef(new Animated.Value(visible ? 1 : 0)).current;
+  useEffect(() => {
+    if (visible) {
+      const a = Animated.timing(anim, {
+        toValue: 1,
+        duration: durationMs,
+        delay: Math.max(0, menuItemCount - 1) * staggerMs,
+        easing: RNEasing.bezier(...AzEasing.Wp7Decelerate),
+        useNativeDriver: true,
+      });
+      a.start();
+      return () => a.stop();
+    }
+    anim.setValue(0);
+    return undefined;
+  }, [visible, menuItemCount, staggerMs, durationMs, anim]);
+  return (
+    <Animated.View
+      style={{
+        opacity: anim,
+        transform: [{ scaleY: anim }],
+        // Web-only hinge from the top edge; native RN ignores transformOrigin.
+        ...( { transformOrigin: 'top center' } as any ),
+      }}
+    >
+      {children}
+    </Animated.View>
+  );
+};
 
 const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
   const {
@@ -659,6 +702,9 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                       depth={depth}
                       isExpandedHost={isExpandedHost}
                       textStyle={kItemTextStyle}
+                      dockingSide={kDockingSide}
+                      menuItemAlignment={menuItemAlignment}
+                      justifyMenuItems={justifyMenuItems}
                       onToggleHost={() => {
                           const newHostState = !(hostStates[item.id] || false);
                           setHostStates(prev => ({ ...prev, [item.id]: newHostState }));
@@ -724,7 +770,13 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
       };
 
       return (
-        <View style={[styles.footer, { alignItems: 'center' }]}>
+        <FooterAccordion
+          visible={isExpanded}
+          menuItemCount={menuItems.length}
+          staggerMs={kStaggerMs}
+          durationMs={kDurationMs}
+        >
+          <View style={[styles.footer, { alignItems: 'center' }]}>
              <View style={styles.divider} />
              {enableRailDragging && (
                  <TouchableOpacity onPress={handleUndock} style={{ paddingVertical: 8 }}><Text style={[styles.menuItemText, { color: footerColor, fontWeight: 'bold' }]}>{`Undock`}</Text></TouchableOpacity>
@@ -734,7 +786,8 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
              )}
              <TouchableOpacity onPress={handleFeedback} style={{ paddingVertical: 4 }}><Text style={[styles.menuItemText, { color: footerColor }]}>Feedback</Text></TouchableOpacity>
              <TouchableOpacity onPress={handleCredit} onLongPress={handleSecLocTrigger} delayLongPress={500} style={{ paddingVertical: 4 }}><Text style={[styles.menuItemText, { color: footerColor, opacity: 0.5 }]}>@HereLiesAz</Text></TouchableOpacity>
-        </View>
+          </View>
+        </FooterAccordion>
       );
   };
 
@@ -753,13 +806,18 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
   // — Kinetic typography (WP7). Defaults animate; opt out via settings (itemEntrance: None, …). —
   const kItemEntrance = (config as AzNavRailSettings).itemEntrance ?? AzEntrance.Turnstile;
   const kItemExit = (config as AzNavRailSettings).itemExit ?? AzExit.Turnstile;
-  const kStaggerMs = (config as AzNavRailSettings).entranceStaggerMs ?? 55;
-  const kDurationMs = (config as AzNavRailSettings).entranceDurationMs ?? 360;
-  const kStartAngle = (config as AzNavRailSettings).entranceStartAngle ?? 70;
+  const kStaggerMs = (config as AzNavRailSettings).entranceStaggerMs ?? 60;
+  const kDurationMs = (config as AzNavRailSettings).entranceDurationMs ?? 720;
+  const kStartAngle = (config as AzNavRailSettings).entranceStartAngle ?? 90;
   const kTiltOnPress = (config as AzNavRailSettings).tiltOnPress ?? false;
   const kMaxTilt = (config as AzNavRailSettings).maxTiltDegrees ?? 10;
   const kItemTextStyle = (config as AzNavRailSettings).itemTextStyle;
   const kDockingSide = config.dockingSide ?? AzDockingSide.LEFT;
+  // Menu-drawer look/feel — new defaults (side-aligned + justified) preserve caller intent when unset.
+  const menuItemAlignment = (config as AzNavRailSettings).menuItemAlignment ?? 'side';
+  const justifyMenuItems = (config as AzNavRailSettings).justifyMenuItems ?? true;
+  const dimBehindMenu = (config as AzNavRailSettings).dimBehindMenu ?? false;
+  const dimBehindMenuAlpha = (config as AzNavRailSettings).dimBehindMenuAlpha ?? 0.4;
   // Keep the menu mounted through the staggered exit so items can turnstile out as the rail collapses.
   const menuRendered = useAzClosing(isExpanded && !config.noMenu, kItemExit, menuItems.length, kStaggerMs, kDurationMs);
 
@@ -775,6 +833,19 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
   return (
     <AzNavRailContext.Provider value={{ register, unregister, updateSettings, getDividerId, hasItem }}>
         <View style={{ flexDirection: flexDirection, height: '100%', flex: 1 }}>
+            {/* Dim scrim behind the drawer: developer-opt-in via `dimBehindMenu`; alpha via
+                `dimBehindMenuAlpha`. Tapping the scrim collapses the menu. */}
+            {dimBehindMenu && isExpanded && !isFloating && (
+              <TouchableOpacity
+                onPress={() => setIsExpanded(false)}
+                activeOpacity={1}
+                style={{
+                  ...(StyleSheet.absoluteFillObject as object),
+                  backgroundColor: `rgba(0,0,0,${Math.max(0, Math.min(1, dimBehindMenuAlpha))})`,
+                  zIndex: 5,
+                }}
+              />
+            )}
             <Animated.View
                 style={[
                     styles.railContainer,
@@ -782,7 +853,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                     width: railWidthAnim,
                     position: isFloating ? 'absolute' : 'relative',
                     transform: isFloating ? [{ translateX: pan.x }, { translateY: pan.y }] : [],
-                    zIndex: isFloating ? 1000 : 1,
+                    zIndex: isFloating ? 1000 : 10,
                     height: isFloating ? 'auto' : '100%',
                     borderRightWidth: dockingSide === AzDockingSide.LEFT ? 1 : 0,
                     borderLeftWidth: dockingSide === AzDockingSide.RIGHT ? 1 : 0,

--- a/aznavrail-react/src/components/AboutOverlay.tsx
+++ b/aznavrail-react/src/components/AboutOverlay.tsx
@@ -1,11 +1,24 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Linking, BackHandler } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  StyleSheet,
+  Linking,
+  BackHandler,
+  Image,
+  FlatList,
+  Dimensions,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+} from 'react-native';
 import AzMarkdownNative from './AzMarkdownNative';
-import { MoreFromAzOverlay } from './MoreFromAzOverlay';
 import { AzButton } from './AzButton';
 import { AzLoad } from './AzLoad';
 import { AzButtonShape } from '../types';
 import { listDocs, fetchDoc, AzDocEntry } from '../services/githubDocs';
+import { fetchMoreFromAz, AzMoreFromApp } from '../services/moreFromAz';
 
 interface AboutOverlayProps {
   repoUrl: string;
@@ -20,28 +33,42 @@ type DocsState =
   | { status: 'loaded'; entries: AzDocEntry[]; offline: boolean }
   | { status: 'error' };
 
+const HERO_LARGE = 132;
+const HERO_MEDIUM = 96;
+const HERO_SMALL = 64;
+const HERO_SPACING = 12;
+const CAROUSEL_ROW_HEIGHT = HERO_LARGE + 24;
+
 /**
- * Full-screen in-app About reader for React Native. Auto-discovers the repo's markdown docs and
- * renders the selected one inline via {@link AzMarkdownNative}; a GitHub button is pinned at the
- * bottom and an optional "More from Az" entry opens the carousel. Themed to match the rail.
+ * In-app About reader.
+ *
+ * Layout is two vertically-stacked halves:
+ *  - **Top half** — auto-generated table of contents of the app's markdown docs.
+ *  - **Bottom half** — a focused-hero "More from Az" carousel (small · medium · LARGE · medium · small)
+ *    with the active app's banner (when present), name, description, and link buttons under it.
  */
-export const AboutOverlay: React.FC<AboutOverlayProps> = ({ repoUrl, settings = {}, moreFromAzEnabled, moreFromAzJsonUrl, onDismiss }) => {
+export const AboutOverlay: React.FC<AboutOverlayProps> = ({
+  repoUrl,
+  settings = {},
+  moreFromAzEnabled,
+  moreFromAzJsonUrl,
+  onDismiss,
+}) => {
   const accent = settings.activeColor || '#6200ee';
   const surface = settings.translucentBackground || '#ffffff';
   const [state, setState] = useState<DocsState>({ status: 'loading' });
   const [selected, setSelected] = useState<AzDocEntry | null>(null);
   const [body, setBody] = useState<string | null>(null);
-  const [showMore, setShowMore] = useState(false);
+  const [moreApps, setMoreApps] = useState<AzMoreFromApp[] | null>(null);
 
   useEffect(() => {
     const sub = BackHandler.addEventListener('hardwareBackPress', () => {
-      if (showMore) { setShowMore(false); return true; }
       if (selected) { setSelected(null); return true; }
       onDismiss();
       return true;
     });
     return () => sub.remove();
-  }, [selected, showMore, onDismiss]);
+  }, [selected, onDismiss]);
 
   useEffect(() => {
     let active = true;
@@ -59,12 +86,17 @@ export const AboutOverlay: React.FC<AboutOverlayProps> = ({ repoUrl, settings = 
     return () => { active = false; };
   }, [selected]);
 
+  useEffect(() => {
+    if (!moreFromAzEnabled) { setMoreApps([]); return; }
+    let active = true;
+    fetchMoreFromAz(moreFromAzJsonUrl)
+      .then((r) => active && setMoreApps(r?.apps ?? []))
+      .catch(() => active && setMoreApps([]));
+    return () => { active = false; };
+  }, [moreFromAzEnabled, moreFromAzJsonUrl]);
+
   return (
     <View style={[styles.overlay, { backgroundColor: surface }]}>
-      {/* Hide the About reader entirely while More-from-Az is open, so its doc links can't bleed
-          through a translucent carousel surface. */}
-      {!showMore && (
-      <>
       <View style={styles.header}>
         {selected && (
           <TouchableOpacity onPress={() => setSelected(null)} accessibilityLabel="Back to contents">
@@ -82,55 +114,161 @@ export const AboutOverlay: React.FC<AboutOverlayProps> = ({ repoUrl, settings = 
           <ScrollView style={styles.flex}><AzMarkdownNative markdown={body} accent={accent} /></ScrollView>
         )
       ) : (
-        <View style={styles.flex}>
-          {state.status === 'loading' && <AzLoad />}
-          {state.status === 'error' && <Text style={styles.empty}>Couldn't load documentation.</Text>}
-          {state.status === 'loaded' && (
-            <>
-              {state.offline && <Text style={styles.banner}>Showing cached docs (offline or rate-limited).</Text>}
-              {state.entries.length === 0 ? (
-                <Text style={styles.empty}>No documentation found in this repository.</Text>
-              ) : (
-                <ScrollView style={styles.flex} contentContainerStyle={styles.toc}>
-                  {state.entries.map((e) => (
-                    <TouchableOpacity key={e.path} style={[styles.tocRow, { borderColor: accent }]} onPress={() => setSelected(e)}>
-                      <Text style={[styles.tocText, { color: accent }]}>{e.title}</Text>
-                    </TouchableOpacity>
-                  ))}
-                </ScrollView>
-              )}
-              {/* Pinned bottom: "More from Az" (persistent, never scrolls away) then the GitHub link. */}
-              <View style={styles.bottomSpacer} />
-              {moreFromAzEnabled && (
-                <View style={styles.bottomButton}>
-                  <AzButton text="More from Az" color={accent} shape={AzButtonShape.RECTANGLE} onClick={() => setShowMore(true)} />
-                </View>
-              )}
-              <AzButton text="View on GitHub" color={accent} shape={AzButtonShape.RECTANGLE} onClick={() => Linking.openURL(repoUrl).catch(() => {})} />
-            </>
-          )}
-        </View>
-      )}
-      </>
-      )}
+        <>
+          {/* TOP HALF — docs TOC. */}
+          <View style={styles.half}>
+            {state.status === 'loading' && <AzLoad />}
+            {state.status === 'error' && <Text style={styles.empty}>Couldn't load documentation.</Text>}
+            {state.status === 'loaded' && (
+              <>
+                {state.offline && <Text style={styles.banner}>Showing cached docs (offline or rate-limited).</Text>}
+                {state.entries.length === 0 ? (
+                  <Text style={styles.empty}>No documentation found in this repository.</Text>
+                ) : (
+                  <ScrollView style={styles.flex} contentContainerStyle={styles.toc}>
+                    {state.entries.map((e) => (
+                      <TouchableOpacity key={e.path} style={[styles.tocRow, { borderColor: accent }]} onPress={() => setSelected(e)}>
+                        <Text style={[styles.tocText, { color: accent }]}>{e.title}</Text>
+                      </TouchableOpacity>
+                    ))}
+                  </ScrollView>
+                )}
+              </>
+            )}
+          </View>
 
-      {showMore && <MoreFromAzOverlay jsonUrl={moreFromAzJsonUrl} settings={settings} onDismiss={() => setShowMore(false)} />}
+          {/* BOTTOM HALF — focused-hero More-from-Az carousel + active-app info panel. */}
+          {moreFromAzEnabled && (
+            <View style={styles.half}>
+              <View style={styles.divider} />
+              <MoreFromAzHeroCarousel apps={moreApps} accent={accent} />
+            </View>
+          )}
+        </>
+      )}
     </View>
   );
 };
 
+const MoreFromAzHeroCarousel: React.FC<{
+  apps: AzMoreFromApp[] | null;
+  accent: string;
+}> = ({ apps, accent }) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<FlatList<AzMoreFromApp>>(null);
+  const width = Dimensions.get('window').width;
+  const snapInterval = HERO_LARGE + HERO_SPACING;
+  const sidePadding = Math.max(0, (width - HERO_LARGE) / 2);
+
+  if (apps === null) return <View style={styles.flex}><AzLoad /></View>;
+  if (apps.length === 0) return <Text style={styles.empty}>No apps to show right now.</Text>;
+
+  const activeApp = apps[activeIndex];
+
+  const onScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const offset = e.nativeEvent.contentOffset.x;
+    const idx = Math.max(0, Math.min(apps.length - 1, Math.round(offset / snapInterval)));
+    if (idx !== activeIndex) setActiveIndex(idx);
+  };
+
+  return (
+    <View style={styles.flex}>
+      <View style={{ height: CAROUSEL_ROW_HEIGHT, justifyContent: 'center' }}>
+        <FlatList
+          ref={listRef}
+          data={apps}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          snapToInterval={snapInterval}
+          decelerationRate="fast"
+          keyExtractor={(_, i) => String(i)}
+          contentContainerStyle={{ paddingHorizontal: sidePadding, alignItems: 'center' }}
+          ItemSeparatorComponent={() => <View style={{ width: HERO_SPACING }} />}
+          onScroll={onScroll}
+          scrollEventThrottle={16}
+          renderItem={({ item, index }) => {
+            const distance = Math.abs(index - activeIndex);
+            const size = distance === 0 ? HERO_LARGE : distance === 1 ? HERO_MEDIUM : HERO_SMALL;
+            const isActive = index === activeIndex;
+            return (
+              <TouchableOpacity
+                onPress={() => {
+                  if (isActive) {
+                    const url = item.webUrl || item.playStoreUrl || item.githubUrl;
+                    if (url) Linking.openURL(url).catch(() => {});
+                  } else {
+                    listRef.current?.scrollToOffset({ offset: index * snapInterval, animated: true });
+                    setActiveIndex(index);
+                  }
+                }}
+                style={[
+                  styles.heroCard,
+                  {
+                    width: size,
+                    height: size,
+                    borderColor: isActive ? accent : accent + '66',
+                    borderWidth: isActive ? 2 : 1,
+                  },
+                ]}
+              >
+                {isAppIcon(item.iconUrl) ? (
+                  <Image source={{ uri: item.iconUrl }} style={styles.heroImage} />
+                ) : (
+                  <Text style={[styles.heroInitials, { color: accent }]}>{item.name.slice(0, 2).toUpperCase()}</Text>
+                )}
+              </TouchableOpacity>
+            );
+          }}
+        />
+      </View>
+      {activeApp && <ActiveAppPanel app={activeApp} accent={accent} />}
+    </View>
+  );
+};
+
+const ActiveAppPanel: React.FC<{ app: AzMoreFromApp; accent: string }> = ({ app, accent }) => {
+  const open = (u?: string) => {
+    if (!u) return;
+    Linking.openURL(u).catch(() => {});
+  };
+  return (
+    <ScrollView style={styles.flex} contentContainerStyle={{ paddingVertical: 12 }}>
+      {app.bannerUrl ? (
+        <Image source={{ uri: app.bannerUrl }} style={styles.banner96} resizeMode="cover" />
+      ) : null}
+      <Text style={styles.appName}>{app.name}</Text>
+      {!!app.description && <Text style={styles.appDesc}>{app.description}</Text>}
+      <View style={styles.appActions}>
+        {app.playStoreUrl ? <AzButton text="Play" color={accent} shape={AzButtonShape.RECTANGLE} onClick={() => open(app.playStoreUrl)} /> : null}
+        {app.webUrl ? <AzButton text={app.isPwa ? 'Open' : 'Website'} color={accent} shape={AzButtonShape.RECTANGLE} onClick={() => open(app.webUrl)} /> : null}
+        {app.githubUrl ? <AzButton text="GitHub" color={accent} shape={AzButtonShape.RECTANGLE} onClick={() => open(app.githubUrl)} /> : null}
+      </View>
+    </ScrollView>
+  );
+};
+
+function isAppIcon(url: string): boolean {
+  return !!url && !url.includes('avatars.githubusercontent.com');
+}
+
 const styles = StyleSheet.create({
   overlay: { ...StyleSheet.absoluteFillObject, zIndex: 3000, paddingTop: '6%', paddingBottom: '10%', paddingHorizontal: 20 },
   flex: { flex: 1 },
+  half: { flex: 1 },
+  divider: { height: 1, backgroundColor: '#0000001A', marginVertical: 8 },
   header: { flexDirection: 'row', alignItems: 'center' },
   title: { flex: 1, fontSize: 30, fontWeight: 'bold', marginHorizontal: 8 },
   icon: { fontSize: 22, paddingHorizontal: 6 },
   toc: { gap: 8, paddingVertical: 12 },
   tocRow: { borderWidth: 1, borderRadius: 12, paddingVertical: 14, paddingHorizontal: 16, marginBottom: 8 },
-  emph: { borderWidth: 2 },
   tocText: { fontSize: 18 },
-  empty: { opacity: 0.7, paddingVertical: 16, fontSize: 15 },
+  empty: { opacity: 0.7, paddingVertical: 16, fontSize: 15, textAlign: 'center' },
   banner: { opacity: 0.6, paddingVertical: 8, fontSize: 12 },
-  bottomSpacer: { height: 32 },
-  bottomButton: { marginBottom: 12 },
+  heroCard: { borderRadius: 20, overflow: 'hidden', justifyContent: 'center', alignItems: 'center', backgroundColor: '#00000008' },
+  heroImage: { width: '100%', height: '100%' },
+  heroInitials: { fontSize: 28, fontWeight: 'bold' },
+  banner96: { width: '100%', height: 96, borderRadius: 12, marginBottom: 12 },
+  appName: { fontSize: 20, fontWeight: '600' },
+  appDesc: { fontSize: 14, opacity: 0.75, marginTop: 4 },
+  appActions: { flexDirection: 'row', gap: 8, marginTop: 8, flexWrap: 'wrap' },
 });

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useRef, useState } from 'react';
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -12,9 +12,11 @@ import {
   useWindowDimensions,
   ViewStyle,
   LayoutChangeEvent,
+  Animated,
+  Easing as RNEasing,
 } from 'react-native';
 import { AzButton } from './AzButton';
-import { AzButtonShape, AzDockingSide, AzDropdownDesign, AzEntrance, AzExit, AzHeaderIconShape } from '../types';
+import { AzButtonShape, AzDockingSide, AzDropdownDesign, AzEasing, AzEntrance, AzExit, AzHeaderIconShape } from '../types';
 import { AzNavRailDefaults } from '../AzNavRailDefaults';
 import { AboutOverlay } from './AboutOverlay';
 import { AzKineticItem, useAzClosing } from './AzKinetics';
@@ -28,6 +30,12 @@ interface AzDropdownMenuContextValue {
   onNavigate?: (route: string) => void;
   /** Optional style merged over each MENU-design item's label (big/light/wide Metro type). */
   itemTextStyle?: object;
+  /** Docking side propagated to the MENU-design items for side-alignment. */
+  dockingSide?: AzDockingSide;
+  /** Alignment of MENU-design labels within the row. */
+  menuItemAlignment?: 'center' | 'side';
+  /** When true, MENU-design labels are full-justified via computed letter-spacing. */
+  justifyMenuItems?: boolean;
 }
 const AzDropdownMenuContext = createContext<AzDropdownMenuContextValue | null>(null);
 
@@ -87,6 +95,14 @@ export interface AzDropdownMenuProps {
   tiltOnPress?: boolean;
   /** Maximum tilt angle (deg) for `tiltOnPress`. Default 10. */
   maxTiltDegrees?: number;
+  /** When true, opening the menu draws a dim scrim over the rest of the app. Default false. */
+  dimBehindMenu?: boolean;
+  /** Alpha of the dim scrim (0..1). Default 0.4. */
+  dimBehindMenuAlpha?: number;
+  /** How MENU-design labels are aligned. Default `'side'` (docked-side aligned). */
+  menuItemAlignment?: 'center' | 'side';
+  /** When true, MENU-design labels are full-justified via computed letter-spacing. Default true. */
+  justifyMenuItems?: boolean;
   /** The menu items — `AzDropdownItem`, `AzDivider`, etc. */
   children?: React.ReactNode;
 }
@@ -122,23 +138,70 @@ export const AzDropdownItem: React.FC<AzDropdownItemProps> = ({
   closeOnClick = true,
 }) => {
   const ctx = useContext(AzDropdownMenuContext);
+  // Hooks must run unconditionally. Guard reads via optional chaining below.
+  const [availableWidth, setAvailableWidth] = useState(0);
+  const [naturalWidth, setNaturalWidth] = useState(0);
   if (!ctx) throw new Error('AzDropdownItem must be used inside an <AzDropdownMenu>');
-  const { dismiss, design, onNavigate, itemTextStyle } = ctx;
+  const {
+    dismiss,
+    design,
+    onNavigate,
+    itemTextStyle,
+    dockingSide: ctxDockingSide,
+    menuItemAlignment: ctxMenuItemAlignment,
+    justifyMenuItems: ctxJustifyMenuItems,
+  } = ctx;
   const press = () => {
     if (route) onNavigate?.(route);
     onClick();
     if (closeOnClick) dismiss();
   };
   if (design === AzDropdownDesign.MENU) {
+    const alignment = ctxMenuItemAlignment ?? 'side';
+    const justify = ctxJustifyMenuItems ?? true;
+    const textAlign: 'left' | 'right' | 'center' =
+      alignment === 'center'
+        ? 'center'
+        : ctxDockingSide === AzDockingSide.RIGHT ? 'right' : 'left';
+    const onContainerLayout = (e: LayoutChangeEvent) => {
+      const w = e.nativeEvent.layout.width;
+      if (w && Math.abs(w - availableWidth) > 0.5) setAvailableWidth(w);
+    };
+    const onLabelLayout = (e: LayoutChangeEvent) => {
+      const w = e.nativeEvent.layout.width;
+      if (w && Math.abs(w - naturalWidth) > 0.5) setNaturalWidth(w);
+    };
+    let letterSpacing = 0;
+    if (justify && text.length >= 2 && availableWidth > naturalWidth && naturalWidth > 0) {
+      letterSpacing = (availableWidth - naturalWidth) / (text.length - 1);
+    }
     return (
       <TouchableOpacity
         style={styles.menuRow}
         onPress={enabled ? press : undefined}
+        onLayout={onContainerLayout}
         disabled={!enabled}
         accessibilityRole="button"
         accessibilityLabel={text}
       >
-        <Text style={[styles.menuRowText, { color: textColor || color || '#6750A4', opacity: enabled ? 1 : 0.5 }, itemTextStyle]}>
+        {/* Hidden off-screen measurer — natural width only, no layout impact. */}
+        <Text
+          onLayout={onLabelLayout}
+          style={[
+            styles.menuRowText,
+            { position: 'absolute', opacity: 0, left: -9999, top: -9999 } as any,
+            itemTextStyle,
+          ]}
+        >
+          {text}
+        </Text>
+        <Text
+          style={[
+            styles.menuRowText,
+            { color: textColor || color || '#6750A4', opacity: enabled ? 1 : 0.5, textAlign, letterSpacing },
+            itemTextStyle,
+          ]}
+        >
           {text}
         </Text>
       </TouchableOpacity>
@@ -194,11 +257,15 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
   itemEntrance = AzEntrance.Turnstile,
   itemExit = AzExit.Turnstile,
   itemTextStyle,
-  entranceStaggerMs = 55,
-  entranceDurationMs = 360,
-  entranceStartAngle = 70,
+  entranceStaggerMs = 60,
+  entranceDurationMs = 720,
+  entranceStartAngle = 90,
   tiltOnPress = false,
   maxTiltDegrees = 10,
+  dimBehindMenu = false,
+  dimBehindMenuAlpha = 0.4,
+  menuItemAlignment = 'side',
+  justifyMenuItems = true,
   children,
 }) => {
   const [internalOpen, setInternalOpen] = useState(false);
@@ -281,7 +348,15 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
 
       {rendered && (
         <Modal visible transparent animationType="fade" onRequestClose={() => setOpen(false)}>
-          <Pressable style={StyleSheet.absoluteFill} onPress={() => setOpen(false)}>
+          <Pressable
+            style={[
+              StyleSheet.absoluteFill,
+              dimBehindMenu
+                ? { backgroundColor: `rgba(0,0,0,${Math.max(0, Math.min(1, dimBehindMenuAlpha))})` }
+                : null,
+            ]}
+            onPress={() => setOpen(false)}
+          >
             <View
               testID="az-dropdown-panel"
               onLayout={onPanelLayout}
@@ -300,7 +375,7 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
                       : { alignItems: 'center', padding: 8 }
                   }
                 >
-                  <AzDropdownMenuContext.Provider value={{ dismiss: () => setOpen(false), design, onNavigate, itemTextStyle }}>
+                  <AzDropdownMenuContext.Provider value={{ dismiss: () => setOpen(false), design, onNavigate, itemTextStyle, dockingSide, menuItemAlignment, justifyMenuItems }}>
                     {items.map((child, i) => (
                       <AzKineticItem
                         key={i}
@@ -326,6 +401,10 @@ export const AzDropdownMenu: React.FC<AzDropdownMenuProps> = ({
                       appRepositoryUrl={appRepositoryUrl}
                       inAppAbout={inAppAbout}
                       onInAppAbout={() => setShowAbout(true)}
+                      visible={isOpen}
+                      menuItemCount={items.length}
+                      staggerMs={entranceStaggerMs}
+                      durationMs={entranceDurationMs}
                     />
                   )}
                 </ScrollView>
@@ -354,7 +433,19 @@ const AzDropdownFooter: React.FC<{
   appRepositoryUrl?: string;
   inAppAbout?: boolean;
   onInAppAbout?: () => void;
-}> = ({ appRepositoryUrl, inAppAbout = true, onInAppAbout }) => {
+  visible?: boolean;
+  menuItemCount?: number;
+  staggerMs?: number;
+  durationMs?: number;
+}> = ({
+  appRepositoryUrl,
+  inAppAbout = true,
+  onInAppAbout,
+  visible = true,
+  menuItemCount = 0,
+  staggerMs = 60,
+  durationMs = 720,
+}) => {
   const footerColor = '#6750A4';
   // Only open safe schemes — this also runs on the web via react-native-web, where a `javascript:`
   // URL would otherwise execute.
@@ -367,21 +458,48 @@ const AzDropdownFooter: React.FC<{
     if (inAppAbout) onInAppAbout?.();
     else open(appRepositoryUrl);
   };
+
+  // Accordion unfold from the top edge when the last dropdown item begins its own kinetic entrance.
+  const anim = useRef(new Animated.Value(visible ? 1 : 0)).current;
+  useEffect(() => {
+    if (visible) {
+      const a = Animated.timing(anim, {
+        toValue: 1,
+        duration: durationMs,
+        delay: Math.max(0, menuItemCount - 1) * staggerMs,
+        easing: RNEasing.bezier(...AzEasing.Wp7Decelerate),
+        useNativeDriver: true,
+      });
+      a.start();
+      return () => a.stop();
+    }
+    anim.setValue(0);
+    return undefined;
+  }, [visible, menuItemCount, staggerMs, durationMs, anim]);
+
   return (
-    <View style={styles.footer}>
-      {/* About is hidden entirely when no repository URL is configured. */}
-      {!!appRepositoryUrl && (
-        <TouchableOpacity onPress={onAbout} style={styles.footerRow} accessibilityRole="button">
-          <Text style={[styles.footerText, { color: footerColor }]}>About</Text>
+    <Animated.View
+      style={{
+        opacity: anim,
+        transform: [{ scaleY: anim }],
+        ...( { transformOrigin: 'top center' } as any ),
+      }}
+    >
+      <View style={styles.footer}>
+        {/* About is hidden entirely when no repository URL is configured. */}
+        {!!appRepositoryUrl && (
+          <TouchableOpacity onPress={onAbout} style={styles.footerRow} accessibilityRole="button">
+            <Text style={[styles.footerText, { color: footerColor }]}>About</Text>
+          </TouchableOpacity>
+        )}
+        <TouchableOpacity onPress={() => open('mailto:hereliesaz@gmail.com?subject=Feedback')} style={styles.footerRow} accessibilityRole="button">
+          <Text style={[styles.footerText, { color: footerColor }]}>Feedback</Text>
         </TouchableOpacity>
-      )}
-      <TouchableOpacity onPress={() => open('mailto:hereliesaz@gmail.com?subject=Feedback')} style={styles.footerRow} accessibilityRole="button">
-        <Text style={[styles.footerText, { color: footerColor }]}>Feedback</Text>
-      </TouchableOpacity>
-      <TouchableOpacity onPress={() => open('https://instagram.com/HereLiesAz')} style={styles.footerRow} accessibilityRole="button">
-        <Text style={[styles.footerText, { color: footerColor, opacity: 0.5 }]}>@HereLiesAz</Text>
-      </TouchableOpacity>
-    </View>
+        <TouchableOpacity onPress={() => open('https://instagram.com/HereLiesAz')} style={styles.footerRow} accessibilityRole="button">
+          <Text style={[styles.footerText, { color: footerColor, opacity: 0.5 }]}>@HereLiesAz</Text>
+        </TouchableOpacity>
+      </View>
+    </Animated.View>
   );
 };
 

--- a/aznavrail-react/src/components/AzKinetics.tsx
+++ b/aznavrail-react/src/components/AzKinetics.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Animated, Easing, ViewStyle, StyleProp } from 'react-native';
+import { Animated, Easing, Platform, ViewStyle, StyleProp, LayoutChangeEvent } from 'react-native';
 import { AzDockingSide, AzEasing, AzEntrance, AzExit } from '../types';
 
 const CASCADE_DIST = 20; // px vertical slide for FAB-mode / SlideUp cascade
@@ -120,11 +120,28 @@ export const AzKineticItem: React.FC<AzKineticItemProps> = ({
   const outAngle = useTurnstile ? startAngle : 0;
   const outDist = useSlide ? CASCADE_DIST : 0;
 
-  const opacity = animates ? vis : 1;
+  // Docked Turnstile is a pure rotation (no fade); Fade/SlideUp/floating-Turnstile still fade in.
+  const entranceUsesAlpha =
+    entrance === AzEntrance.Fade || entrance === AzEntrance.SlideUp ||
+    (entrance === AzEntrance.Turnstile && floating);
+  const exitUsesAlpha = exit === AzExit.Fade || (exit === AzExit.Turnstile && floating);
+  const usesAlpha = entranceUsesAlpha || exitUsesAlpha;
+  const opacity = animates && usesAlpha ? vis : 1;
   const rotateY = vis.interpolate({ inputRange: [0, 1], outputRange: [`${outAngle}deg`, '0deg'] });
   const translateY = vis.interpolate({ inputRange: [0, 1], outputRange: [outDist, 0] });
   const rotateXTilt = tiltX.interpolate({ inputRange: [-1, 1], outputRange: [`${-maxTiltDegrees}deg`, `${maxTiltDegrees}deg`] });
   const rotateYTilt = tiltY.interpolate({ inputRange: [-1, 1], outputRange: [`${-maxTiltDegrees}deg`, `${maxTiltDegrees}deg`] });
+
+  // Native RN silently ignores `transformOrigin`, so on iOS/Android we emulate the docked hinge by
+  // translating ±(width/2) before the rotate and back after. Web uses the CSS property instead.
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const onLayout = (e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    if (w && Math.abs(w - measuredWidth) > 0.5) setMeasuredWidth(w);
+  };
+  const nativePivot = Platform.OS !== 'web' && useTurnstile && measuredWidth > 0;
+  const half = measuredWidth / 2;
+  const pivotOffset = nativePivot ? (dockingSide === AzDockingSide.RIGHT ? half : -half) : 0;
 
   const springBack = () => {
     Animated.spring(tiltX, { toValue: 0, useNativeDriver: true }).start();
@@ -158,15 +175,18 @@ export const AzKineticItem: React.FC<AzKineticItemProps> = ({
   return (
     <Animated.View
       {...tiltHandlers}
+      onLayout={onLayout}
       style={[
         style,
         {
           opacity,
           transform: [
             { perspective: 600 },
+            ...(nativePivot ? [{ translateX: pivotOffset }] : []),
             { rotateY },
             { rotateX: rotateXTilt },
             { rotateY: rotateYTilt },
+            ...(nativePivot ? [{ translateX: -pivotOffset }] : []),
             { translateY },
           ],
           transformOrigin, // web-only; ignored on native

--- a/aznavrail-react/src/components/RailMenuItem.tsx
+++ b/aznavrail-react/src/components/RailMenuItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { AzNavItem } from '../types';
+import { View, Text, TouchableOpacity, StyleSheet, LayoutChangeEvent } from 'react-native';
+import { AzDockingSide, AzNavItem } from '../types';
 
 /** Internal props for `RailMenuItem` — one row inside the expanded-menu scroll view. */
 interface RailMenuItemProps {
@@ -18,6 +18,12 @@ interface RailMenuItemProps {
     renderSubItems: () => React.ReactNode;
     /** Optional style merged over the row label (big/light/wide Metro type). */
     textStyle?: object;
+    /** Docking side of the rail — drives side-alignment when `menuItemAlignment === 'side'`. */
+    dockingSide?: AzDockingSide;
+    /** Alignment of the label within the row: `center` (legacy) or `side` (docked-side aligned). */
+    menuItemAlignment?: 'center' | 'side';
+    /** When true, labels are full-justified via computed letter-spacing. */
+    justifyMenuItems?: boolean;
 }
 
 /**
@@ -31,7 +37,10 @@ export const RailMenuItem: React.FC<RailMenuItemProps> = ({
     onToggleHost,
     onItemClick,
     renderSubItems,
-    textStyle
+    textStyle,
+    dockingSide = AzDockingSide.LEFT,
+    menuItemAlignment = 'side',
+    justifyMenuItems = true,
 }) => {
     const [displayOption, setDisplayOption] = useState(item.selectedOption);
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -86,16 +95,56 @@ export const RailMenuItem: React.FC<RailMenuItemProps> = ({
     if (item.isToggle) accessibilityState.checked = item.isChecked;
     if (item.isHost || item.isNestedRail) accessibilityState.expanded = isExpandedHost;
 
+    // Alignment + kerning-justify computed per-row. We measure the label's natural width off-screen,
+    // then compute an equal letter-spacing that stretches it to fill the row.
+    const textAlign =
+        menuItemAlignment === 'center'
+            ? 'center'
+            : dockingSide === AzDockingSide.RIGHT ? 'right' : 'left';
+    const [availableWidth, setAvailableWidth] = useState(0);
+    const [naturalWidth, setNaturalWidth] = useState(0);
+    const onContainerLayout = (e: LayoutChangeEvent) => {
+        const w = e.nativeEvent.layout.width;
+        if (w && Math.abs(w - availableWidth) > 0.5) setAvailableWidth(w);
+    };
+    const onLabelLayout = (e: LayoutChangeEvent) => {
+        const w = e.nativeEvent.layout.width;
+        if (w && Math.abs(w - naturalWidth) > 0.5) setNaturalWidth(w);
+    };
+    let letterSpacing = 0;
+    if (justifyMenuItems && displayText && displayText.length >= 2 && availableWidth > naturalWidth && naturalWidth > 0) {
+        letterSpacing = (availableWidth - naturalWidth) / (displayText.length - 1);
+    }
+
     return (
         <View>
             <TouchableOpacity
                 onPress={handlePress}
+                onLayout={onContainerLayout}
                 style={[styles.menuItem, { paddingLeft: 16 + (depth * 16), backgroundColor: (!item.isHost) ? `${item.fillColor ?? item.color ?? '#000000'}1F` : 'transparent' }]}
                 accessibilityRole={item.isToggle ? "switch" : "menuitem"}
                 accessibilityLabel={displayText}
                 accessibilityState={accessibilityState}
             >
-                <Text style={[styles.menuItemText, { fontWeight: item.isHost ? 'bold' : 'normal', color: item.textColor ?? item.color ?? '#000000' }, textStyle]}>
+                {/* Off-screen "measurer" — same font/style as the visible label, absent from layout. */}
+                <Text
+                    onLayout={onLabelLayout}
+                    style={[styles.measurer, { fontWeight: item.isHost ? 'bold' : 'normal' }, textStyle]}
+                >
+                    {displayText}
+                </Text>
+                <Text
+                    style={[
+                        styles.menuItemText,
+                        {
+                            fontWeight: item.isHost ? 'bold' : 'normal',
+                            color: item.textColor ?? item.color ?? '#000000',
+                            textAlign,
+                            letterSpacing,
+                        },
+                        textStyle,
+                    ]}
+                >
                     {displayText}
                 </Text>
                 {item.isHost && (
@@ -112,12 +161,19 @@ const styles = StyleSheet.create({
   menuItem: {
       padding: 16,
       flexDirection: 'row',
-      justifyContent: 'center',
       alignItems: 'center',
   },
   menuItemText: {
       fontSize: 16,
-      textAlign: 'center',
       flex: 1,
+  },
+  // Rendered off-screen (position:absolute + opacity:0) so it doesn't affect layout, but its onLayout
+  // still fires with the label's natural width — which drives the letterSpacing calculation above.
+  measurer: {
+      fontSize: 16,
+      position: 'absolute',
+      opacity: 0,
+      left: -9999,
+      top: -9999,
   },
 });

--- a/aznavrail-react/src/services/moreFromAz.ts
+++ b/aznavrail-react/src/services/moreFromAz.ts
@@ -11,6 +11,8 @@ export interface AzMoreFromApp {
   webUrl?: string;
   /** When true, `webUrl` is a PWA (an "Open" button); otherwise it's a "Website". */
   isPwa?: boolean;
+  /** Optional banner (docs/banner.* in the app's repo) shown at the top of the app info. */
+  bannerUrl?: string;
 }
 
 /** Stable sort placing apps with a Play link first. */
@@ -38,6 +40,7 @@ function appFromObject(o: any): AzMoreFromApp | null {
       playStoreUrl: o.play || undefined,
       webUrl: o.web || undefined,
       isPwa: Boolean(o.isPwa),
+      bannerUrl: typeof o.bannerUrl === 'string' && o.bannerUrl ? o.bannerUrl : undefined,
     };
   }
   // Un-baked link object { github?, play?, web? } -> degraded card.
@@ -83,16 +86,92 @@ export function parse(json: string): MoreFromResult {
 }
 
 /**
- * Reads the **baked** "More from Az" manifest from [jsonUrl]. All resolution (Play link, website/PWA,
- * WIP filtering, sorting, name/icon/description) is done in CI, so this is a pure parse — which also
- * closes the previous web CORS gap (no client-side Play/website fetches).
+ * Reads the **baked** "More from Az" manifest from [jsonUrl]. Play/website/WIP resolution is done in
+ * CI so this is a pure parse.  After parsing, entries whose `iconUrl` is blank (or the owner's GH
+ * avatar) trigger a repo-level walk against raw.githubusercontent.com — standard mipmap paths first,
+ * then the OpenGraph social preview.  Entries without a `bannerUrl` also get a `docs/banner.*` walk
+ * so the About page can render a banner strip above the active app's info.
  */
 export async function fetchMoreFromAz(jsonUrl: string): Promise<MoreFromResult | null> {
   const res = await cachedGet(jsonUrl);
   if (!res) return null;
+  let parsed: MoreFromResult;
   try {
-    return parse(res.body);
+    parsed = parse(res.body);
   } catch {
     return null;
   }
+  const enriched = await enrichWithRepoAssets(parsed.apps);
+  return { version: parsed.version, apps: enriched };
+}
+
+const LAUNCHER_ICON_PATHS = [
+  'app/src/main/res/mipmap-xxxhdpi/ic_launcher.webp',
+  'app/src/main/res/mipmap-xxxhdpi/ic_launcher.png',
+  'app/src/main/res/mipmap-xxhdpi/ic_launcher.webp',
+  'app/src/main/res/mipmap-xxhdpi/ic_launcher.png',
+  'app/src/main/res/mipmap-xhdpi/ic_launcher.webp',
+  'app/src/main/res/mipmap-xhdpi/ic_launcher.png',
+  'app/src/main/res/mipmap-hdpi/ic_launcher.png',
+];
+
+const BANNER_NAMES = [
+  'docs/banner.png', 'docs/banner.webp', 'docs/banner.jpg', 'docs/banner.jpeg',
+  'docs/Banner.png', 'docs/Banner.webp',
+  'docs/hero.png', 'docs/hero.webp',
+];
+
+const BRANCHES = ['main', 'master', 'HEAD'];
+
+async function headOk(url: string): Promise<boolean> {
+  try {
+    // HEAD would be ideal, but on the web CORS blocks preflight for many hosts. GET with cache: 'no-store'
+    // (and no-cors mode so we get an opaque response) is the safest cross-platform ping.
+    const r = await fetch(url, { method: 'GET', mode: 'no-cors', cache: 'no-store' as any } as any);
+    // In `no-cors` mode the status is 0 with type "opaque"; treat that as "reachable" so we don't
+    // gate on CORS misconfig. On native platforms (no CORS), we get the real status.
+    return (r.type === 'opaque') || (r.status >= 200 && r.status < 400);
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveRepoIcon(owner: string, repo: string): Promise<string> {
+  for (const branch of BRANCHES) {
+    for (const path of LAUNCHER_ICON_PATHS) {
+      const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${path}`;
+      if (await headOk(url)) return url;
+    }
+  }
+  return `https://opengraph.githubassets.com/1/${owner}/${repo}`;
+}
+
+export async function resolveRepoBanner(owner: string, repo: string): Promise<string | undefined> {
+  for (const branch of BRANCHES) {
+    for (const name of BANNER_NAMES) {
+      const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${name}`;
+      if (await headOk(url)) return url;
+    }
+  }
+  return undefined;
+}
+
+export async function enrichWithRepoAssets(apps: AzMoreFromApp[]): Promise<AzMoreFromApp[]> {
+  return Promise.all(
+    apps.map(async (app) => {
+      const gh = app.githubUrl;
+      if (!gh) return app;
+      const parsed = parseRepo(gh);
+      if (!parsed) return app;
+      const [owner, repo] = parsed;
+      const needsIcon = !app.iconUrl || app.iconUrl.includes('avatars.githubusercontent.com');
+      const needsBanner = !app.bannerUrl;
+      if (!needsIcon && !needsBanner) return app;
+      const [iconUrl, bannerUrl] = await Promise.all([
+        needsIcon ? resolveRepoIcon(owner, repo) : Promise.resolve(app.iconUrl),
+        needsBanner ? resolveRepoBanner(owner, repo) : Promise.resolve(app.bannerUrl),
+      ]);
+      return { ...app, iconUrl: iconUrl || app.iconUrl, bannerUrl };
+    }),
+  );
 }

--- a/aznavrail-react/src/types.ts
+++ b/aznavrail-react/src/types.ts
@@ -173,11 +173,11 @@ export interface AzNavRailSettings {
   itemExit?: AzExit;
   /** Style merged over each menu item's label (big/light/wide Metro type). */
   itemTextStyle?: object;
-  /** Per-item cascade delay (ms), multiplied by position. Default 55. */
+  /** Per-item cascade delay (ms), multiplied by position. Default 60. */
   entranceStaggerMs?: number;
-  /** Duration (ms) of each item's entrance/exit. Default 360. */
+  /** Duration (ms) of each item's entrance/exit. Default 720. */
   entranceDurationMs?: number;
-  /** Starting rotateY (deg) for the turnstile sweep. Default 70. */
+  /** Starting rotateY (deg) for the turnstile sweep. Default 90 (pure edge-on → flat). */
   entranceStartAngle?: number;
   /** When true, menu items tilt toward the press point (suppressed for draggable items). Default false. */
   tiltOnPress?: boolean;
@@ -187,6 +187,16 @@ export interface AzNavRailSettings {
   titleEntrance?: AzEntrance;
   /** Style merged over the big screen title's default. */
   titleTextStyle?: object;
+
+  // — Menu-drawer look/feel —
+  /** When true, expanding the drawer draws a dim scrim over the rest of the app. Default false. */
+  dimBehindMenu?: boolean;
+  /** Alpha of the dim scrim (0..1). Default 0.4. Ignored when `dimBehindMenu` is false. */
+  dimBehindMenuAlpha?: number;
+  /** How menu-drawer labels are aligned within their rows. Default `'side'` (docked-side aligned). */
+  menuItemAlignment?: 'center' | 'side';
+  /** When true, menu-drawer labels are full-justified via computed letter-spacing. Default true. */
+  justifyMenuItems?: boolean;
 }
 
 /** A single entry in the long-press hidden menu of a draggable reloc item. */

--- a/aznavrail-react/src/web/AboutOverlay.css
+++ b/aznavrail-react/src/web/AboutOverlay.css
@@ -119,3 +119,66 @@
 .az-more-name { font-size: 1.3rem; font-weight: 700; }
 .az-more-desc { margin-top: 6px; opacity: 0.85; }
 .az-more-actions { display: flex; gap: 12px; margin-top: 16px; }
+
+/* About-page split (top TOC / bottom focused-hero carousel). */
+.az-about-half {
+  flex: 1 1 50%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+}
+.az-about-hero {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.az-about-hero-rail {
+  display: flex;
+  align-items: center;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  padding: 12px 0;
+  height: 156px;
+  scrollbar-width: none;
+}
+.az-about-hero-rail::-webkit-scrollbar { display: none; }
+.az-about-hero-card {
+  flex: 0 0 auto;
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(0,0,0,0.03);
+  border: 1px solid;
+  padding: 0;
+  cursor: pointer;
+  scroll-snap-align: center;
+  transition: width 240ms cubic-bezier(0.1, 0.9, 0.2, 1),
+              height 240ms cubic-bezier(0.1, 0.9, 0.2, 1),
+              border-width 200ms ease-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.az-about-hero-card img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.az-about-hero-info { padding: 12px 4px; overflow-y: auto; }
+.az-about-hero-banner {
+  width: 100%;
+  height: 96px;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 12px;
+  display: block;
+}
+.az-about-hero-name { font-size: 1.25rem; font-weight: 600; }
+.az-about-hero-desc { font-size: 0.9rem; opacity: 0.75; margin-top: 4px; }
+.az-about-hero-actions { display: flex; gap: 8px; margin-top: 12px; flex-wrap: wrap; }
+.az-about-hero-actions button {
+  background: transparent;
+  border: 2px solid;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/aznavrail-react/src/web/AboutOverlay.jsx
+++ b/aznavrail-react/src/web/AboutOverlay.jsx
@@ -1,15 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './AboutOverlay.css';
 import AzMarkdownWeb from './AzMarkdownWeb';
-import MoreFromAzOverlay from './MoreFromAzOverlay';
 import { listDocs, fetchDoc } from '../services/githubDocs';
+import { fetchMoreFromAz } from '../services/moreFromAz';
 
 /**
- * Full-screen in-app About reader for the web. Auto-discovers the repo's markdown docs
- * (root + docs/), lists them as a themed table of contents, and renders the selected doc inline.
- * A "View on GitHub" button sits pinned at the bottom with extra spacing; an optional "More from Az"
- * entry opens the author's other-apps carousel. Themed from `settings.activeColor` /
- * `settings.translucentBackground` to match the rail.
+ * In-app About reader for the web.
+ *
+ * Layout is two vertically-stacked halves:
+ *  - **Top half** — auto-generated table of contents of the repo's markdown docs.
+ *  - **Bottom half** — a focused-hero More-from-Az carousel with a size pattern
+ *    (small · medium · LARGE · medium · small) and the active app's banner (when the repo has
+ *    `docs/banner.*`), name, description, and link buttons.
  */
 export default function AboutOverlay({ repoUrl, settings = {}, moreFromAzEnabled, moreFromAzJsonUrl, onDismiss }) {
   const accent = settings.activeColor || '#6200ee';
@@ -18,7 +20,7 @@ export default function AboutOverlay({ repoUrl, settings = {}, moreFromAzEnabled
   const [state, setState] = useState({ status: 'loading', entries: [], offline: false });
   const [selected, setSelected] = useState(null);
   const [docBody, setDocBody] = useState(null);
-  const [showMore, setShowMore] = useState(false);
+  const [moreApps, setMoreApps] = useState(null);
 
   useEffect(() => {
     let active = true;
@@ -36,6 +38,15 @@ export default function AboutOverlay({ repoUrl, settings = {}, moreFromAzEnabled
     return () => { active = false; };
   }, [selected]);
 
+  useEffect(() => {
+    if (!moreFromAzEnabled) { setMoreApps([]); return; }
+    let active = true;
+    fetchMoreFromAz(moreFromAzJsonUrl)
+      .then((r) => active && setMoreApps(r?.apps ?? []))
+      .catch(() => active && setMoreApps([]));
+    return () => { active = false; };
+  }, [moreFromAzEnabled, moreFromAzJsonUrl]);
+
   return (
     <div className="az-about-overlay" style={{ background: surface }}>
       <div className="az-about-header">
@@ -51,40 +62,145 @@ export default function AboutOverlay({ repoUrl, settings = {}, moreFromAzEnabled
           {docBody === null ? <div className="az-about-loading">Loading…</div> : <AzMarkdownWeb markdown={docBody} accent={accent} />}
         </div>
       ) : (
-        <div className="az-about-body">
-          {state.status === 'loading' && <div className="az-about-loading">Loading…</div>}
-          {state.status === 'error' && <div className="az-about-empty">Couldn't load documentation.</div>}
-          {state.status === 'loaded' && (
-            <>
-              {state.offline && <div className="az-about-banner">Showing cached docs (offline or rate-limited).</div>}
-              {state.entries.length === 0 ? (
-                <div className="az-about-empty">No documentation found in this repository.</div>
-              ) : (
-                <div className="az-about-toc">
-                  {state.entries.map((e) => (
-                    <button key={e.path} className="az-about-tocrow" style={{ borderColor: accent, color: accent }} onClick={() => setSelected(e)}>
-                      {e.title}
-                    </button>
-                  ))}
-                  {moreFromAzEnabled && (
-                    <button className="az-about-tocrow emphasized" style={{ borderColor: accent, color: accent }} onClick={() => setShowMore(true)}>
-                      More from Az
-                    </button>
-                  )}
-                </div>
-              )}
-              <div className="az-about-spacer" />
-              <hr className="az-about-divider" />
-              <a className="az-about-repo" href={repoUrl} target="_blank" rel="noreferrer" style={{ borderColor: accent, color: accent }}>
-                View on GitHub
-              </a>
-            </>
-          )}
-        </div>
-      )}
+        <>
+          {/* TOP HALF — docs TOC. */}
+          <div className="az-about-half">
+            {state.status === 'loading' && <div className="az-about-loading">Loading…</div>}
+            {state.status === 'error' && <div className="az-about-empty">Couldn't load documentation.</div>}
+            {state.status === 'loaded' && (
+              <>
+                {state.offline && <div className="az-about-banner">Showing cached docs (offline or rate-limited).</div>}
+                {state.entries.length === 0 ? (
+                  <div className="az-about-empty">No documentation found in this repository.</div>
+                ) : (
+                  <div className="az-about-toc">
+                    {state.entries.map((e) => (
+                      <button key={e.path} className="az-about-tocrow" style={{ borderColor: accent, color: accent }} onClick={() => setSelected(e)}>
+                        {e.title}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
 
-      {showMore && (
-        <MoreFromAzOverlay jsonUrl={moreFromAzJsonUrl} settings={settings} onDismiss={() => setShowMore(false)} />
+          {/* BOTTOM HALF — More-from-Az focused-hero carousel + active-app info. */}
+          {moreFromAzEnabled && (
+            <div className="az-about-half">
+              <hr className="az-about-divider" />
+              <MoreFromAzHeroCarousel apps={moreApps} accent={accent} />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+const HERO_LARGE = 132;
+const HERO_MEDIUM = 96;
+const HERO_SMALL = 64;
+const HERO_SPACING = 12;
+
+function MoreFromAzHeroCarousel({ apps, accent }) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const railRef = useRef(null);
+
+  if (apps === null) return <div className="az-about-loading">Loading…</div>;
+  if (apps.length === 0) return <div className="az-about-empty">No apps to show right now.</div>;
+
+  const activeApp = apps[activeIndex];
+
+  const onScroll = () => {
+    const el = railRef.current;
+    if (!el) return;
+    const center = el.scrollLeft + el.clientWidth / 2;
+    let closest = 0;
+    let closestDelta = Infinity;
+    for (let i = 0; i < apps.length; i += 1) {
+      const child = el.children[i];
+      if (!child) continue;
+      const c = child.offsetLeft + child.offsetWidth / 2;
+      const d = Math.abs(c - center);
+      if (d < closestDelta) { closestDelta = d; closest = i; }
+    }
+    if (closest !== activeIndex) setActiveIndex(closest);
+  };
+
+  const scrollTo = (i) => {
+    const el = railRef.current;
+    if (!el) return;
+    const child = el.children[i];
+    if (!child) return;
+    const target = child.offsetLeft + child.offsetWidth / 2 - el.clientWidth / 2;
+    el.scrollTo({ left: target, behavior: 'smooth' });
+    setActiveIndex(i);
+  };
+
+  const isAppIcon = (u) => !!u && !u.includes('avatars.githubusercontent.com');
+  const open = (u) => { if (u) window.open(u, '_blank', 'noopener,noreferrer'); };
+
+  return (
+    <div className="az-about-hero">
+      <div
+        ref={railRef}
+        className="az-about-hero-rail"
+        onScroll={onScroll}
+        style={{
+          padding: `0 calc(50% - ${HERO_LARGE / 2}px)`,
+          gap: `${HERO_SPACING}px`,
+        }}
+      >
+        {apps.map((app, i) => {
+          const distance = Math.abs(i - activeIndex);
+          const size = distance === 0 ? HERO_LARGE : distance === 1 ? HERO_MEDIUM : HERO_SMALL;
+          const isActive = i === activeIndex;
+          return (
+            <button
+              key={i}
+              className="az-about-hero-card"
+              onClick={() => (isActive ? open(app.webUrl || app.playStoreUrl || app.githubUrl) : scrollTo(i))}
+              style={{
+                width: size,
+                height: size,
+                borderColor: isActive ? accent : accent + '66',
+                borderWidth: isActive ? 2 : 1,
+              }}
+              aria-label={app.name}
+            >
+              {isAppIcon(app.iconUrl) ? (
+                <img src={app.iconUrl} alt={app.name} />
+              ) : (
+                <span style={{ color: accent, fontSize: 28, fontWeight: 'bold' }}>
+                  {(app.name || '').slice(0, 2).toUpperCase()}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      {activeApp && (
+        <div className="az-about-hero-info">
+          {activeApp.bannerUrl ? (
+            <img src={activeApp.bannerUrl} alt={`${activeApp.name} banner`} className="az-about-hero-banner" />
+          ) : null}
+          <div className="az-about-hero-name">{activeApp.name}</div>
+          {activeApp.description && <div className="az-about-hero-desc">{activeApp.description}</div>}
+          <div className="az-about-hero-actions">
+            {activeApp.playStoreUrl && (
+              <button style={{ borderColor: accent, color: accent }} onClick={() => open(activeApp.playStoreUrl)}>Play</button>
+            )}
+            {activeApp.webUrl && (
+              <button style={{ borderColor: accent, color: accent }} onClick={() => open(activeApp.webUrl)}>
+                {activeApp.isPwa ? 'Open' : 'Website'}
+              </button>
+            )}
+            {activeApp.githubUrl && (
+              <button style={{ borderColor: accent, color: accent }} onClick={() => open(activeApp.githubUrl)}>GitHub</button>
+            )}
+          </div>
+        </div>
       )}
     </div>
   );

--- a/aznavrail-react/src/web/AzDropdownMenu.css
+++ b/aznavrail-react/src/web/AzDropdownMenu.css
@@ -59,15 +59,16 @@
   padding: 4px 0;
 }
 
-/* Matches the rail's menu item text: 16px / weight 500 / centred (see web MenuItem.css). */
+/* Matches the rail's menu item text: 16px / weight 500. Alignment is set inline by the JSX so the
+   docked-side default can flip left/right. */
 .az-dropdown-menu-item--menu {
   padding: 12px 16px;
-  text-align: center;
   font-size: 16px;
   font-weight: 500;
   cursor: pointer;
   user-select: none;
   color: #6750A4;
+  position: relative;
 }
 
 .az-dropdown-menu-item--menu:hover { background-color: rgba(103, 80, 164, 0.08); }

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -17,22 +17,77 @@ function useDropdownContext() {
  * expanded-drawer look); in a `rail`-design panel it renders as a compact AzButton. Navigates
  * `route` (if set, via the menu's `onNavigate`) then runs `onClick`, folding the menu by default.
  */
-export const AzDropdownItem = ({ text, onClick, route, shape = 'RECTANGLE', enabled = true, color, textColor, fillColor, closeOnClick = true }) => {
-  const { dismiss, design, onNavigate } = useDropdownContext();
+export const AzDropdownItem = ({
+  text,
+  onClick,
+  route,
+  shape = 'RECTANGLE',
+  enabled = true,
+  color,
+  textColor,
+  fillColor,
+  closeOnClick = true,
+  index = 0,
+}) => {
+  const {
+    dismiss,
+    design,
+    onNavigate,
+    dockingSide,
+    menuItemAlignment,
+    justifyMenuItems,
+    entranceStartAngle,
+    entranceStaggerMs,
+    entranceDurationMs,
+  } = useDropdownContext();
   const press = () => {
     if (route && onNavigate) onNavigate(route);
     onClick && onClick();
     if (closeOnClick) dismiss();
   };
+  const rowRef = useRef(null);
+  const measureRef = useRef(null);
+  const [letterSpacing, setLetterSpacing] = useState(0);
+  useEffect(() => {
+    if (!justifyMenuItems || !text || text.length < 2) { setLetterSpacing(0); return; }
+    const row = rowRef.current;
+    const meas = measureRef.current;
+    if (!row || !meas) return;
+    const w = row.getBoundingClientRect().width;
+    const nat = meas.getBoundingClientRect().width;
+    if (w > nat && nat > 0) setLetterSpacing((w - nat) / (text.length - 1));
+    else setLetterSpacing(0);
+  }, [text, justifyMenuItems]);
   if (design === 'menu') {
+    const hingeSide = dockingSide === 'RIGHT' ? 'right' : 'left';
+    const textAlign =
+      menuItemAlignment === 'center'
+        ? 'center'
+        : dockingSide === 'RIGHT'
+          ? 'right'
+          : 'left';
     return (
       <div
+        ref={rowRef}
         className={`az-dropdown-menu-item--menu${enabled ? '' : ' disabled'}`}
-        style={{ color: textColor || color || undefined }}
+        style={{
+          color: textColor || color || undefined,
+          textAlign,
+          letterSpacing: `${letterSpacing}px`,
+          animation: `azTurnstile ${entranceDurationMs}ms cubic-bezier(0.1, 0.9, 0.2, 1) ${index * entranceStaggerMs}ms both`,
+          transformOrigin: `${hingeSide} center`,
+          '--az-start-angle': `${dockingSide === 'RIGHT' ? -entranceStartAngle : entranceStartAngle}deg`,
+        }}
         role="menuitem"
         tabIndex={enabled ? 0 : -1}
         onClick={enabled ? press : undefined}
       >
+        <span
+          ref={measureRef}
+          style={{ position: 'absolute', visibility: 'hidden', whiteSpace: 'nowrap', left: -9999 }}
+        >
+          {text}
+        </span>
         {text}
       </div>
     );
@@ -91,6 +146,13 @@ const AzDropdownMenu = ({
   expanded,
   onExpandedChange,
   onNavigate,
+  entranceStaggerMs = 60,
+  entranceDurationMs = 720,
+  entranceStartAngle = 90,
+  dimBehindMenu = false,
+  dimBehindMenuAlpha = 0.4,
+  menuItemAlignment = 'side',
+  justifyMenuItems = true,
   children,
 }) => {
   const [internalOpen, setInternalOpen] = useState(false);
@@ -185,14 +247,42 @@ const AzDropdownMenu = ({
         {/* The app icon — drawn like the rail header, clipped to the configured shape/size. */}
         <img src="/app-icon.png" alt="App Icon" className="az-dropdown-menu-app-icon" style={{ borderRadius: triggerRadius }} />
       </button>
+      {isOpen && dimBehindMenu && (
+        <div
+          className="az-nav-rail__scrim"
+          style={{ '--az-scrim-alpha': String(Math.max(0, Math.min(1, dimBehindMenuAlpha))), position: 'fixed', inset: 0, zIndex: 999 }}
+          onClick={() => setOpen(false)}
+        />
+      )}
       {isOpen && (
-        <div className={`az-dropdown-menu-panel ${design === 'menu' ? 'menu' : 'rail'}`} style={panelStyle} role="menu">
-          <AzDropdownMenuContext.Provider value={{ dismiss: () => setOpen(false), design, onNavigate }}>
-            {children}
+        <div className={`az-dropdown-menu-panel ${design === 'menu' ? 'menu' : 'rail'}`} style={{ ...panelStyle, zIndex: 1000 }} role="menu">
+          <AzDropdownMenuContext.Provider
+            value={{
+              dismiss: () => setOpen(false),
+              design,
+              onNavigate,
+              dockingSide,
+              menuItemAlignment,
+              justifyMenuItems,
+              entranceStartAngle,
+              entranceStaggerMs,
+              entranceDurationMs,
+            }}
+          >
+            {React.Children.map(children, (child, i) =>
+              React.isValidElement(child) ? React.cloneElement(child, { index: i }) : child
+            )}
           </AzDropdownMenuContext.Provider>
-          {/* The expanded-menu design carries the rail's footer. */}
+          {/* The expanded-menu design carries the rail's footer. Its accordion unfold starts when
+              the LAST item starts its own kinetic entrance. */}
           {design === 'menu' && showFooter && (
-            <div className="az-dropdown-menu-footer">
+            <div
+              className="az-dropdown-menu-footer az-nav-rail__footer-accordion"
+              style={{
+                animationDelay: `${Math.max(0, React.Children.count(children) - 1) * entranceStaggerMs}ms`,
+                animationDuration: `${entranceDurationMs}ms`,
+              }}
+            >
               {/* About is hidden entirely when no repository URL is configured. */}
               {!!appRepositoryUrl && (
                 <div className="az-dropdown-menu-footer-item" onClick={() => {

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -46,7 +46,17 @@ const AzNavRail = ({
     moreFromAzEnabled = true,
     moreFromAzJsonUrl = 'https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json',
     moreRailItem = false,
-    appRepositoryUrl
+    appRepositoryUrl,
+    // WP7 kinetic typography — same defaults as the RN build.
+    itemEntrance = 'Turnstile',
+    entranceStaggerMs = 60,
+    entranceDurationMs = 720,
+    entranceStartAngle = 90,
+    // Menu drawer look/feel.
+    dimBehindMenu = false,
+    dimBehindMenuAlpha = 0.4,
+    menuItemAlignment = 'side',
+    justifyMenuItems = true,
   } = settings;
 
   // If noMenu is true, we force expanded to false, unless infoScreen overrides (which it doesn't really)
@@ -322,7 +332,7 @@ const AzNavRail = ({
       }
   };
 
-  const renderMenuItem = (item, depth = 0) => {
+  const renderMenuItem = (item, depth = 0, index = 0, count = 1) => {
       if (item.isDivider) {
           return <AzDivider key={item.id} />;
       }
@@ -348,10 +358,22 @@ const AzNavRail = ({
                   isExpanded={isHostExpanded}
                   onHostClick={() => toggleHost(item)}
                   infoScreen={infoScreen}
+                  index={index}
+                  count={count}
+                  visible={isExpanded}
+                  entrance={itemEntrance}
+                  startAngle={entranceStartAngle}
+                  staggerMs={entranceStaggerMs}
+                  durationMs={entranceDurationMs}
+                  dockingSide={dockingSide}
+                  menuItemAlignment={menuItemAlignment}
+                  justifyMenuItems={justifyMenuItems}
               />
               {isHost && isHostExpanded && (
                   <div className="az-nav-rail-subitems">
-                      {effectiveSubItems.map(subItem => renderMenuItem(subItem, depth + 1))}
+                      {effectiveSubItems.map((subItem, subIdx) =>
+                        renderMenuItem(subItem, depth + 1, subIdx, effectiveSubItems.length)
+                      )}
                   </div>
               )}
           </React.Fragment>
@@ -396,9 +418,16 @@ const AzNavRail = ({
 
   return (
     <>
+    {dimBehindMenu && isExpanded && (
+      <div
+        className="az-nav-rail__scrim"
+        style={{ '--az-scrim-alpha': String(Math.max(0, Math.min(1, dimBehindMenuAlpha))) }}
+        onClick={() => setIsExpanded(false)}
+      />
+    )}
     <div
       className={`az-nav-rail ${isExpanded ? 'expanded' : 'collapsed'} ${dockingSide === 'RIGHT' ? 'right' : ''}`}
-      style={{ width: isExpanded ? expandedRailWidth : collapsedRailWidth, backgroundColor: translucentBackground || '#f0f0f0' }}
+      style={{ width: isExpanded ? expandedRailWidth : collapsedRailWidth, backgroundColor: translucentBackground || '#f0f0f0', position: 'relative', zIndex: 10 }}
     >
       <div className="header" onClick={onToggle}>
         {(!isExpanded || !displayAppNameInHeader) ? (
@@ -414,7 +443,7 @@ const AzNavRail = ({
         <div className="content">
           {isExpanded ? (
             <div className="menu">
-              {menuItems.map(item => renderMenuItem(item))}
+              {menuItems.map((item, i) => renderMenuItem(item, 0, i, menuItems.length))}
             </div>
           ) : (
             <div className={`rail ${packRailButtons ? 'packed' : ''}`} style={{overflowY: 'auto', maxHeight: '100%'}}>
@@ -601,7 +630,18 @@ const AzNavRail = ({
       )}
 
       {showFooter && isExpanded && (
-        <div className="footer" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '16px', color: activeColor || 'currentColor' }}>
+        <div
+          className="footer az-nav-rail__footer-accordion"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            padding: '16px',
+            color: activeColor || 'currentColor',
+            animationDelay: `${Math.max(0, menuItems.length - 1) * entranceStaggerMs}ms`,
+            animationDuration: `${entranceDurationMs}ms`,
+          }}
+        >
              <div className="az-menu-item-text" style={{ padding: '8px 0', fontWeight: 'bold' }}>{appName}</div>
              {!!appRepositoryUrl && (
                <div

--- a/aznavrail-react/src/web/MenuItem.css
+++ b/aznavrail-react/src/web/MenuItem.css
@@ -17,7 +17,6 @@
 
 .az-menu-item-content {
   display: flex;
-  justify-content: center;
   align-items: center;
   width: 100%;
 }
@@ -25,7 +24,6 @@
 .az-menu-item-text {
   font-size: 16px;
   font-weight: 500;
-  text-align: center;
   flex: 1;
 }
 
@@ -38,4 +36,49 @@
   opacity: 0.7;
 }
 
-/* Indent for sub-items would be handled by parent logic or extra class */
+/* Off-screen label used only to measure the natural width for the kerning-justify pass. */
+.az-menu-item-measurer {
+  position: absolute;
+  visibility: hidden;
+  white-space: nowrap;
+  font-size: 16px;
+  font-weight: 500;
+  left: -9999px;
+  top: -9999px;
+}
+
+/* WP7 turnstile entrance — swings the row from edge-on (var(--az-start-angle)) to flat around the
+   docked side. `perspective` on the parent gives it depth without stacking-context weirdness. */
+@keyframes azTurnstile {
+  from {
+    transform: perspective(600px) rotateY(var(--az-start-angle, 90deg));
+  }
+  to {
+    transform: perspective(600px) rotateY(0deg);
+  }
+}
+
+/* Accordion unfold used by the footer — scales from 0 to full height, hinged at the top edge. */
+@keyframes azFooterAccordion {
+  from {
+    transform: scaleY(0);
+    opacity: 0;
+  }
+  to {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+.az-nav-rail__footer-accordion {
+  transform-origin: top center;
+  animation: azFooterAccordion 720ms cubic-bezier(0.1, 0.9, 0.2, 1) both;
+}
+
+/* Dim scrim behind the drawer when the developer opts in via `dimBehindMenu`. */
+.az-nav-rail__scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, var(--az-scrim-alpha, 0.4));
+  z-index: 5;
+}

--- a/aznavrail-react/src/web/MenuItem.jsx
+++ b/aznavrail-react/src/web/MenuItem.jsx
@@ -1,10 +1,39 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './MenuItem.css';
 
 /**
- * A menu item component for the expanded navigation rail.
+ * A menu item component for the expanded navigation rail (plain-web build).
+ *
+ * Extras vs. the RN component:
+ *  - Kinetic entrance: a per-item CSS animation that swings the row from 90° edge-on to 0° flat,
+ *    hinged on the docked side (`transform-origin: left|right center`). The stagger delay is set
+ *    by `index * staggerMs` so items overlap when `staggerMs` is much smaller than `durationMs`.
+ *  - Side-alignment: labels are hard-aligned to the docked side (or centered) via `text-align`.
+ *  - Kerning-justify: for labels shorter than the row, `letter-spacing` is measured & applied so
+ *    the label fills the row edge-to-edge.
  */
-const MenuItem = ({ item, depth = 0, onToggle, onCyclerClick, isHost, isExpanded, onHostClick, infoScreen }) => {
+const MenuItem = ({
+  item,
+  depth = 0,
+  onToggle,
+  onCyclerClick,
+  isHost,
+  isExpanded,
+  onHostClick,
+  infoScreen,
+  // WP7 kinetic entrance
+  index = 0,
+  count = 1,
+  visible = true,
+  entrance = 'Turnstile',
+  startAngle = 90,
+  staggerMs = 60,
+  durationMs = 720,
+  dockingSide = 'LEFT',
+  // Menu-drawer look
+  menuItemAlignment = 'side',
+  justifyMenuItems = true,
+}) => {
   const {
     text,
     isToggle,
@@ -13,16 +42,11 @@ const MenuItem = ({ item, depth = 0, onToggle, onCyclerClick, isHost, isExpanded
     toggleOffText,
     isCycler,
     selectedOption,
-    menuText,
-    menuToggleOnText,
-    menuToggleOffText,
-    menuOptions,
     textColor,
-    fillColor,
     onClick,
     isDivider,
     color = 'currentColor',
-    onFocus
+    onFocus,
   } = item;
 
   if (isDivider) {
@@ -35,25 +59,25 @@ const MenuItem = ({ item, depth = 0, onToggle, onCyclerClick, isHost, isExpanded
     if (!isInteractive) return;
 
     if (infoScreen) {
-        if (item.isHelpItem && onClick) {
-            onClick();
-        } else if (isHost) {
-            onHostClick();
-        }
-        return;
+      if (item.isHelpItem && onClick) {
+        onClick();
+      } else if (isHost) {
+        onHostClick();
+      }
+      return;
     }
 
     if (onFocus) onFocus();
 
     if (isHost) {
-        onHostClick();
+      onHostClick();
     } else if (isToggle) {
-        onClick && onClick();
+      onClick && onClick();
     } else if (isCycler) {
-        onCyclerClick();
+      onCyclerClick();
     } else {
-        onClick && onClick();
-        onToggle(); // Collapse menu
+      onClick && onClick();
+      onToggle(); // Collapse menu
     }
   };
 
@@ -72,35 +96,79 @@ const MenuItem = ({ item, depth = 0, onToggle, onCyclerClick, isHost, isExpanded
     ariaProps['aria-haspopup'] = 'true';
   }
 
+  // Kinetic entrance: rotateY from `startAngle` → 0, hinged on the docked edge.
+  const useTurnstile = entrance === 'Turnstile';
+  const hingeSide = dockingSide === 'RIGHT' ? 'right' : 'left';
+  const kineticStyle = useTurnstile && visible
+    ? {
+        animation: `azTurnstile ${durationMs}ms cubic-bezier(0.1, 0.9, 0.2, 1) ${index * staggerMs}ms both`,
+        transformOrigin: `${hingeSide} center`,
+        // Custom prop the keyframes read.
+        '--az-start-angle': `${dockingSide === 'RIGHT' ? -startAngle : startAngle}deg`,
+      }
+    : undefined;
+
+  // Side-align + kerning-justify.
+  const textAlign =
+    menuItemAlignment === 'center'
+      ? 'center'
+      : dockingSide === 'RIGHT'
+        ? 'right'
+        : 'left';
+
+  const rowRef = useRef(null);
+  const measureRef = useRef(null);
+  const [letterSpacing, setLetterSpacing] = useState(0);
+  const label = (isToggle ? (isChecked ? toggleOnText : toggleOffText) : (isCycler ? selectedOption : text)) || '';
+  useEffect(() => {
+    if (!justifyMenuItems || !label || label.length < 2) { setLetterSpacing(0); return; }
+    const row = rowRef.current;
+    const meas = measureRef.current;
+    if (!row || !meas) return;
+    const rowWidth = row.getBoundingClientRect().width - paddingLeft - 16;
+    const natural = meas.getBoundingClientRect().width;
+    if (rowWidth > natural && natural > 0) {
+      setLetterSpacing((rowWidth - natural) / (label.length - 1));
+    } else {
+      setLetterSpacing(0);
+    }
+  }, [label, justifyMenuItems, paddingLeft]);
+
+  const labelStyle = { textAlign, letterSpacing: `${letterSpacing}px`, flex: 1, color: textColor || undefined };
+
   return (
     <div
-        className="az-menu-item"
-        style={{ color: color, paddingLeft: `${paddingLeft}px`, position: 'relative' }}
-        onClick={handleClick}
-        data-az-nav-id={item.id}
-        {...ariaProps}
+      ref={rowRef}
+      className="az-menu-item"
+      style={{ color, paddingLeft: `${paddingLeft}px`, position: 'relative', ...kineticStyle }}
+      onClick={handleClick}
+      data-az-nav-id={item.id}
+      {...ariaProps}
     >
-        {isToggle ? (
-            <div className="az-menu-item-content toggle">
-                 <span className="az-menu-item-text">
-                     {isChecked ? toggleOnText : toggleOffText}
-                 </span>
-            </div>
-        ) : isCycler ? (
-             <div className="az-menu-item-content cycler">
-                 <span className="az-menu-item-text">{text}</span>
-                 <span className="az-menu-item-value">{selectedOption}</span>
-             </div>
-        ) : (
-            <div className="az-menu-item-content button">
-                <span className="az-menu-item-text">{text}</span>
-                {isHost && (
-                    <span className="az-menu-item-arrow">
-                        {isExpanded ? '▼' : '▶'}
-                    </span>
-                )}
-            </div>
-        )}
+      {/* Off-screen measurer — same font-size as the visible label. */}
+      <span ref={measureRef} className="az-menu-item-measurer">{label}</span>
+
+      {isToggle ? (
+        <div className="az-menu-item-content toggle">
+          <span className="az-menu-item-text" style={labelStyle}>
+            {isChecked ? toggleOnText : toggleOffText}
+          </span>
+        </div>
+      ) : isCycler ? (
+        <div className="az-menu-item-content cycler">
+          <span className="az-menu-item-text" style={labelStyle}>{text}</span>
+          <span className="az-menu-item-value">{selectedOption}</span>
+        </div>
+      ) : (
+        <div className="az-menu-item-content button">
+          <span className="az-menu-item-text" style={labelStyle}>{text}</span>
+          {isHost && (
+            <span className="az-menu-item-arrow">
+              {isExpanded ? '▼' : '▶'}
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -93,6 +93,20 @@ falls back to the AzNavRail library repo. On **web** there is no package namespa
 While a footer screen (About or More from Az) is open, visible Help cards and any guidance callouts
 are hidden and restore exactly where they were on close (all platforms).
 
+**About page layout.** The About screen is split into two vertically-stacked halves:
+
+- **Top half** — auto-generated table of contents of the app's markdown docs (`.md` files in the
+  repo root and `docs/`). Selecting a row swaps in an inline reader for that document.
+- **Bottom half** — a **focused-hero More-from-Az carousel** with a size pattern
+  `small · medium · LARGE · medium · small`. The LARGE (center) item is the currently active app;
+  its **banner** (when the repo has `docs/banner.png` / `.webp` / `.jpg` — or `docs/hero.*`),
+  name, description, and link buttons (Play / Website / GitHub) render below the carousel.
+
+**Icons & banners** are baked into `more-from-az.json` by CI (Play `og:image` → website `og:image` →
+Android launcher icons on `raw.githubusercontent.com` → repo social preview). If the manifest is
+stale or `iconUrl` is blank at runtime, the runtime performs the same launcher-icon walk itself so
+new apps show a proper icon before the next CI bake.
+
 
 ### B. Theming (`azTheme`)
 Controls visual style defaults.
@@ -124,10 +138,20 @@ config-driven (preset enums, no free-composable escape hatch). Defaults animate;
 / `AzExit.None` to opt a surface out. In **FAB / floating** mode the cascade becomes a vertical up/down
 slide (no docked edge to hinge on).
 
+The signature look is a **pure 90° `rotationY` sweep** hinged on the docked edge — no fade, no vertical
+slide. Items overlap heavily by default: `entranceDurationMs = 720` and `entranceStaggerMs = 60`
+means the next item begins ~60 ms after the previous one *begins* while the previous one is still
+animating. The footer (About / Feedback / @HereLiesAz) then **unfolds like an accordion** from the
+top edge, starting the moment the last item begins — so the whole rail-open motion completes in one
+continuous beat.
+
 ```kotlin
 azKinetics(
     itemEntrance = AzEntrance.Turnstile,   // None | Fade | SlideUp | Turnstile  (default Turnstile)
     itemExit = AzExit.Turnstile,           // None | Fade | Turnstile            (default Turnstile)
+    entranceStartAngle = 90f,              // pure edge-on → flat  (default 90)
+    entranceDurationMs = 720,              // per-item duration ms (default 720)
+    entranceStaggerMs = 60,                // per-item stagger ms  (default 60 → items overlap)
     tiltOnPress = true,                    // off by default on the rail (drag-safe)
     itemTextStyle = TextStyle(fontSize = 22.sp, fontWeight = FontWeight.Light),
     titleEntrance = AzEntrance.Turnstile,  // the big AzNavHost screen title
@@ -139,7 +163,33 @@ default), and its app-icon trigger carries an automatic margin.
 
 **React Implementation:** the rail reads kinetics from `settings`
 (`itemEntrance`, `itemExit`, `titleEntrance`, `tiltOnPress`, `itemTextStyle`, …); `AzDropdownMenu`
-takes matching props. `AzEasing.Wp7Decelerate` is the signature easing.
+takes matching props. `AzEasing.Wp7Decelerate` is the signature easing. On **native React Native**
+the hinge is emulated via a `translateX ±(width/2)` pivot correction around the rotation because
+`transformOrigin` is silently ignored there; on web the CSS `transform-origin: left/right center`
+does it natively.
+
+### B.1 Menu-drawer look-and-feel (dim, side-alignment, kerning-justify)
+
+Three developer knobs on `azConfig` shape the drawer itself. They only affect the **expanded-menu
+drawer** (and the standalone `AzDropdownMenu`'s panel) — small rail-button labels are unaffected.
+
+```kotlin
+azConfig(
+    dimBehindMenu = true,                              // opt-in dim scrim; default false
+    dimBehindMenuAlpha = 0.4f,                         // 0..1; default 0.4
+    menuItemAlignment = AzMenuItemAlignment.SIDE,      // SIDE (default) | CENTER
+    justifyMenuItems = true,                           // full-justify labels via letter-spacing; default true
+)
+```
+
+`SIDE` alignment: labels use `TextAlign.Start` when docked LEFT and `TextAlign.End` when docked
+RIGHT. `justifyMenuItems` measures each label's natural width, computes the extra pixels needed to
+fill the row, and applies it as `letterSpacing` — a Word-style full justification. Labels shorter
+than 2 characters, or already at/past the row width, are skipped.
+
+**React Implementation:** identical fields on `AzNavRailSettings` and on the `AzDropdownMenu` props:
+`dimBehindMenu`, `dimBehindMenuAlpha`, `menuItemAlignment: 'center' | 'side'`, `justifyMenuItems`.
+Same defaults (`side`, `true`, opt-in dim at `0.4`).
 
 ### C. Advanced Features (`azAdvanced`)
 Enables complex behaviors like drag-and-drop and help overlays.

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -3,6 +3,7 @@ package com.hereliesaz.aznavrail
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -47,7 +48,15 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import com.hereliesaz.aznavrail.model.AzEasing
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -138,13 +147,18 @@ interface AzDropdownMenuScope {
         appRepositoryUrl: String = "",
         itemTextStyle: TextStyle? = null,
         itemEntrance: AzEntrance = AzEntrance.Turnstile,
-        entranceStaggerMs: Int = 55,
-        entranceDurationMs: Int = 360,
+        entranceStaggerMs: Int = 60,
+        entranceDurationMs: Int = 720,
         entranceEasing: Easing = AzEasing.Wp7Decelerate,
-        entranceStartAngle: Float = 70f,
+        entranceStartAngle: Float = 90f,
         tiltOnPress: Boolean = false,
         maxTiltDegrees: Float = 10f,
-        itemExit: AzExit = AzExit.Turnstile
+        itemExit: AzExit = AzExit.Turnstile,
+        dimBehindMenu: Boolean = false,
+        dimBehindMenuAlpha: Float = 0.4f,
+        menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment =
+            com.hereliesaz.aznavrail.model.AzMenuItemAlignment.SIDE,
+        justifyMenuItems: Boolean = true,
     )
 
     /**
@@ -210,13 +224,18 @@ internal data class AzDropdownConfig(
     val appRepositoryUrl: String = "",
     val itemTextStyle: TextStyle? = null,
     val itemEntrance: AzEntrance = AzEntrance.Turnstile,
-    val entranceStaggerMs: Int = 55,
-    val entranceDurationMs: Int = 360,
+    val entranceStaggerMs: Int = 60,
+    val entranceDurationMs: Int = 720,
     val entranceEasing: Easing = AzEasing.Wp7Decelerate,
-    val entranceStartAngle: Float = 70f,
+    val entranceStartAngle: Float = 90f,
     val tiltOnPress: Boolean = false,
     val maxTiltDegrees: Float = 10f,
-    val itemExit: AzExit = AzExit.Turnstile
+    val itemExit: AzExit = AzExit.Turnstile,
+    val dimBehindMenu: Boolean = false,
+    val dimBehindMenuAlpha: Float = 0.4f,
+    val menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment =
+        com.hereliesaz.aznavrail.model.AzMenuItemAlignment.SIDE,
+    val justifyMenuItems: Boolean = true,
 )
 
 /** One declared entry, collected by the builder and rendered by the composable. */
@@ -296,12 +315,17 @@ private class AzDropdownMenuScopeImpl : AzDropdownMenuScope {
         entranceStartAngle: Float,
         tiltOnPress: Boolean,
         maxTiltDegrees: Float,
-        itemExit: AzExit
+        itemExit: AzExit,
+        dimBehindMenu: Boolean,
+        dimBehindMenuAlpha: Float,
+        menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment,
+        justifyMenuItems: Boolean,
     ) {
         config = AzDropdownConfig(
             design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape, headerIconSize,
             showFooter, inAppAbout, appRepositoryUrl, itemTextStyle, itemEntrance, entranceStaggerMs,
-            entranceDurationMs, entranceEasing, entranceStartAngle, tiltOnPress, maxTiltDegrees, itemExit
+            entranceDurationMs, entranceEasing, entranceStartAngle, tiltOnPress, maxTiltDegrees, itemExit,
+            dimBehindMenu, dimBehindMenuAlpha, menuItemAlignment, justifyMenuItems,
         )
     }
 
@@ -375,8 +399,26 @@ private fun AzDropdownMenuRow(
     textColor: Color,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    textStyle: TextStyle? = null
+    textStyle: TextStyle? = null,
+    dockingSide: AzDockingSide = AzDockingSide.LEFT,
+    menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment =
+        com.hereliesaz.aznavrail.model.AzMenuItemAlignment.SIDE,
+    justifyMenuItems: Boolean = true,
 ) {
+    val textAlign = when (menuItemAlignment) {
+        com.hereliesaz.aznavrail.model.AzMenuItemAlignment.CENTER -> TextAlign.Center
+        com.hereliesaz.aznavrail.model.AzMenuItemAlignment.SIDE ->
+            if (dockingSide == AzDockingSide.RIGHT) TextAlign.End else TextAlign.Start
+    }
+    val columnAlignment = when (menuItemAlignment) {
+        com.hereliesaz.aznavrail.model.AzMenuItemAlignment.CENTER -> Alignment.CenterHorizontally
+        com.hereliesaz.aznavrail.model.AzMenuItemAlignment.SIDE ->
+            if (dockingSide == AzDockingSide.RIGHT) Alignment.End else Alignment.Start
+    }
+    val mergedStyle = MaterialTheme.typography.titleLarge.merge(textStyle)
+    val textMeasurer = androidx.compose.ui.text.rememberTextMeasurer()
+    val density = androidx.compose.ui.platform.LocalDensity.current
+
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -387,17 +429,28 @@ private fun AzDropdownMenuRow(
             ),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(
-            modifier = Modifier.weight(1f),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            text.split('\n').forEach { line ->
-                Text(
-                    text = line,
-                    style = MaterialTheme.typography.titleLarge.merge(textStyle),
-                    color = if (enabled) textColor else textColor.copy(alpha = 0.5f),
-                    textAlign = TextAlign.Center
-                )
+        androidx.compose.foundation.layout.BoxWithConstraints(Modifier.weight(1f)) {
+            val availableWidthPx = with(density) { maxWidth.toPx() }
+            Column(horizontalAlignment = columnAlignment) {
+                text.split('\n').forEach { line ->
+                    val kerning = if (!justifyMenuItems || line.length < 2) androidx.compose.ui.unit.TextUnit.Unspecified
+                    else {
+                        val naturalWidthPx = try {
+                            textMeasurer.measure(text = line, style = mergedStyle).size.width.toFloat()
+                        } catch (_: Throwable) { availableWidthPx }
+                        val extraPx = availableWidthPx - naturalWidthPx
+                        if (extraPx <= 0f) androidx.compose.ui.unit.TextUnit.Unspecified
+                        else with(density) { (extraPx / (line.length - 1)).toSp() }
+                    }
+                    Text(
+                        text = line,
+                        style = mergedStyle,
+                        color = if (enabled) textColor else textColor.copy(alpha = 0.5f),
+                        textAlign = textAlign,
+                        letterSpacing = kerning,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         }
     }
@@ -414,7 +467,15 @@ private fun AzDropdownMenuRow(
  *   browser.
  */
 @Composable
-private fun AzDropdownFooter(repoUrl: String, onAboutClick: (() -> Unit)?) {
+private fun AzDropdownFooter(
+    repoUrl: String,
+    onAboutClick: (() -> Unit)?,
+    visible: Boolean = true,
+    menuItemCount: Int = 0,
+    staggerMs: Int = 60,
+    durationMs: Int = 720,
+    easing: Easing = AzEasing.Wp7Decelerate,
+) {
     val context = LocalContext.current
     val footerColor = MaterialTheme.colorScheme.primary
     val appName = remember(context.packageName) {
@@ -427,9 +488,29 @@ private fun AzDropdownFooter(repoUrl: String, onAboutClick: (() -> Unit)?) {
         }
     }
 
+    // Accordion-unfold from the top edge when the last dropdown item starts its own kinetic entrance.
+    val scaleY = remember { Animatable(if (visible) 1f else 0f) }
+    val fade = remember { Animatable(if (visible) 1f else 0f) }
+    LaunchedEffect(visible) {
+        val spec = tween<Float>(durationMillis = durationMs, easing = easing)
+        if (visible) {
+            delay((menuItemCount - 1).coerceAtLeast(0).toLong() * staggerMs)
+            launch { scaleY.animateTo(1f, spec) }
+            launch { fade.animateTo(1f, spec) }
+        } else {
+            scaleY.snapTo(0f)
+            fade.snapTo(0f)
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .graphicsLayer {
+                this.scaleY = scaleY.value
+                this.alpha = fade.value
+                transformOrigin = TransformOrigin(0.5f, 0f)
+            }
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -535,7 +616,10 @@ private fun AzDropdownEntryItem(
                     textColor = effectiveTextColor(entry.textColor, entry.color),
                     onClick = action,
                     modifier = kinetic,
-                    textStyle = config.itemTextStyle
+                    textStyle = config.itemTextStyle,
+                    dockingSide = config.dockingSide,
+                    menuItemAlignment = config.menuItemAlignment,
+                    justifyMenuItems = config.justifyMenuItems,
                 )
             } else {
                 Box(modifier = kinetic) {
@@ -564,7 +648,10 @@ private fun AzDropdownEntryItem(
                         if (entry.closeOnClick) dismiss()
                     },
                     modifier = kinetic,
-                    textStyle = config.itemTextStyle
+                    textStyle = config.itemTextStyle,
+                    dockingSide = config.dockingSide,
+                    menuItemAlignment = config.menuItemAlignment,
+                    justifyMenuItems = config.justifyMenuItems,
                 )
             } else {
                 Box(modifier = kinetic) {
@@ -602,7 +689,10 @@ private fun AzDropdownEntryItem(
                         if (entry.closeOnClick) dismiss()
                     },
                     modifier = kinetic,
-                    textStyle = config.itemTextStyle
+                    textStyle = config.itemTextStyle,
+                    dockingSide = config.dockingSide,
+                    menuItemAlignment = config.menuItemAlignment,
+                    justifyMenuItems = config.justifyMenuItems,
                 )
             } else {
                 Box(modifier = kinetic) {
@@ -776,6 +866,25 @@ fun AzDropdownMenu(
             durationMs = config.entranceDurationMs
         )
         if (rendered) {
+            // Full-screen dim scrim behind the popup, only when the developer opted in. Rendered as its
+            // own Popup so it covers everything the menu might sit above and dismisses the menu on tap.
+            if (config.dimBehindMenu) {
+                Popup(
+                    onDismissRequest = { setOpen(false) },
+                    properties = PopupProperties(focusable = false, dismissOnClickOutside = true),
+                ) {
+                    Box(
+                        Modifier
+                            .fillMaxSize()
+                            .background(
+                                androidx.compose.ui.graphics.Color.Black.copy(
+                                    alpha = config.dimBehindMenuAlpha.coerceIn(0f, 1f),
+                                )
+                            )
+                            .clickable { setOpen(false) }
+                    )
+                }
+            }
             Popup(
                 popupPositionProvider = positionProvider,
                 onDismissRequest = { setOpen(false) },
@@ -807,7 +916,12 @@ fun AzDropdownMenu(
                                 repoUrl = effectiveRepoUrl,
                                 onAboutClick = if (config.inAppAbout && effectiveRepoUrl.isNotBlank()) {
                                     { dismiss(); showAbout = true }
-                                } else null
+                                } else null,
+                                visible = isOpen,
+                                menuItemCount = entries.size,
+                                staggerMs = config.entranceStaggerMs,
+                                durationMs = config.entranceDurationMs,
+                                easing = config.entranceEasing,
                             )
                         }
                     }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -484,10 +484,16 @@ fun AzNavRail(
                     Modifier.padding(bottom = railWidth)
                 else -> Modifier.padding(top = railWidth)
             }
+            val scrimColor = if (scope.dimBehindMenu) {
+                androidx.compose.ui.graphics.Color.Black.copy(
+                    alpha = scope.dimBehindMenuAlpha.coerceIn(0f, 1f),
+                )
+            } else androidx.compose.ui.graphics.Color.Transparent
             Box(
                 modifier = Modifier
                     .matchParentSize()
                     .then(scrimPadding)
+                    .background(scrimColor)
                     .pointerInput(Unit) {
                         detectTapGestures(onTap = { isExpanded = false })
                     }
@@ -846,6 +852,10 @@ fun AzNavRail(
 
                 // FIXED FOOTER (Does not scroll, pinned below menu)
                 if (scope.showFooter && isExpanded) {
+                    // Accordion delay tracks the LAST menu item's start: the footer begins the moment
+                    // the last item's own kinetic entrance kicks off. Use the same top-level count the
+                    // menu itself uses for its staggered entrance.
+                    val footerMenuCount = scope.navItems.count { !it.isSubItem }
                     Column {
                         AzDivider()
                         Footer(
@@ -863,7 +873,12 @@ fun AzNavRail(
                             footerColor = scope.activeColor,
                             onAboutClick = if (scope.advancedConfig.inAppAbout) {
                                 { isExpanded = false; hostScope?.showAbout() }
-                            } else null
+                            } else null,
+                            visible = isExpanded,
+                            menuItemCount = footerMenuCount,
+                            staggerMs = scope.entranceStaggerMs,
+                            durationMs = scope.entranceDurationMs,
+                            easing = scope.entranceEasing,
                         )
                     }
                 }
@@ -1082,7 +1097,10 @@ private fun MenuItemNode(
         helpEnabled = showHelpOverlay,
         activeColor = scope.activeColor,
         kineticModifier = kinetic,
-        textStyle = scope.itemTextStyle
+        textStyle = scope.itemTextStyle,
+        dockingSide = dockingSide,
+        menuItemAlignment = scope.menuItemAlignment,
+        justifyMenuItems = scope.justifyMenuItems
     )
 
     if (item.isHost && hostStates[item.id] == true) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -26,6 +26,7 @@ import com.hereliesaz.aznavrail.model.AzEntrance
 import com.hereliesaz.aznavrail.model.AzExit
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
 import com.hereliesaz.aznavrail.model.AzItemConfig
+import com.hereliesaz.aznavrail.model.AzMenuItemAlignment
 import com.hereliesaz.aznavrail.model.AzNavItem
 import com.hereliesaz.aznavrail.model.AzNestedRailAlignment
 import java.util.Collections.emptySet
@@ -80,7 +81,7 @@ interface AzNavRailScope {
      *   (`com.<owner>.<repo>` → `github.com/<owner>/<repo>`); set it only when the namespace doesn't
      *   match the repo. **Not required.**
      */
-    fun azConfig(dockingSide: AzDockingSide = AzDockingSide.LEFT, packButtons: Boolean = false, noMenu: Boolean = false, vibrate: Boolean = false, displayAppName: Boolean = false, activeClassifiers: Set<String> = emptySet(), usePhysicalDocking: Boolean = false, expandedWidth: Dp = 160.dp, collapsedWidth: Dp = 100.dp, showFooter: Boolean = true, appRepositoryUrl: String = "")
+    fun azConfig(dockingSide: AzDockingSide = AzDockingSide.LEFT, packButtons: Boolean = false, noMenu: Boolean = false, vibrate: Boolean = false, displayAppName: Boolean = false, activeClassifiers: Set<String> = emptySet(), usePhysicalDocking: Boolean = false, expandedWidth: Dp = 160.dp, collapsedWidth: Dp = 100.dp, showFooter: Boolean = true, appRepositoryUrl: String = "", dimBehindMenu: Boolean = false, dimBehindMenuAlpha: Float = 0.4f, menuItemAlignment: AzMenuItemAlignment = AzMenuItemAlignment.SIDE, justifyMenuItems: Boolean = true)
 
     /**
      * Configures the visual theme of the rail.
@@ -123,10 +124,10 @@ interface AzNavRailScope {
         itemEntrance: AzEntrance = AzEntrance.Turnstile,
         itemExit: AzExit = AzExit.Turnstile,
         itemTextStyle: TextStyle? = null,
-        entranceStaggerMs: Int = 55,
-        entranceDurationMs: Int = 360,
+        entranceStaggerMs: Int = 60,
+        entranceDurationMs: Int = 720,
         entranceEasing: Easing = AzEasing.Wp7Decelerate,
-        entranceStartAngle: Float = 70f,
+        entranceStartAngle: Float = 90f,
         tiltOnPress: Boolean = false,
         maxTiltDegrees: Float = 10f,
         titleEntrance: AzEntrance = AzEntrance.Turnstile,
@@ -805,6 +806,16 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     /** If true, the docking side tracks the physical device edge, adapting to rotation. */
     var usePhysicalDocking: Boolean = false
 
+    // -- Menu drawer look/feel (side-align, kerning-justify, dim scrim) --
+    /** When true, expanding the drawer draws a dim scrim over the rest of the app. */
+    var dimBehindMenu: Boolean = false
+    /** Alpha of the [dimBehindMenu] scrim (0..1). Default 0.4. Ignored when [dimBehindMenu] is false. */
+    var dimBehindMenuAlpha: Float = 0.4f
+    /** How menu-drawer labels are horizontally aligned within their rows. Default [AzMenuItemAlignment.SIDE]. */
+    var menuItemAlignment: AzMenuItemAlignment = AzMenuItemAlignment.SIDE
+    /** When true, menu-drawer labels are full-justified via computed letter-spacing. Default true. */
+    var justifyMenuItems: Boolean = true
+
     // Theme
     /** Color applied to selected/active items and connecting lines. [Color.Unspecified] falls back to [MaterialTheme.colorScheme.primary]. */
     var activeColor: Color = Color.Unspecified
@@ -830,13 +841,13 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     /** Optional style merged over each menu item's label. */
     var itemTextStyle: TextStyle? = null
     /** Per-item cascade delay (ms), multiplied by position. */
-    var entranceStaggerMs: Int = 55
+    var entranceStaggerMs: Int = 60
     /** Duration (ms) of each item's entrance/exit. */
-    var entranceDurationMs: Int = 360
+    var entranceDurationMs: Int = 720
     /** Easing for the entrance/exit. */
     var entranceEasing: Easing = AzEasing.Wp7Decelerate
     /** Starting `rotationY` (deg) for the turnstile sweep. */
-    var entranceStartAngle: Float = 70f
+    var entranceStartAngle: Float = 90f
     /** When true, menu items tilt toward the press point (suppressed for draggable items). */
     var tiltOnPress: Boolean = false
     /** Maximum tilt angle (deg) for [tiltOnPress]. */
@@ -851,7 +862,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
     var advancedConfig: AzAdvancedConfig = AzAdvancedConfig()
 
 
-    override fun azConfig(dockingSide: AzDockingSide, packButtons: Boolean, noMenu: Boolean, vibrate: Boolean, displayAppName: Boolean, activeClassifiers: Set<String>, usePhysicalDocking: Boolean, expandedWidth: Dp, collapsedWidth: Dp, showFooter: Boolean, appRepositoryUrl: String) {
+    override fun azConfig(dockingSide: AzDockingSide, packButtons: Boolean, noMenu: Boolean, vibrate: Boolean, displayAppName: Boolean, activeClassifiers: Set<String>, usePhysicalDocking: Boolean, expandedWidth: Dp, collapsedWidth: Dp, showFooter: Boolean, appRepositoryUrl: String, dimBehindMenu: Boolean, dimBehindMenuAlpha: Float, menuItemAlignment: AzMenuItemAlignment, justifyMenuItems: Boolean) {
         this.dockingSide = dockingSide
         this.packButtons = packButtons
         this.noMenu = noMenu
@@ -863,6 +874,10 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         this.collapsedWidth = collapsedWidth
         this.showFooter = showFooter
         this.appRepositoryUrl = appRepositoryUrl
+        this.dimBehindMenu = dimBehindMenu
+        this.dimBehindMenuAlpha = dimBehindMenuAlpha
+        this.menuItemAlignment = menuItemAlignment
+        this.justifyMenuItems = justifyMenuItems
     }
 
     override fun azAbout(inAppAbout: Boolean, moreFromAzEnabled: Boolean, moreFromAzJsonUrl: String, moreRailItem: Boolean) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AboutOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AboutOverlay.kt
@@ -1,22 +1,31 @@
 package com.hereliesaz.aznavrail.internal
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.border
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -27,6 +36,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -34,18 +44,26 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
 import com.hereliesaz.aznavrail.AzNavRailScopeImpl
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzDocEntry
+import com.hereliesaz.aznavrail.model.AzMoreFromApp
 import com.hereliesaz.aznavrail.service.GithubDocsRepository
+import com.hereliesaz.aznavrail.service.MoreFromAzRepository
 import com.hereliesaz.aznavrail.AzButton
 import com.hereliesaz.aznavrail.AzDivider
 import com.hereliesaz.aznavrail.AzLoad
 import com.hereliesaz.aznavrail.LocalAzSafeZones
+import kotlin.math.abs
 
 /** UI state for the About reader's table-of-contents fetch. */
 private sealed interface DocsUi {
@@ -55,14 +73,14 @@ private sealed interface DocsUi {
 }
 
 /**
- * Full-screen, themed in-app About reader. Auto-discovers the consuming app's markdown docs (root +
- * `docs/`) from [repoUrl], lists them as a table of contents, and renders the selected doc inline via
- * [AzMarkdown]. A GitHub repo button sits at the bottom with extra spacing, and an optional
- * "More from Az" entry opens the author's other-apps carousel.
+ * Full-screen, themed in-app About reader.
  *
- * Built from the rail's own components ([AzButton], [AzLoad], [AzDivider]) and tokens
- * ([AzNavRailScopeImpl.activeColor], [AzNavRailScopeImpl.translucentBackground]) so it matches the
- * rail's aesthetic. Dismissed via the close button or the system back button.
+ * Layout is two vertically-stacked halves:
+ *  - **Top half** — auto-generated table of contents of the app's markdown docs (`.md` files in the
+ *    repo root and `docs/`). Selecting a row swaps in the [DocReader] inline.
+ *  - **Bottom half** — a **focus-based "More from Az" carousel** with a 5-item size pattern
+ *    (small · medium · LARGE · medium · small). The LARGE (center-most) item is the currently active
+ *    app; its banner (when present), name, description, and link buttons are rendered below the row.
  */
 @Composable
 internal fun AboutOverlay(
@@ -86,6 +104,19 @@ internal fun AboutOverlay(
             onSuccess = { DocsUi.Loaded(it.entries, it.rateLimitedOrOffline) },
             onFailure = { DocsUi.Error },
         )
+    }
+
+    // Fetch More-from-Az apps for the bottom-half carousel. We render eagerly so the developer can
+    // scroll the carousel while a doc is loading in the top half.
+    val moreApps by produceState<List<AzMoreFromApp>?>(
+        initialValue = null,
+        scope.advancedConfig.moreFromAzEnabled,
+        scope.advancedConfig.moreFromAzJsonUrl,
+    ) {
+        value = if (scope.advancedConfig.moreFromAzEnabled) {
+            MoreFromAzRepository.fetch(context, scope.advancedConfig.moreFromAzJsonUrl)
+                .getOrNull()?.apps ?: emptyList()
+        } else emptyList()
     }
 
     Box(
@@ -130,59 +161,53 @@ internal fun AboutOverlay(
                     DocReader(entry = selected!!, accent = accent)
                 }
             } else {
-                when (val state = docs) {
-                    is DocsUi.Loading -> Box(Modifier.fillMaxSize(), Alignment.Center) { AzLoad() }
-                    is DocsUi.Error -> ErrorState(accent) { /* retry via recomposition key bump not needed */ onDismiss() }
-                    is DocsUi.Loaded -> {
-                        if (state.entries.isEmpty()) {
-                            Box(Modifier.fillMaxSize().weight(1f), Alignment.Center) {
-                                Text(
-                                    "No documentation found in this repository.",
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                                )
-                            }
-                        } else {
-                            if (state.offline) {
-                                Text(
-                                    "Showing cached docs (offline or rate-limited).",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                                )
-                                Spacer(Modifier.height(8.dp))
-                            }
-                            LazyColumn(
-                                modifier = Modifier.weight(1f).fillMaxWidth(),
-                                verticalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                items(state.entries, key = { it.path }) { entry ->
-                                    TocRow(entry.title, accent) { selected = entry }
+                // TOP HALF — docs TOC. Always occupies the top ~50% of the overlay.
+                Box(Modifier.weight(1f).fillMaxWidth()) {
+                    when (val state = docs) {
+                        is DocsUi.Loading -> Box(Modifier.fillMaxSize(), Alignment.Center) { AzLoad() }
+                        is DocsUi.Error -> ErrorState(accent) { onDismiss() }
+                        is DocsUi.Loaded -> {
+                            Column(Modifier.fillMaxSize()) {
+                                if (state.offline) {
+                                    Text(
+                                        "Showing cached docs (offline or rate-limited).",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                                    )
+                                    Spacer(Modifier.height(8.dp))
+                                }
+                                if (state.entries.isEmpty()) {
+                                    Box(Modifier.fillMaxSize(), Alignment.Center) {
+                                        Text(
+                                            "No documentation found in this repository.",
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                                        )
+                                    }
+                                } else {
+                                    LazyColumn(
+                                        modifier = Modifier.fillMaxSize(),
+                                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                                    ) {
+                                        items(state.entries, key = { it.path }) { entry ->
+                                            TocRow(entry.title, accent) { selected = entry }
+                                        }
+                                    }
                                 }
                             }
                         }
-                        // Pinned bottom: "More from Az" (persistent, never scrolls away) then the
-                        // GitHub link, both separated from the list.
-                        Spacer(Modifier.height(32.dp))
-                        AzDivider()
-                        Spacer(Modifier.height(16.dp))
-                        if (onOpenMoreFromAz != null) {
-                            AzButton(
-                                onClick = { onOpenMoreFromAz() },
-                                text = "More from Az",
-                                color = accent,
-                                activeColor = accent,
-                                shape = AzButtonShape.RECTANGLE,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                            Spacer(Modifier.height(12.dp))
-                        }
-                        AzButton(
-                            onClick = { openUrl(context, repoUrl) },
-                            text = "View on GitHub",
-                            color = accent,
-                            activeColor = accent,
-                            shape = AzButtonShape.RECTANGLE,
-                            modifier = Modifier.fillMaxWidth(),
+                    }
+                }
+
+                // BOTTOM HALF — More-from-Az focused-hero carousel + active-app info panel.
+                if (scope.advancedConfig.moreFromAzEnabled) {
+                    Spacer(Modifier.height(12.dp))
+                    AzDivider()
+                    Spacer(Modifier.height(8.dp))
+                    Box(Modifier.weight(1f).fillMaxWidth()) {
+                        MoreFromAzHeroCarousel(
+                            apps = moreApps,
+                            accent = accent,
                         )
                     }
                 }
@@ -245,7 +270,206 @@ private fun ErrorState(accent: Color, onClose: () -> Unit) {
     }
 }
 
-private fun openUrl(context: android.content.Context, url: String) {
+// --- More-from-Az focused-hero carousel ---------------------------------------------------------
+
+private val HERO_LARGE = 132.dp
+private val HERO_MEDIUM = 96.dp
+private val HERO_SMALL = 64.dp
+private val HERO_SPACING = 12.dp
+
+/**
+ * Horizontal LazyRow with center-snap fling and per-item scaling. Sizes derive from each item's
+ * distance from the row's visual center:
+ *   0 tiles away  → LARGE (the active app)
+ *   1 tile away   → MEDIUM
+ *   2+ tiles away → SMALL
+ * The active app's banner (when present), name, description, and link buttons render below the row.
+ */
+@Composable
+private fun MoreFromAzHeroCarousel(
+    apps: List<AzMoreFromApp>?,
+    accent: Color,
+) {
+    when {
+        apps == null -> Box(Modifier.fillMaxSize(), Alignment.Center) { AzLoad() }
+        apps.isEmpty() -> Box(Modifier.fillMaxSize(), Alignment.Center) {
+            Text(
+                "No apps to show right now.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+            )
+        }
+        else -> {
+            val listState = rememberLazyListState()
+            val fling = rememberSnapFlingBehavior(lazyListState = listState)
+            val context = LocalContext.current
+
+            // Active index = the item whose center is closest to the row's visual center.
+            val activeIndex by remember(apps) {
+                derivedStateOf {
+                    val info = listState.layoutInfo
+                    val viewportCenter = (info.viewportStartOffset + info.viewportEndOffset) / 2
+                    info.visibleItemsInfo.minByOrNull {
+                        abs((it.offset + it.size / 2) - viewportCenter)
+                    }?.index ?: listState.firstVisibleItemIndex
+                }
+            }
+            val activeApp = apps.getOrNull(activeIndex)
+
+            Column(Modifier.fillMaxSize()) {
+                BoxWithConstraints(Modifier.fillMaxWidth().height(HERO_LARGE + 24.dp)) {
+                    val density = LocalDensity.current
+                    val edgePadding = with(density) { ((maxWidth - HERO_LARGE) / 2).coerceAtLeast(0.dp) }
+                    LazyRow(
+                        state = listState,
+                        flingBehavior = fling,
+                        contentPadding = PaddingValues(horizontal = edgePadding),
+                        horizontalArrangement = Arrangement.spacedBy(HERO_SPACING),
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        items(apps.size, key = { it }) { index ->
+                            val distance = kotlin.math.abs(index - activeIndex)
+                            val target: Dp = when (distance) {
+                                0 -> HERO_LARGE
+                                1 -> HERO_MEDIUM
+                                else -> HERO_SMALL
+                            }
+                            val size by animateDpAsState(target, label = "heroSize")
+                            HeroCard(
+                                app = apps[index],
+                                size = size,
+                                accent = accent,
+                                active = index == activeIndex,
+                                onClick = {
+                                    if (index == activeIndex) {
+                                        apps[index].primaryUrl?.let { openUrl(context, it) }
+                                    } else {
+                                        // Tapping a non-center card would ideally scroll it to center; the
+                                        // snapping-fling behavior will pull it in on the next drag.
+                                    }
+                                },
+                            )
+                        }
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+                activeApp?.let { ActiveAppPanel(it, accent) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeroCard(
+    app: AzMoreFromApp,
+    size: Dp,
+    accent: Color,
+    active: Boolean,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(20.dp)
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(shape)
+            .border(
+                width = if (active) 2.dp else 1.dp,
+                color = if (active) accent else accent.copy(alpha = 0.4f),
+                shape = shape,
+            )
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center,
+    ) {
+        if (isAppIcon(app.iconUrl)) {
+            Image(
+                painter = rememberAsyncImagePainter(app.iconUrl),
+                contentDescription = app.name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize().clip(shape),
+            )
+        } else {
+            Text(
+                app.name.take(2).uppercase(),
+                style = MaterialTheme.typography.headlineMedium,
+                color = accent,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActiveAppPanel(app: AzMoreFromApp, accent: Color) {
+    val context = LocalContext.current
+    Column(
+        Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+    ) {
+        if (!app.bannerUrl.isNullOrBlank()) {
+            Image(
+                painter = rememberAsyncImagePainter(app.bannerUrl),
+                contentDescription = "${app.name} banner",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(96.dp)
+                    .clip(RoundedCornerShape(12.dp)),
+            )
+            Spacer(Modifier.height(12.dp))
+        }
+        Text(
+            app.name,
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (app.description.isNotBlank()) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                app.description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            app.playStoreUrl?.let {
+                AzButton(
+                    onClick = { openUrl(context, it) },
+                    text = "Play",
+                    color = accent,
+                    activeColor = accent,
+                    shape = AzButtonShape.RECTANGLE,
+                )
+            }
+            if (!app.webUrl.isNullOrBlank()) {
+                AzButton(
+                    onClick = { openUrl(context, app.webUrl!!) },
+                    text = if (app.isPwa) "Open" else "Website",
+                    color = accent,
+                    activeColor = accent,
+                    shape = AzButtonShape.RECTANGLE,
+                )
+            }
+            app.githubUrl?.let {
+                AzButton(
+                    onClick = { openUrl(context, it) },
+                    text = "GitHub",
+                    color = accent,
+                    activeColor = accent,
+                    shape = AzButtonShape.RECTANGLE,
+                )
+            }
+        }
+    }
+}
+
+/** The URL a card opens when tapped: prefer the website/PWA, then Play, then the GitHub repo. */
+private val AzMoreFromApp.primaryUrl: String?
+    get() = webUrl ?: playStoreUrl ?: githubUrl
+
+/** True only for a genuine app icon — never the owner's GitHub avatar. */
+private fun isAppIcon(url: String): Boolean =
+    url.isNotBlank() && !url.contains("avatars.githubusercontent.com", ignoreCase = true)
+
+private fun openUrl(context: Context, url: String) {
     try {
         context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
     } catch (_: Exception) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzKinetics.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzKinetics.kt
@@ -67,13 +67,18 @@ internal fun rememberAzKineticModifier(
 
     // Hidden (pre-entrance) pose. In FAB mode, or for SlideUp, the cascade is a vertical slide.
     val hiddenRotY = if (!floating && entrance == AzEntrance.Turnstile) startAngle else 0f
-    val hiddenAlpha = if (entrance == AzEntrance.None) 1f else 0f
+    // Pure Turnstile (docked): rotation only, no fade — the item swings from edge-on to flat.
+    // Fade/SlideUp still fade in; None stays fully opaque.
+    val entranceUsesAlpha = entrance == AzEntrance.Fade || entrance == AzEntrance.SlideUp ||
+        (entrance == AzEntrance.Turnstile && floating)
+    val hiddenAlpha = if (entranceUsesAlpha) 0f else 1f
     val hiddenTransY =
         if (entrance != AzEntrance.None && (floating || entrance == AzEntrance.SlideUp)) cascadeDist else 0f
 
     // Exit pose. None means "do not animate out" (the parent just unmounts).
     val exitRotY = if (!floating && exit == AzExit.Turnstile) startAngle else 0f
-    val exitAlpha = if (exit == AzExit.None) 1f else 0f
+    val exitUsesAlpha = exit == AzExit.Fade || (exit == AzExit.Turnstile && floating)
+    val exitAlpha = if (exitUsesAlpha) 0f else 1f
     val exitTransY = if (exit != AzExit.None && floating) -cascadeDist else 0f
 
     val rotY = remember { Animatable(hiddenRotY) }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
@@ -3,6 +3,9 @@ package com.hereliesaz.aznavrail.internal
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
@@ -13,15 +16,22 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.aznavrail.AzNavRailScopeImpl
+import com.hereliesaz.aznavrail.model.AzEasing
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Renders the pinned footer strip shown at the bottom of the expanded menu.
@@ -50,14 +60,41 @@ internal fun Footer(
     scope: AzNavRailScopeImpl,
     repoUrl: String,
     footerColor: Color,
-    onAboutClick: (() -> Unit)? = null
+    onAboutClick: (() -> Unit)? = null,
+    // Accordion-unfold controls. `visible` drives the anim; the delay is `(menuItemCount-1)*staggerMs`
+    // so the footer begins the moment the LAST menu item begins its own kinetic entrance.
+    visible: Boolean = true,
+    menuItemCount: Int = 0,
+    staggerMs: Int = 60,
+    durationMs: Int = 720,
+    easing: Easing = AzEasing.Wp7Decelerate,
 ) {
     val context = LocalContext.current
+
+    // Accordion-unfold: scaleY 0→1 from the top edge + alpha 0→1, keyed off `visible`.
+    val scaleY = remember { Animatable(if (visible) 1f else 0f) }
+    val fade = remember { Animatable(if (visible) 1f else 0f) }
+    LaunchedEffect(visible) {
+        val spec = tween<Float>(durationMillis = durationMs, easing = easing)
+        if (visible) {
+            delay((menuItemCount - 1).coerceAtLeast(0).toLong() * staggerMs)
+            launch { scaleY.animateTo(1f, spec) }
+            launch { fade.animateTo(1f, spec) }
+        } else {
+            launch { scaleY.snapTo(0f) }
+            launch { fade.snapTo(0f) }
+        }
+    }
 
     // Footer items strictly on their own rows (Column) and center aligned
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .graphicsLayer {
+                this.scaleY = scaleY.value
+                this.alpha = fade.value
+                transformOrigin = TransformOrigin(0.5f, 0f)
+            }
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MenuItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MenuItem.kt
@@ -25,9 +25,16 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.navigation.NavController
+import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzMenuItemAlignment
 import com.hereliesaz.aznavrail.model.AzNavItem
 
 /**
@@ -61,7 +68,10 @@ internal fun MenuItem(
     helpEnabled: Boolean = false,
     activeColor: androidx.compose.ui.graphics.Color? = null,
     kineticModifier: Modifier = Modifier,
-    textStyle: TextStyle? = null
+    textStyle: TextStyle? = null,
+    dockingSide: AzDockingSide = AzDockingSide.LEFT,
+    menuItemAlignment: AzMenuItemAlignment = AzMenuItemAlignment.SIDE,
+    justifyMenuItems: Boolean = true
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -187,6 +197,17 @@ internal fun MenuItem(
             }
             .background(backgroundColor)
     ) {
+        val textAlign = when (menuItemAlignment) {
+            AzMenuItemAlignment.CENTER -> TextAlign.Center
+            AzMenuItemAlignment.SIDE ->
+                if (dockingSide == AzDockingSide.RIGHT) TextAlign.End else TextAlign.Start
+        }
+        val columnAlignment = when (menuItemAlignment) {
+            AzMenuItemAlignment.CENTER -> Alignment.CenterHorizontally
+            AzMenuItemAlignment.SIDE ->
+                if (dockingSide == AzDockingSide.RIGHT) Alignment.End else Alignment.Start
+        }
+
         Row(
             modifier = modifier
                 .fillMaxWidth()
@@ -197,18 +218,39 @@ internal fun MenuItem(
             verticalAlignment = Alignment.CenterVertically
         ) {
             val lines = textToShow.split('\n')
+            val mergedStyle = MaterialTheme.typography.titleLarge.merge(textStyle)
+            // Measure natural width per line and compute a per-line letter-spacing that fills the row
+            // (kerning-justify). Single-character or overflowing lines are skipped.
+            val textMeasurer = rememberTextMeasurer()
+            val density = LocalDensity.current
+
             Column(
                 modifier = Modifier.weight(1f),
-                horizontalAlignment = Alignment.CenterHorizontally
+                horizontalAlignment = columnAlignment
             ) {
-                lines.forEachIndexed { index, line ->
-                    Text(
-                        text = line,
-                        style = MaterialTheme.typography.titleLarge.merge(textStyle),
-                        color = textColor,
-                        modifier = Modifier,
-                        textAlign = androidx.compose.ui.text.style.TextAlign.Center
-                    )
+                androidx.compose.foundation.layout.BoxWithConstraints(Modifier.fillMaxWidth()) {
+                    val availableWidthPx = with(density) { maxWidth.toPx() }
+                    Column(horizontalAlignment = columnAlignment) {
+                        lines.forEach { line ->
+                            val kerning = if (!justifyMenuItems || line.length < 2) 0.sp
+                            else {
+                                val naturalWidthPx = try {
+                                    textMeasurer.measure(text = line, style = mergedStyle).size.width.toFloat()
+                                } catch (_: Throwable) { availableWidthPx }
+                                val extraPx = availableWidthPx - naturalWidthPx
+                                if (extraPx <= 0f) 0.sp
+                                else with(density) { (extraPx / (line.length - 1)).toSp() }
+                            }
+                            Text(
+                                text = line,
+                                style = mergedStyle,
+                                color = textColor,
+                                modifier = Modifier.fillMaxWidth(),
+                                textAlign = textAlign,
+                                letterSpacing = kerning,
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzAboutModels.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzAboutModels.kt
@@ -35,5 +35,7 @@ data class AzMoreFromApp(
     val githubUrl: String? = null,
     val playStoreUrl: String? = null,
     val webUrl: String? = null,
-    val isPwa: Boolean = false
+    val isPwa: Boolean = false,
+    /** Optional banner (docs/banner.* in the app's repo) shown at the top of the app's info panel. */
+    val bannerUrl: String? = null,
 )

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzMenuItemAlignment.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzMenuItemAlignment.kt
@@ -1,0 +1,10 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * How the text of a menu-drawer label is aligned inside its row.
+ *
+ * - [CENTER] — legacy behavior: center-aligned regardless of docking side.
+ * - [SIDE]   — aligned to the docked side (`Start` when docked LEFT, `End` when docked RIGHT).
+ *              This is the WP7-style default: labels hug the same edge the rail itself is anchored to.
+ */
+enum class AzMenuItemAlignment { CENTER, SIDE }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/MoreFromAzRepository.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/service/MoreFromAzRepository.kt
@@ -2,8 +2,15 @@ package com.hereliesaz.aznavrail.service
 
 import android.content.Context
 import com.hereliesaz.aznavrail.model.AzMoreFromApp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
 
 /**
  * Reads the **baked** "More from Az" manifest produced by `.github/workflows/bump-more-from-az.yml`.
@@ -21,11 +28,93 @@ object MoreFromAzRepository {
     /** Result of [fetch]: the manifest version plus the apps to render (already Play-first sorted). */
     data class MoreFromResult(val version: Int, val apps: List<AzMoreFromApp>)
 
-    /** Fetches and parses the baked manifest from [jsonUrl] (cached via [AzHttpCache]). */
+    /** Fetches and parses the baked manifest from [jsonUrl] (cached via [AzHttpCache]).
+     *
+     *  After parsing, entries with a blank/avatar iconUrl trigger a repo-level icon walk against
+     *  raw.githubusercontent.com (standard mipmap paths, adaptive-icon xml, opengraph fallback).
+     *  Entries with an unknown bannerUrl trigger the same walk for `docs/banner.*`. Both walks are
+     *  best-effort: any failure leaves the field as-is. */
     suspend fun fetch(context: Context, jsonUrl: String): Result<MoreFromResult> {
         val res = AzHttpCache.get(context, jsonUrl)
             ?: return Result.failure(IllegalStateException("Could not load $jsonUrl"))
-        return runCatching { parse(res.body) }
+        val parsed = runCatching { parse(res.body) }.getOrElse { return Result.failure(it) }
+        val enriched = runCatching { enrichWithRepoAssets(parsed.apps) }.getOrDefault(parsed.apps)
+        return Result.success(parsed.copy(apps = enriched))
+    }
+
+    /** Fills in [AzMoreFromApp.iconUrl] and [AzMoreFromApp.bannerUrl] from the app's GitHub repo when
+     *  the manifest didn't already supply them. Runs the per-app walks in parallel. */
+    internal suspend fun enrichWithRepoAssets(apps: List<AzMoreFromApp>): List<AzMoreFromApp> =
+        coroutineScope {
+            apps.map { app ->
+                async(Dispatchers.IO) {
+                    val gh = app.githubUrl ?: return@async app
+                    val (owner, repo) = GithubDocsRepository.parseRepo(gh) ?: return@async app
+                    val needsIcon = app.iconUrl.isBlank() ||
+                        app.iconUrl.contains("avatars.githubusercontent.com")
+                    val needsBanner = app.bannerUrl.isNullOrBlank()
+                    if (!needsIcon && !needsBanner) return@async app
+                    val newIcon = if (needsIcon) resolveRepoIcon(owner, repo) else app.iconUrl
+                    val newBanner = if (needsBanner) resolveRepoBanner(owner, repo) else app.bannerUrl
+                    app.copy(iconUrl = newIcon.ifBlank { app.iconUrl }, bannerUrl = newBanner)
+                }
+            }.awaitAll()
+        }
+
+    /** Standard Android launcher icon paths, densities highest → lowest, webp before png. */
+    private val launcherIconPaths = listOf(
+        "app/src/main/res/mipmap-xxxhdpi/ic_launcher.webp",
+        "app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+        "app/src/main/res/mipmap-xxhdpi/ic_launcher.webp",
+        "app/src/main/res/mipmap-xxhdpi/ic_launcher.png",
+        "app/src/main/res/mipmap-xhdpi/ic_launcher.webp",
+        "app/src/main/res/mipmap-xhdpi/ic_launcher.png",
+        "app/src/main/res/mipmap-hdpi/ic_launcher.png",
+    )
+
+    private val bannerNames = listOf(
+        "docs/banner.png", "docs/banner.webp", "docs/banner.jpg", "docs/banner.jpeg",
+        "docs/Banner.png", "docs/Banner.webp",
+        "docs/hero.png", "docs/hero.webp",
+    )
+
+    /** HEAD-checks common Android launcher-icon paths on the default branch's raw content. On miss,
+     *  falls back to the repo's OpenGraph social preview (always present, but is the repo card, not
+     *  necessarily the app icon). Returns "" only on total failure. */
+    internal suspend fun resolveRepoIcon(owner: String, repo: String): String {
+        // Try both "main" and "HEAD" (HEAD is resolved by GitHub to the default branch).
+        for (branch in listOf("main", "master", "HEAD")) {
+            for (path in launcherIconPaths) {
+                val url = "https://raw.githubusercontent.com/$owner/$repo/$branch/$path"
+                if (headOk(url)) return url
+            }
+        }
+        return "https://opengraph.githubassets.com/1/$owner/$repo"
+    }
+
+    internal suspend fun resolveRepoBanner(owner: String, repo: String): String? {
+        for (branch in listOf("main", "master", "HEAD")) {
+            for (name in bannerNames) {
+                val url = "https://raw.githubusercontent.com/$owner/$repo/$branch/$name"
+                if (headOk(url)) return url
+            }
+        }
+        return null
+    }
+
+    private suspend fun headOk(url: String): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val conn = URL(url).openConnection() as HttpURLConnection
+            conn.instanceFollowRedirects = true
+            conn.requestMethod = "HEAD"
+            conn.connectTimeout = 6000
+            conn.readTimeout = 6000
+            val code = conn.responseCode
+            conn.disconnect()
+            code in 200..299
+        } catch (_: Exception) {
+            false
+        }
     }
 
     /** Parses the manifest JSON into a Play-first list of apps; tolerant of un-baked entries. */
@@ -64,6 +153,7 @@ object MoreFromAzRepository {
                 playStoreUrl = o.optStringOrNull("play"),
                 webUrl = o.optStringOrNull("web"),
                 isPwa = o.optBoolean("isPwa", false),
+                bannerUrl = o.optStringOrNull("bannerUrl"),
             )
         }
         // Un-baked link object { github?, play?, web? } -> degraded card.

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -93,6 +93,20 @@ falls back to the AzNavRail library repo. On **web** there is no package namespa
 While a footer screen (About or More from Az) is open, visible Help cards and any guidance callouts
 are hidden and restore exactly where they were on close (all platforms).
 
+**About page layout.** The About screen is split into two vertically-stacked halves:
+
+- **Top half** — auto-generated table of contents of the app's markdown docs (`.md` files in the
+  repo root and `docs/`). Selecting a row swaps in an inline reader for that document.
+- **Bottom half** — a **focused-hero More-from-Az carousel** with a size pattern
+  `small · medium · LARGE · medium · small`. The LARGE (center) item is the currently active app;
+  its **banner** (when the repo has `docs/banner.png` / `.webp` / `.jpg` — or `docs/hero.*`),
+  name, description, and link buttons (Play / Website / GitHub) render below the carousel.
+
+**Icons & banners** are baked into `more-from-az.json` by CI (Play `og:image` → website `og:image` →
+Android launcher icons on `raw.githubusercontent.com` → repo social preview). If the manifest is
+stale or `iconUrl` is blank at runtime, the runtime performs the same launcher-icon walk itself so
+new apps show a proper icon before the next CI bake.
+
 
 ### B. Theming (`azTheme`)
 Controls visual style defaults.
@@ -124,10 +138,20 @@ config-driven (preset enums, no free-composable escape hatch). Defaults animate;
 / `AzExit.None` to opt a surface out. In **FAB / floating** mode the cascade becomes a vertical up/down
 slide (no docked edge to hinge on).
 
+The signature look is a **pure 90° `rotationY` sweep** hinged on the docked edge — no fade, no vertical
+slide. Items overlap heavily by default: `entranceDurationMs = 720` and `entranceStaggerMs = 60`
+means the next item begins ~60 ms after the previous one *begins* while the previous one is still
+animating. The footer (About / Feedback / @HereLiesAz) then **unfolds like an accordion** from the
+top edge, starting the moment the last item begins — so the whole rail-open motion completes in one
+continuous beat.
+
 ```kotlin
 azKinetics(
     itemEntrance = AzEntrance.Turnstile,   // None | Fade | SlideUp | Turnstile  (default Turnstile)
     itemExit = AzExit.Turnstile,           // None | Fade | Turnstile            (default Turnstile)
+    entranceStartAngle = 90f,              // pure edge-on → flat  (default 90)
+    entranceDurationMs = 720,              // per-item duration ms (default 720)
+    entranceStaggerMs = 60,                // per-item stagger ms  (default 60 → items overlap)
     tiltOnPress = true,                    // off by default on the rail (drag-safe)
     itemTextStyle = TextStyle(fontSize = 22.sp, fontWeight = FontWeight.Light),
     titleEntrance = AzEntrance.Turnstile,  // the big AzNavHost screen title
@@ -139,7 +163,33 @@ default), and its app-icon trigger carries an automatic margin.
 
 **React Implementation:** the rail reads kinetics from `settings`
 (`itemEntrance`, `itemExit`, `titleEntrance`, `tiltOnPress`, `itemTextStyle`, …); `AzDropdownMenu`
-takes matching props. `AzEasing.Wp7Decelerate` is the signature easing.
+takes matching props. `AzEasing.Wp7Decelerate` is the signature easing. On **native React Native**
+the hinge is emulated via a `translateX ±(width/2)` pivot correction around the rotation because
+`transformOrigin` is silently ignored there; on web the CSS `transform-origin: left/right center`
+does it natively.
+
+### B.1 Menu-drawer look-and-feel (dim, side-alignment, kerning-justify)
+
+Three developer knobs on `azConfig` shape the drawer itself. They only affect the **expanded-menu
+drawer** (and the standalone `AzDropdownMenu`'s panel) — small rail-button labels are unaffected.
+
+```kotlin
+azConfig(
+    dimBehindMenu = true,                              // opt-in dim scrim; default false
+    dimBehindMenuAlpha = 0.4f,                         // 0..1; default 0.4
+    menuItemAlignment = AzMenuItemAlignment.SIDE,      // SIDE (default) | CENTER
+    justifyMenuItems = true,                           // full-justify labels via letter-spacing; default true
+)
+```
+
+`SIDE` alignment: labels use `TextAlign.Start` when docked LEFT and `TextAlign.End` when docked
+RIGHT. `justifyMenuItems` measures each label's natural width, computes the extra pixels needed to
+fill the row, and applies it as `letterSpacing` — a Word-style full justification. Labels shorter
+than 2 characters, or already at/past the row width, are skipped.
+
+**React Implementation:** identical fields on `AzNavRailSettings` and on the `AzDropdownMenu` props:
+`dimBehindMenu`, `dimBehindMenuAlpha`, `menuItemAlignment: 'center' | 'side'`, `justifyMenuItems`.
+Same defaults (`side`, `true`, opt-in dim at `0.4`).
 
 ### C. Advanced Features (`azAdvanced`)
 Enables complex behaviors like drag-and-drop and help overlays.

--- a/docs/API.md
+++ b/docs/API.md
@@ -100,9 +100,23 @@ fun azConfig(
     expandedWidth: Dp = 160.dp,
     collapsedWidth: Dp = 100.dp,
     showFooter: Boolean = true,
-    appRepositoryUrl: String = ""
+    appRepositoryUrl: String = "",
+    // Menu-drawer look-and-feel:
+    dimBehindMenu: Boolean = false,
+    dimBehindMenuAlpha: Float = 0.4f,
+    menuItemAlignment: AzMenuItemAlignment = AzMenuItemAlignment.SIDE,
+    justifyMenuItems: Boolean = true,
 )
 ~~~
+
+* `dimBehindMenu` / `dimBehindMenuAlpha` — opt-in dim scrim behind the expanded drawer. When off,
+  the drawer's tap-catcher is still full-size but fully transparent (existing behaviour).
+* `menuItemAlignment: AzMenuItemAlignment` (`CENTER` | `SIDE`) — alignment of the drawer's labels
+  within their rows. Default `SIDE`: `TextAlign.Start` when docked LEFT, `TextAlign.End` when
+  docked RIGHT. Small rail-button labels are unaffected.
+* `justifyMenuItems: Boolean` — when true, each label is measured with a `TextMeasurer` and its
+  `letterSpacing` is set to the amount that fills the row edge-to-edge (Word-style justify).
+  Single-character labels and labels wider than the row are skipped. Default `true`.
 
 * `appRepositoryUrl` — **optional** override for the host app's GitHub repo used by the About reader.
   Blank (the default) auto-derives the repo from the app **namespace**: `com.<owner>.<repo>` →
@@ -144,10 +158,10 @@ fun azKinetics(
     itemEntrance: AzEntrance = AzEntrance.Turnstile,
     itemExit: AzExit = AzExit.Turnstile,
     itemTextStyle: TextStyle? = null,
-    entranceStaggerMs: Int = 55,
-    entranceDurationMs: Int = 360,
+    entranceStaggerMs: Int = 60,     // small stagger → items overlap heavily
+    entranceDurationMs: Int = 720,   // per-item duration
     entranceEasing: Easing = AzEasing.Wp7Decelerate,
-    entranceStartAngle: Float = 70f,
+    entranceStartAngle: Float = 90f, // pure edge-on → flat, no fade, no slide
     tiltOnPress: Boolean = false,
     maxTiltDegrees: Float = 10f,
     titleEntrance: AzEntrance = AzEntrance.Turnstile,

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -93,6 +93,20 @@ falls back to the AzNavRail library repo. On **web** there is no package namespa
 While a footer screen (About or More from Az) is open, visible Help cards and any guidance callouts
 are hidden and restore exactly where they were on close (all platforms).
 
+**About page layout.** The About screen is split into two vertically-stacked halves:
+
+- **Top half** — auto-generated table of contents of the app's markdown docs (`.md` files in the
+  repo root and `docs/`). Selecting a row swaps in an inline reader for that document.
+- **Bottom half** — a **focused-hero More-from-Az carousel** with a size pattern
+  `small · medium · LARGE · medium · small`. The LARGE (center) item is the currently active app;
+  its **banner** (when the repo has `docs/banner.png` / `.webp` / `.jpg` — or `docs/hero.*`),
+  name, description, and link buttons (Play / Website / GitHub) render below the carousel.
+
+**Icons & banners** are baked into `more-from-az.json` by CI (Play `og:image` → website `og:image` →
+Android launcher icons on `raw.githubusercontent.com` → repo social preview). If the manifest is
+stale or `iconUrl` is blank at runtime, the runtime performs the same launcher-icon walk itself so
+new apps show a proper icon before the next CI bake.
+
 
 ### B. Theming (`azTheme`)
 Controls visual style defaults.
@@ -124,10 +138,20 @@ config-driven (preset enums, no free-composable escape hatch). Defaults animate;
 / `AzExit.None` to opt a surface out. In **FAB / floating** mode the cascade becomes a vertical up/down
 slide (no docked edge to hinge on).
 
+The signature look is a **pure 90° `rotationY` sweep** hinged on the docked edge — no fade, no vertical
+slide. Items overlap heavily by default: `entranceDurationMs = 720` and `entranceStaggerMs = 60`
+means the next item begins ~60 ms after the previous one *begins* while the previous one is still
+animating. The footer (About / Feedback / @HereLiesAz) then **unfolds like an accordion** from the
+top edge, starting the moment the last item begins — so the whole rail-open motion completes in one
+continuous beat.
+
 ```kotlin
 azKinetics(
     itemEntrance = AzEntrance.Turnstile,   // None | Fade | SlideUp | Turnstile  (default Turnstile)
     itemExit = AzExit.Turnstile,           // None | Fade | Turnstile            (default Turnstile)
+    entranceStartAngle = 90f,              // pure edge-on → flat  (default 90)
+    entranceDurationMs = 720,              // per-item duration ms (default 720)
+    entranceStaggerMs = 60,                // per-item stagger ms  (default 60 → items overlap)
     tiltOnPress = true,                    // off by default on the rail (drag-safe)
     itemTextStyle = TextStyle(fontSize = 22.sp, fontWeight = FontWeight.Light),
     titleEntrance = AzEntrance.Turnstile,  // the big AzNavHost screen title
@@ -139,7 +163,33 @@ default), and its app-icon trigger carries an automatic margin.
 
 **React Implementation:** the rail reads kinetics from `settings`
 (`itemEntrance`, `itemExit`, `titleEntrance`, `tiltOnPress`, `itemTextStyle`, …); `AzDropdownMenu`
-takes matching props. `AzEasing.Wp7Decelerate` is the signature easing.
+takes matching props. `AzEasing.Wp7Decelerate` is the signature easing. On **native React Native**
+the hinge is emulated via a `translateX ±(width/2)` pivot correction around the rotation because
+`transformOrigin` is silently ignored there; on web the CSS `transform-origin: left/right center`
+does it natively.
+
+### B.1 Menu-drawer look-and-feel (dim, side-alignment, kerning-justify)
+
+Three developer knobs on `azConfig` shape the drawer itself. They only affect the **expanded-menu
+drawer** (and the standalone `AzDropdownMenu`'s panel) — small rail-button labels are unaffected.
+
+```kotlin
+azConfig(
+    dimBehindMenu = true,                              // opt-in dim scrim; default false
+    dimBehindMenuAlpha = 0.4f,                         // 0..1; default 0.4
+    menuItemAlignment = AzMenuItemAlignment.SIDE,      // SIDE (default) | CENTER
+    justifyMenuItems = true,                           // full-justify labels via letter-spacing; default true
+)
+```
+
+`SIDE` alignment: labels use `TextAlign.Start` when docked LEFT and `TextAlign.End` when docked
+RIGHT. `justifyMenuItems` measures each label's natural width, computes the extra pixels needed to
+fill the row, and applies it as `letterSpacing` — a Word-style full justification. Labels shorter
+than 2 characters, or already at/past the row width, are skipped.
+
+**React Implementation:** identical fields on `AzNavRailSettings` and on the `AzDropdownMenu` props:
+`dimBehindMenu`, `dimBehindMenuAlpha`, `menuItemAlignment: 'center' | 'side'`, `justifyMenuItems`.
+Same defaults (`side`, `true`, opt-in dim at `0.4`).
 
 ### C. Advanced Features (`azAdvanced`)
 Enables complex behaviors like drag-and-drop and help overlays.

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -25,9 +25,21 @@ fun azConfig(
     expandedWidth: Dp = 160.dp,
     collapsedWidth: Dp = 100.dp,
     showFooter: Boolean = true,
-    appRepositoryUrl: String = ""
+    appRepositoryUrl: String = "",
+    // Menu-drawer look-and-feel:
+    dimBehindMenu: Boolean = false,                              // opt-in dim scrim behind the drawer
+    dimBehindMenuAlpha: Float = 0.4f,                            // 0..1 alpha of the scrim
+    menuItemAlignment: AzMenuItemAlignment = AzMenuItemAlignment.SIDE, // SIDE (default) | CENTER
+    justifyMenuItems: Boolean = true,                            // full-justify labels via letter-spacing
 )
 ~~~
+
+The menu-drawer knobs only affect the **expanded-menu drawer** labels (the standalone
+`AzDropdownMenu` mirrors them on its own `azConfig`). Small rail-button labels are unaffected.
+`SIDE` alignment resolves to `TextAlign.Start` when docked LEFT and `TextAlign.End` when RIGHT.
+`justifyMenuItems` measures each label's natural width and computes an equal `letterSpacing` so it
+fills the row edge-to-edge (Word-style justify); single-character or already-wider-than-row labels
+are skipped.
 
 `appRepositoryUrl` is an **optional** override for the About reader's repo. Blank (the default)
 auto-derives the repo from the app **namespace** on Android: `com.<owner>.<repo>` →
@@ -68,11 +80,11 @@ fun azKinetics(
     itemEntrance: AzEntrance = AzEntrance.Turnstile,
     itemExit: AzExit = AzExit.Turnstile,
     itemTextStyle: TextStyle? = null,
-    entranceStaggerMs: Int = 55,
-    entranceDurationMs: Int = 360,
+    entranceStaggerMs: Int = 60,           // small stagger → items overlap heavily
+    entranceDurationMs: Int = 720,         // per-item duration
     entranceEasing: Easing = AzEasing.Wp7Decelerate,
-    entranceStartAngle: Float = 70f,
-    tiltOnPress: Boolean = false,   // off by default on the rail (drag-safe)
+    entranceStartAngle: Float = 90f,       // pure edge-on → flat, no fade, no slide
+    tiltOnPress: Boolean = false,          // off by default on the rail (drag-safe)
     maxTiltDegrees: Float = 10f,
     titleEntrance: AzEntrance = AzEntrance.Turnstile,
     titleTextStyle: TextStyle? = null
@@ -81,8 +93,16 @@ fun azKinetics(
 
 `AzEntrance` = `None | Fade | SlideUp | Turnstile`; `AzExit` = `None | Fade | Turnstile`;
 `AzEasing.Wp7Decelerate` is the signature snappy easing. `tiltOnPress` is automatically suppressed for
-draggable/relocatable items. In React, the rail reads these from `settings` (`itemEntrance`,
-`itemExit`, `titleEntrance`, …).
+draggable/relocatable items. The default **Turnstile** entrance is a pure 90° `rotationY` sweep
+hinged on the docked edge — no fade, no vertical slide. Because the stagger (60 ms) is much smaller
+than the duration (720 ms), items overlap heavily: the next item starts ~60 ms after the previous
+begins while the previous is still animating. The footer (About / Feedback / @HereLiesAz) then
+**unfolds like an accordion** from the top edge, starting the moment the last item begins
+(delay = `(count - 1) * staggerMs`).
+
+In React, the rail reads these from `settings` (`itemEntrance`, `itemExit`, `titleEntrance`, …).
+On **native React Native** the hinge is emulated via a `translateX ±(width/2)` correction around
+`rotateY` because RN ignores `transformOrigin`; on web the CSS property applies natively.
 
 ### `azAdvanced`
 Controls system overrides, loading states, and floating window bindings.

--- a/sample-pwa/src/App.tsx
+++ b/sample-pwa/src/App.tsx
@@ -94,6 +94,9 @@ function App() {
     vibrate: false,
     activeClassifiers: new Set<string>(),
     headerIconSize: 0,
+    dimBehindMenu: false,
+    menuItemAlignment: 'side',
+    justifyMenuItems: true,
   })
 
   const themeColor = '#6200EE'
@@ -123,6 +126,9 @@ function App() {
       inAppAbout
       moreFromAzEnabled
       moreRailItem
+      dimBehindMenu={customization.dimBehindMenu}
+      menuItemAlignment={customization.menuItemAlignment}
+      justifyMenuItems={customization.justifyMenuItems}
       onDismissInfoScreen={() => {
         setShowHelp(false)
         setDismissCount((n) => n + 1)

--- a/sample-pwa/src/screens/CustomizationDemo.tsx
+++ b/sample-pwa/src/screens/CustomizationDemo.tsx
@@ -22,6 +22,10 @@ export interface CustomizationState {
   vibrate: boolean
   activeClassifiers: Set<string>
   headerIconSize: number
+  // WP7 menu-drawer knobs.
+  dimBehindMenu: boolean
+  menuItemAlignment: 'center' | 'side'
+  justifyMenuItems: boolean
 }
 
 const headerShapes = Object.values(AzHeaderIconShape) as AzHeaderIconShape[]
@@ -105,6 +109,27 @@ export default function CustomizationDemo({
         label="vibrate"
         value={state.vibrate}
         onChange={(v) => onChange({ ...state, vibrate: v })}
+      />
+
+      {/* WP7 menu-drawer knobs (new in this release). */}
+      <Toggle
+        label="dimBehindMenu — dim the rest of the app when the drawer expands (40% alpha)"
+        value={state.dimBehindMenu}
+        onChange={(v) => onChange({ ...state, dimBehindMenu: v })}
+      />
+      <Block label={`menuItemAlignment: ${state.menuItemAlignment}`}>
+        <select
+          value={state.menuItemAlignment}
+          onChange={(e) => onChange({ ...state, menuItemAlignment: e.target.value as 'center' | 'side' })}
+        >
+          <option value="side">side (docked-side aligned — default)</option>
+          <option value="center">center (legacy)</option>
+        </select>
+      </Block>
+      <Toggle
+        label="justifyMenuItems — full-justify labels via computed letter-spacing"
+        value={state.justifyMenuItems}
+        onChange={(v) => onChange({ ...state, justifyMenuItems: v })}
       />
 
       <Block label="appRepositoryUrl (required on web)">


### PR DESCRIPTION
## Summary

Delivers the intended Windows-Phone-7 kinetic look end-to-end, reshapes the About page, adds programmatic app-icon extraction from repos, and lands three long-missing menu-drawer knobs (dim, side-alignment, kerning-justify). Both platforms — `aznavrail/` (Compose) and `aznavrail-react/` (RN + react-native-web + plain web) — plus the CI bake, the SampleApp and sample-pwa, and all docs.

### 1. Kinetic animation redesigned

- Menu-item entrance/exit is now a **pure 90° `rotationY` sweep** hinged on the docked edge — no fade, no vertical slide.
- New defaults: `entranceStartAngle = 90` (was 70), `entranceDurationMs = 720` (was 360), `entranceStaggerMs = 60` (was 55). With duration ≫ stagger, items overlap heavily — the next item begins ~60 ms after the previous begins *while* the previous is still animating.
- **Native RN pivot correction**: `AzKineticItem` now measures its own width and applies `translateX ±(width/2)` before/after `rotateY` (skipped on `Platform.OS === 'web'`). Docked hinge finally shows on iOS/Android RN, not just Compose and web.

Files: `aznavrail/…/internal/AzKinetics.kt`, `aznavrail/…/AzNavRailScope.kt`, `aznavrail/…/AzDropdownMenu.kt`, `aznavrail-react/src/components/AzKinetics.tsx`, `aznavrail-react/src/AzNavRail.tsx`, `aznavrail-react/src/components/AzDropdownMenu.tsx`, `aznavrail-react/src/types.ts`.

### 2. Footer accordion

The rail and dropdown footer (About / Feedback / @HereLiesAz) unfold as one unit with `scaleY(0→1) + opacity(0→1)`, top-center transform origin, matching `Wp7Decelerate` easing, starting the moment the **last** menu item starts (delay = `(count - 1) * staggerMs`).

Files: `aznavrail/…/internal/Footer.kt`, `aznavrail/…/AzNavRail.kt` (call site), `aznavrail/…/AzDropdownMenu.kt` (AzDropdownFooter), `aznavrail-react/src/AzNavRail.tsx` (new `FooterAccordion`), `aznavrail-react/src/components/AzDropdownMenu.tsx`, plain-web CSS keyframe `@keyframes azFooterAccordion` in `aznavrail-react/src/web/MenuItem.css`.

### 3. Programmatic launcher-icon extraction

When Play/website `og:image` resolvers leave `iconUrl` blank, both the CI bake and the runtime now walk the app's repo:

1. `raw.githubusercontent.com/{owner}/{repo}/{main|master|HEAD}/app/src/main/res/mipmap-xxxhdpi/ic_launcher.webp` → `.png` → xxhdpi → xhdpi → hdpi.
2. GitHub Contents-API tree walk for any `mipmap-*/ic_launcher*.{png,webp}` (Compose Multiplatform and other layouts).
3. Adaptive-icon `mipmap-anydpi-v26/ic_launcher.xml` foreground drawable lookup.
4. Repo social preview (`opengraph.githubassets.com/1/{owner}/{repo}`) as a last resort.

Also introduces `AzMoreFromApp.bannerUrl`: both CI and runtime probe `docs/banner.png` / `.webp` / `.jpg` (and `docs/hero.*`) and expose it as a per-app banner used in the new About-page hero panel.

Files: `.github/scripts/bake_more_from_az.py`, `aznavrail/…/service/MoreFromAzRepository.kt`, `aznavrail/…/model/AzAboutModels.kt`, `aznavrail-react/src/services/moreFromAz.ts`.

### 4. About page split (top TOC / bottom focused-hero carousel)

Two vertically-stacked halves:

- **Top half** — the existing docs TOC (`.md` files in the repo root and `docs/`), unchanged internals.
- **Bottom half** — a new **focused-hero More-from-Az carousel** with a size pattern `small · medium · LARGE · medium · small`. The LARGE (center) item is the active app; its banner (when present), name, description, and link buttons (Play / Website / GitHub) render below the row.

The old pinned "More from Az" and "View on GitHub" buttons at the bottom of About are removed.

Files: `aznavrail/…/internal/AboutOverlay.kt` (rewritten), `aznavrail-react/src/components/AboutOverlay.tsx` (rewritten with `MoreFromAzHeroCarousel`), `aznavrail-react/src/web/AboutOverlay.jsx` + `AboutOverlay.css`.

### 5. New developer options on `azConfig` (and mirrored on `AzDropdownMenu`'s `azConfig`)

- **`dimBehindMenu: Boolean = false`** + **`dimBehindMenuAlpha: Float = 0.4f`** — opt-in dim scrim over the rest of the app while the drawer is open. Tap-to-collapse preserved.
- **`menuItemAlignment: AzMenuItemAlignment = SIDE`** (`SIDE` default | `CENTER`) — labels hug the docked edge (`TextAlign.Start` when LEFT, `TextAlign.End` when RIGHT).
- **`justifyMenuItems: Boolean = true`** — measures each label's natural width via `TextMeasurer` (RN `onLayout` off-screen span on JS), applies a computed `letterSpacing` so it fills the row edge-to-edge (Word-style justify). Single-character and already-overflowing labels are skipped.

Only affects **drawer** labels — small rail-button labels are unaffected.

Files (Compose): new `aznavrail/…/model/AzMenuItemAlignment.kt`, `aznavrail/…/AzNavRailScope.kt`, `aznavrail/…/internal/MenuItem.kt`, `aznavrail/…/AzNavRail.kt` (dim scrim), `aznavrail/…/AzDropdownMenu.kt` (dim scrim + row alignment + kerning).
Files (React): `aznavrail-react/src/types.ts`, `aznavrail-react/src/AzNavRail.tsx`, `aznavrail-react/src/components/RailMenuItem.tsx`, `aznavrail-react/src/components/AzDropdownMenu.tsx`, `aznavrail-react/src/web/AzNavRail.jsx`, `aznavrail-react/src/web/MenuItem.jsx`, `aznavrail-react/src/web/AzDropdownMenu.jsx`.

### Plain-web build

The `aznavrail-react/src/web/*` variant now carries the same behavior via CSS keyframes (`azTurnstile`, `azFooterAccordion`), an off-screen JS-measured `letterSpacing` pass on each drawer label, a `.az-nav-rail__scrim` overlay for the dim option, and the two-half About page with CSS scroll-snap hero carousel.

### Sample apps

- `SampleApp/…/CustomizationDemoScreen.kt` — new toggles/cyclers for `dimBehindMenu`, `menuItemAlignment`, `justifyMenuItems` plumbed through `CustomizationState` and `MainApp.kt`.
- `sample-pwa/src/screens/CustomizationDemo.tsx` and `App.tsx` — mirrored controls on the PWA sample.

### Docs

`README.md`, `docs/API.md`, `docs/DSL.md`, `docs/AZNAVRAIL_COMPLETE_GUIDE.md` (canonical + bundled `resources/` + `assets/` copies), plus `aznavrail-react/CHANGELOG.md`.

## Test plan

- [ ] `./gradlew :SampleApp:installDebug` and drive **CustomizationDemoScreen** — expand the rail, watch the 90° hinged swing with heavy overlap; the footer accordions in as the last item starts.
- [ ] Toggle `dimBehindMenu`, `menuItemAlignment`, `justifyMenuItems` in the demo — confirm each takes effect.
- [ ] Open **About** — top half shows the docs TOC; bottom half shows the 5-item hero carousel; the center card's info panel updates as the row scrolls; banner appears above the info panel for apps whose repos have `docs/banner.*`.
- [ ] Force one manifest entry to have `iconUrl = ""` — confirm the runtime `resolveRepoIcon` fills a `raw.githubusercontent.com` launcher URL and Coil loads it.
- [ ] `cd sample-pwa && pnpm dev` (or `yarn dev`) and repeat the same manual pass in the browser and via react-native-web.
- [ ] On native RN (if a linked app is available), confirm the hinge visibly sits on the docked side (translateX pivot correction is applied).
- [ ] `./gradlew :aznavrail:testDebugUnitTest` and (`cd aznavrail-react && yarn test`) — pre-existing test-file `@types/react-test-renderer` shape mismatches are unrelated to this diff.
- [ ] Dry-run `.github/scripts/bake_more_from_az.py` against a checkout with `GITHUB_TOKEN` set and inspect the resulting `more-from-az.json` — previously-empty `iconUrl` entries should resolve to `raw.githubusercontent.com/...` for apps that ship `ic_launcher.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_