### PR TITLE
fix(compose): remove duplicate AzEasing import in AzDropdownMenu

### DIFF
--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -54,7 +54,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import com.hereliesaz.aznavrail.model.AzEasing
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import androidx.compose.ui.text.TextStyle


### PR DESCRIPTION
## Summary

- Follow-up to #480: that PR introduced a duplicate `com.hereliesaz.aznavrail.model.AzEasing` import in `AzDropdownMenu.kt` — once in the block I added for the accordion-footer animation (line 57), once in the pre-existing `model.*` import group (line 81).
- Kotlin flags the duplicate FQN import as **ambiguous** and refuses to compile, so `:aznavrail:compileDebugKotlin` fails on `main`:

  ```
  e: AzDropdownMenu.kt:57:39 Conflicting import: imported name 'AzEasing' is ambiguous.
  e: AzDropdownMenu.kt:81:39 Conflicting import: imported name 'AzEasing' is ambiguous.
  ```

- Drop the duplicate at line 57. The pre-existing import at line 81, grouped with the other `model.*` imports where it belongs, is kept. No other changes.

## Test plan

- [ ] `./gradlew :aznavrail:compileDebugKotlin` succeeds on the follow-up branch.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_