### PR TITLE
Hybrid kerning + font-scale justify solver; AzDivider inherits font color

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,9 +566,15 @@ unaffected.
   dim scrim over the rest of the app while the drawer is open. Tapping the scrim collapses it.
 - **`menuItemAlignment`** (`SIDE` default | `CENTER`) — labels hug the docked edge instead of
   center-aligning. `SIDE` = `TextAlign.Start` when docked LEFT, `TextAlign.End` when RIGHT.
-- **`justifyMenuItems`** (default `true`) — measures each label's natural width and applies a
-  computed `letterSpacing` so it fills the row edge-to-edge (Word-style justify). Single-character
-  labels and labels wider than the row are skipped.
+- **`justifyMenuItems`** (default `true`) — runs a **hybrid kerning + font-scale solver**: fills
+  the row with `letterSpacing` alone until tracking would exceed `α · fontSize` (`α = 0.15`); once
+  the cap hits, the font scales up so both letter-spacing and font-size converge on the mix that
+  lands the label exactly on the row width. Font growth is capped at `1.5×`. Short/overflowing
+  labels are skipped.
+- **`AzDivider`** now defaults its color to the surrounding **font** color
+  (`LocalContentColor.current` on Compose, `currentColor` on the web), and the rail/dropdown/About
+  call sites pass their accent explicitly — the divider belongs to the same visual family as the
+  labels next to it, never a muted outline.
 
 ```kotlin
 azConfig(

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased — follow-up (hybrid justify + AzDivider color)
+
+### Changed
+- **`justifyMenuItems` now uses a hybrid kerning + font-scale solver** (`src/util/AzJustify.ts` on
+  React; `internal/AzJustify.kt` on Compose). Kerning fills the row up to `α · fontSize` of
+  tracking (`α = 0.15`); when saturated, the font scales up so both letter-spacing and font-size
+  converge on the mix that lands the label exactly on the row width. Font growth capped at `1.5×`.
+  Fixes the previous pure-letter-spacing pass over-spreading short labels.
+- **`AzDivider` inherits the font color.** New default is `LocalContentColor.current` on Compose,
+  `currentColor` on the web (React and plain-JSX builds). The rail's expanded-menu divider, the
+  About-page split divider, and the standalone `AzDropdownMenu`'s footer divider all pass their
+  accent color explicitly so the divider belongs to the same visual family as the labels next to
+  it — never a muted outline.
+
 ## Unreleased
 
 Windows-Phone-7 fidelity pass: the signature kinetic-typography entrance is redesigned end-to-end,

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -727,7 +727,9 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
   };
 
   const renderFooter = () => {
-      const footerColor = activeColor || '#6200ee';
+      // Use `config.activeColor` so DSL overrides (via `dslOverrides.activeColor`) win over the raw
+      // prop — matches the pattern used everywhere else the rail reads its theming.
+      const footerColor = config.activeColor || '#6200ee';
 
       const handleUndock = () => {
         if (enableRailDragging) {
@@ -883,7 +885,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                 <ScrollView style={styles.menuContent}>
                     {menuItems.map((item, index) => {
                          if (item.isDivider) {
-                             return <View key={item.id} style={[styles.divider, { backgroundColor: activeColor || '#6200ee' }]} />;
+                             return <View key={item.id} style={[styles.divider, { backgroundColor: config.activeColor || '#6200ee' }]} />;
                          }
                          return renderMenuItem(item, index, menuItems.length, isExpanded);
                     })}

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -777,7 +777,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
           durationMs={kDurationMs}
         >
           <View style={[styles.footer, { alignItems: 'center' }]}>
-             <View style={styles.divider} />
+             <View style={[styles.divider, { backgroundColor: footerColor }]} />
              {enableRailDragging && (
                  <TouchableOpacity onPress={handleUndock} style={{ paddingVertical: 8 }}><Text style={[styles.menuItemText, { color: footerColor, fontWeight: 'bold' }]}>{`Undock`}</Text></TouchableOpacity>
              )}
@@ -883,7 +883,7 @@ const AzNavRailInner: React.FC<AzNavRailProps> = (props) => {
                 <ScrollView style={styles.menuContent}>
                     {menuItems.map((item, index) => {
                          if (item.isDivider) {
-                             return <View key={item.id} style={styles.divider} />;
+                             return <View key={item.id} style={[styles.divider, { backgroundColor: activeColor || '#6200ee' }]} />;
                          }
                          return renderMenuItem(item, index, menuItems.length, isExpanded);
                     })}
@@ -1153,8 +1153,9 @@ const styles = StyleSheet.create({
       fontSize: 16,
   },
   divider: {
+      // backgroundColor is applied inline from `activeColor` (or the footer's accent) so the
+      // divider matches the font next to it — never a muted line.
       height: 1,
-      backgroundColor: '#ccc',
       marginVertical: 8,
   },
   footer: {

--- a/aznavrail-react/src/components/AboutOverlay.tsx
+++ b/aznavrail-react/src/components/AboutOverlay.tsx
@@ -140,7 +140,7 @@ export const AboutOverlay: React.FC<AboutOverlayProps> = ({
           {/* BOTTOM HALF — focused-hero More-from-Az carousel + active-app info panel. */}
           {moreFromAzEnabled && (
             <View style={styles.half}>
-              <View style={styles.divider} />
+              <View style={[styles.divider, { backgroundColor: accent }]} />
               <MoreFromAzHeroCarousel apps={moreApps} accent={accent} />
             </View>
           )}
@@ -255,7 +255,7 @@ const styles = StyleSheet.create({
   overlay: { ...StyleSheet.absoluteFillObject, zIndex: 3000, paddingTop: '6%', paddingBottom: '10%', paddingHorizontal: 20 },
   flex: { flex: 1 },
   half: { flex: 1 },
-  divider: { height: 1, backgroundColor: '#0000001A', marginVertical: 8 },
+  divider: { height: 1, marginVertical: 8 },
   header: { flexDirection: 'row', alignItems: 'center' },
   title: { flex: 1, fontSize: 30, fontWeight: 'bold', marginHorizontal: 8 },
   icon: { fontSize: 22, paddingHorizontal: 6 },

--- a/aznavrail-react/src/components/AzDivider.tsx
+++ b/aznavrail-react/src/components/AzDivider.tsx
@@ -16,7 +16,11 @@ export interface AzDividerProps {
  */
 export const AzDivider: React.FC<AzDividerProps> = ({
   thickness = 1,
-  color = 'rgba(0, 0, 0, 0.12)', // Default Material outline copy(alpha = 0.5f) equivalent approx
+  // Default is `currentColor` on web so the divider inherits the surrounding font color and belongs
+  // to the same visual family as the text next to it. On native (where `currentColor` isn't a thing)
+  // this falls through to the parent Text style, which is fine because the rail/dropdown pass an
+  // explicit `color` at their call sites.
+  color = 'currentColor',
   horizontalPadding = 16,
   verticalPadding = 8,
 }) => {

--- a/aznavrail-react/src/components/AzDivider.tsx
+++ b/aznavrail-react/src/components/AzDivider.tsx
@@ -16,11 +16,12 @@ export interface AzDividerProps {
  */
 export const AzDivider: React.FC<AzDividerProps> = ({
   thickness = 1,
-  // Default is `currentColor` on web so the divider inherits the surrounding font color and belongs
-  // to the same visual family as the text next to it. On native (where `currentColor` isn't a thing)
-  // this falls through to the parent Text style, which is fine because the rail/dropdown pass an
-  // explicit `color` at their call sites.
-  color = 'currentColor',
+  // Default is `currentColor` on web (react-native-web forwards it to CSS, so the divider inherits
+  // the surrounding font color and belongs to the same visual family as the text next to it). On
+  // native iOS/Android, `View.backgroundColor` does NOT understand CSS keywords and would throw at
+  // runtime, so we fall back to a subtle outline color there. The rail's/dropdown's own call sites
+  // pass their accent explicitly, so this native fallback only affects standalone uses.
+  color = typeof document !== 'undefined' ? 'currentColor' : 'rgba(0, 0, 0, 0.12)',
   horizontalPadding = 16,
   verticalPadding = 8,
 }) => {

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -20,6 +20,9 @@ import { AzButtonShape, AzDockingSide, AzDropdownDesign, AzEasing, AzEntrance, A
 import { AzNavRailDefaults } from '../AzNavRailDefaults';
 import { AboutOverlay } from './AboutOverlay';
 import { AzKineticItem, useAzClosing } from './AzKinetics';
+import { solveHybridJustify } from '../util/AzJustify';
+
+const DROPDOWN_BASE_FONT_PX = 16;
 
 /** Context the menu provides so item components can navigate, fold the menu, and match its design. */
 interface AzDropdownMenuContextValue {
@@ -171,10 +174,15 @@ export const AzDropdownItem: React.FC<AzDropdownItemProps> = ({
       const w = e.nativeEvent.layout.width;
       if (w && Math.abs(w - naturalWidth) > 0.5) setNaturalWidth(w);
     };
+    // Hybrid kerning + font-scale justify — see src/util/AzJustify.
     let letterSpacing = 0;
-    if (justify && text.length >= 2 && availableWidth > naturalWidth && naturalWidth > 0) {
-      letterSpacing = (availableWidth - naturalWidth) / (text.length - 1);
+    let fontScale = 1;
+    if (justify && text.length >= 2 && availableWidth > 0 && naturalWidth > 0) {
+      const solved = solveHybridJustify(naturalWidth, availableWidth, text.length, DROPDOWN_BASE_FONT_PX);
+      fontScale = solved.scale;
+      letterSpacing = solved.letterSpacing;
     }
+    const scaledFontSize = DROPDOWN_BASE_FONT_PX * fontScale;
     return (
       <TouchableOpacity
         style={styles.menuRow}
@@ -198,7 +206,7 @@ export const AzDropdownItem: React.FC<AzDropdownItemProps> = ({
         <Text
           style={[
             styles.menuRowText,
-            { color: textColor || color || '#6750A4', opacity: enabled ? 1 : 0.5, textAlign, letterSpacing },
+            { color: textColor || color || '#6750A4', opacity: enabled ? 1 : 0.5, textAlign, letterSpacing, fontSize: scaledFontSize },
             itemTextStyle,
           ]}
         >

--- a/aznavrail-react/src/components/RailMenuItem.tsx
+++ b/aznavrail-react/src/components/RailMenuItem.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, LayoutChangeEvent } from 'react-native';
 import { AzDockingSide, AzNavItem } from '../types';
+import { solveHybridJustify } from '../util/AzJustify';
+
+const BASE_FONT_PX = 16;
 
 /** Internal props for `RailMenuItem` — one row inside the expanded-menu scroll view. */
 interface RailMenuItemProps {
@@ -111,10 +114,21 @@ export const RailMenuItem: React.FC<RailMenuItemProps> = ({
         const w = e.nativeEvent.layout.width;
         if (w && Math.abs(w - naturalWidth) > 0.5) setNaturalWidth(w);
     };
+    // Hybrid justify: try kerning up to α·fontSize, then grow the font past that limit so both
+    // letter-spacing and font-scale reach a stable mix that fills the row. See ../util/AzJustify.
     let letterSpacing = 0;
-    if (justifyMenuItems && displayText && displayText.length >= 2 && availableWidth > naturalWidth && naturalWidth > 0) {
-        letterSpacing = (availableWidth - naturalWidth) / (displayText.length - 1);
+    let fontScale = 1;
+    if (justifyMenuItems && displayText && displayText.length >= 2 && availableWidth > 0 && naturalWidth > 0) {
+        const { scale, letterSpacing: ls } = solveHybridJustify(
+            naturalWidth,
+            availableWidth,
+            displayText.length,
+            BASE_FONT_PX,
+        );
+        fontScale = scale;
+        letterSpacing = ls;
     }
+    const scaledFontSize = BASE_FONT_PX * fontScale;
 
     return (
         <View>
@@ -141,6 +155,7 @@ export const RailMenuItem: React.FC<RailMenuItemProps> = ({
                             color: item.textColor ?? item.color ?? '#000000',
                             textAlign,
                             letterSpacing,
+                            fontSize: scaledFontSize,
                         },
                         textStyle,
                     ]}

--- a/aznavrail-react/src/util/AzJustify.ts
+++ b/aznavrail-react/src/util/AzJustify.ts
@@ -1,0 +1,50 @@
+/**
+ * Closed-form solver for the hybrid **kerning + font-scale** justification used by the WP7-style
+ * menu drawer. Mirrors `internal/AzJustify.kt` on Compose.
+ *
+ * Given the natural width of a label at its base font size, the row width to fill, the character
+ * count, and the base font size, returns `{ scale, letterSpacing }` such that
+ * `scale · naturalWidth + (n − 1) · letterSpacing === rowWidth` while never letting
+ * `letterSpacing / (scale · baseFontSize)` exceed `maxTrackingRatio`.
+ *
+ * ### Math
+ *
+ * With `n = charCount`, `W₀ = naturalWidth`, `f₀ = baseFontSize`, `W = rowWidth`,
+ * `α = maxTrackingRatio`, unknowns `s` (font scale) & `k` (letter-spacing px):
+ *
+ *  - Total width: `s·W₀ + (n − 1)·k = W`
+ *  - Kerning cap: `k ≤ α · s · f₀`
+ *
+ * Phase A tries `s = 1`, `k = (W − W₀) / (n − 1)`. If `k ≤ α · f₀`, accept.
+ *
+ * Phase B saturates the kerning: set `k = α · s · f₀` in the equation, solve
+ * `s = W / (W₀ + (n − 1) · α · f₀)`, then `k = α · s · f₀`. Clamp `s` at `[1, maxFontScale]`
+ * (if `s` clamps high the label ends up slightly shorter than the row — accept a small gap over
+ * further distortion).
+ */
+export function solveHybridJustify(
+  naturalWidth: number,
+  rowWidth: number,
+  charCount: number,
+  baseFontSize: number,
+  maxTrackingRatio = 0.15,
+  maxFontScale = 1.5,
+): { scale: number; letterSpacing: number } {
+  if (
+    charCount < 2 ||
+    naturalWidth <= 0 ||
+    rowWidth <= 0 ||
+    naturalWidth >= rowWidth
+  ) {
+    return { scale: 1, letterSpacing: 0 };
+  }
+  const gaps = charCount - 1;
+  const kAtScale1 = (rowWidth - naturalWidth) / gaps;
+  if (kAtScale1 <= maxTrackingRatio * baseFontSize) {
+    return { scale: 1, letterSpacing: kAtScale1 };
+  }
+  const denom = naturalWidth + gaps * maxTrackingRatio * baseFontSize;
+  const scale = Math.max(1, Math.min(maxFontScale, rowWidth / denom));
+  const letterSpacing = maxTrackingRatio * scale * baseFontSize;
+  return { scale, letterSpacing };
+}

--- a/aznavrail-react/src/web/AboutOverlay.css
+++ b/aznavrail-react/src/web/AboutOverlay.css
@@ -62,7 +62,14 @@
 .az-about-tocrow.emphasized { border-width: 2px; font-weight: 700; opacity: 1; }
 
 .az-about-spacer { height: 32px; }
-.az-about-divider { width: 100%; opacity: 0.3; margin: 16px 0; }
+.az-about-divider {
+  /* Default border color inherits from `currentColor`; the JSX also sets it explicitly to the
+     accent so the divider belongs to the same visual family as the font next to it. */
+  width: 100%;
+  border: none;
+  border-top: 1px solid currentColor;
+  margin: 16px 0;
+}
 
 .az-about-repo {
   display: inline-block;

--- a/aznavrail-react/src/web/AboutOverlay.jsx
+++ b/aznavrail-react/src/web/AboutOverlay.jsx
@@ -88,7 +88,7 @@ export default function AboutOverlay({ repoUrl, settings = {}, moreFromAzEnabled
           {/* BOTTOM HALF — More-from-Az focused-hero carousel + active-app info. */}
           {moreFromAzEnabled && (
             <div className="az-about-half">
-              <hr className="az-about-divider" />
+              <hr className="az-about-divider" style={{ borderTopColor: accent, color: accent }} />
               <MoreFromAzHeroCarousel apps={moreApps} accent={accent} />
             </div>
           )}

--- a/aznavrail-react/src/web/AzDivider.css
+++ b/aznavrail-react/src/web/AzDivider.css
@@ -1,6 +1,7 @@
 .az-divider {
   height: 1px;
-  background-color: rgba(0, 0, 0, 0.12); /* Default outline variant opacity */
+  /* Color is applied inline (defaulting to currentColor) so the divider inherits the surrounding
+     font color and matches the rail's accent instead of a muted outline. */
   margin: 8px 16px;
   width: calc(100% - 32px);
   flex-shrink: 0;

--- a/aznavrail-react/src/web/AzDivider.jsx
+++ b/aznavrail-react/src/web/AzDivider.jsx
@@ -4,9 +4,15 @@ import './AzDivider.css';
 /**
  * A divider component for use within AzNavRail.
  * Renders a horizontal line with standard padding.
+ *
+ * The default color is `currentColor` so the divider inherits the surrounding font color and
+ * belongs to the same visual family as the text next to it — not a muted outline.
+ *
+ * @param {object} props
+ * @param {string} [props.color='currentColor'] - CSS color; defaults to inheriting the parent's text color.
  */
-const AzDivider = () => {
-  return <div className="az-divider" />;
+const AzDivider = ({ color = 'currentColor' }) => {
+  return <div className="az-divider" style={{ backgroundColor: color }} />;
 };
 
 export default AzDivider;

--- a/aznavrail-react/src/web/AzDropdownMenu.css
+++ b/aznavrail-react/src/web/AzDropdownMenu.css
@@ -82,7 +82,9 @@
   align-items: center;
   padding: 16px;
   color: #6750A4;
-  border-top: 1px solid rgba(103, 80, 164, 0.12);
+  /* Border color matches the font (currentColor) instead of a muted outline, so the divider
+     belongs to the same visual family as the labels next to it. */
+  border-top: 1px solid currentColor;
 }
 
 .az-dropdown-menu-footer-item {

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -1,7 +1,10 @@
 import React, { createContext, useContext, useState, useRef, useEffect } from 'react';
 import AzButton from './AzButton';
 import AboutOverlay from './AboutOverlay';
+import { solveHybridJustify } from '../util/AzJustify';
 import './AzDropdownMenu.css';
+
+const DROPDOWN_WEB_BASE_FONT_PX = 16;
 
 const AzDropdownMenuContext = createContext(null);
 
@@ -47,16 +50,21 @@ export const AzDropdownItem = ({
   };
   const rowRef = useRef(null);
   const measureRef = useRef(null);
+  // Hybrid kerning + font-scale justify — see ../util/AzJustify.
   const [letterSpacing, setLetterSpacing] = useState(0);
+  const [fontScale, setFontScale] = useState(1);
   useEffect(() => {
-    if (!justifyMenuItems || !text || text.length < 2) { setLetterSpacing(0); return; }
+    if (!justifyMenuItems || !text || text.length < 2) {
+      setLetterSpacing(0); setFontScale(1); return;
+    }
     const row = rowRef.current;
     const meas = measureRef.current;
     if (!row || !meas) return;
     const w = row.getBoundingClientRect().width;
     const nat = meas.getBoundingClientRect().width;
-    if (w > nat && nat > 0) setLetterSpacing((w - nat) / (text.length - 1));
-    else setLetterSpacing(0);
+    const solved = solveHybridJustify(nat, w, text.length, DROPDOWN_WEB_BASE_FONT_PX);
+    setLetterSpacing(solved.letterSpacing);
+    setFontScale(solved.scale);
   }, [text, justifyMenuItems]);
   if (design === 'menu') {
     const hingeSide = dockingSide === 'RIGHT' ? 'right' : 'left';
@@ -74,6 +82,7 @@ export const AzDropdownItem = ({
           color: textColor || color || undefined,
           textAlign,
           letterSpacing: `${letterSpacing}px`,
+          fontSize: `${DROPDOWN_WEB_BASE_FONT_PX * fontScale}px`,
           animation: `azTurnstile ${entranceDurationMs}ms cubic-bezier(0.1, 0.9, 0.2, 1) ${index * entranceStaggerMs}ms both`,
           transformOrigin: `${hingeSide} center`,
           '--az-start-angle': `${dockingSide === 'RIGHT' ? -entranceStartAngle : entranceStartAngle}deg`,

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -334,7 +334,7 @@ const AzNavRail = ({
 
   const renderMenuItem = (item, depth = 0, index = 0, count = 1) => {
       if (item.isDivider) {
-          return <AzDivider key={item.id} />;
+          return <AzDivider key={item.id} color={activeColor || 'currentColor'} />;
       }
 
       const finalItem = item.isCycler
@@ -449,7 +449,7 @@ const AzNavRail = ({
             <div className={`rail ${packRailButtons ? 'packed' : ''}`} style={{overflowY: 'auto', maxHeight: '100%'}}>
               {effectiveRailItems
                 .map(item => {
-                  if (item.isDivider) return <AzDivider key={item.id} />;
+                  if (item.isDivider) return <AzDivider key={item.id} color={activeColor || 'currentColor'} />;
 
                   const finalItem = item.isCycler
                     ? { ...item, selectedOption: cyclerStates[item.id]?.displayedOption }

--- a/aznavrail-react/src/web/MenuItem.jsx
+++ b/aznavrail-react/src/web/MenuItem.jsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './MenuItem.css';
+import { solveHybridJustify } from '../util/AzJustify';
+
+const WEB_BASE_FONT_PX = 16;
 
 /**
  * A menu item component for the expanded navigation rail (plain-web build).
@@ -118,23 +121,31 @@ const MenuItem = ({
 
   const rowRef = useRef(null);
   const measureRef = useRef(null);
+  // Hybrid kerning + font-scale justify — see ../util/AzJustify.
   const [letterSpacing, setLetterSpacing] = useState(0);
+  const [fontScale, setFontScale] = useState(1);
   const label = (isToggle ? (isChecked ? toggleOnText : toggleOffText) : (isCycler ? selectedOption : text)) || '';
   useEffect(() => {
-    if (!justifyMenuItems || !label || label.length < 2) { setLetterSpacing(0); return; }
+    if (!justifyMenuItems || !label || label.length < 2) {
+      setLetterSpacing(0); setFontScale(1); return;
+    }
     const row = rowRef.current;
     const meas = measureRef.current;
     if (!row || !meas) return;
     const rowWidth = row.getBoundingClientRect().width - paddingLeft - 16;
     const natural = meas.getBoundingClientRect().width;
-    if (rowWidth > natural && natural > 0) {
-      setLetterSpacing((rowWidth - natural) / (label.length - 1));
-    } else {
-      setLetterSpacing(0);
-    }
+    const solved = solveHybridJustify(natural, rowWidth, label.length, WEB_BASE_FONT_PX);
+    setLetterSpacing(solved.letterSpacing);
+    setFontScale(solved.scale);
   }, [label, justifyMenuItems, paddingLeft]);
 
-  const labelStyle = { textAlign, letterSpacing: `${letterSpacing}px`, flex: 1, color: textColor || undefined };
+  const labelStyle = {
+    textAlign,
+    letterSpacing: `${letterSpacing}px`,
+    fontSize: `${WEB_BASE_FONT_PX * fontScale}px`,
+    flex: 1,
+    color: textColor || undefined,
+  };
 
   return (
     <div

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -183,9 +183,14 @@ azConfig(
 ```
 
 `SIDE` alignment: labels use `TextAlign.Start` when docked LEFT and `TextAlign.End` when docked
-RIGHT. `justifyMenuItems` measures each label's natural width, computes the extra pixels needed to
-fill the row, and applies it as `letterSpacing` — a Word-style full justification. Labels shorter
-than 2 characters, or already at/past the row width, are skipped.
+RIGHT. `justifyMenuItems` runs a **hybrid kerning + font-scale solver**: it first tries to fill the
+row with `letterSpacing` alone, but never exceeds `α · fontSize` of tracking (default `α = 0.15`);
+once kerning saturates, the font itself scales up so both letter-spacing and font-scale converge on
+the mix that lands the label exactly on the row width. Font growth is capped at `1.5×`. Labels
+shorter than 2 characters, or already at/past the row width, are skipped. `AzDivider` also picks up
+the same font color as the surrounding text (via `LocalContentColor` on Compose and `currentColor`
+on the web), so the divider belongs to the same visual family as the labels next to it — not a
+muted outline.
 
 **React Implementation:** identical fields on `AzNavRailSettings` and on the `AzDropdownMenu` props:
 `dimBehindMenu`, `dimBehindMenuAlpha`, `menuItemAlignment: 'center' | 'side'`, `justifyMenuItems`.

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDivider.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDivider.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -21,12 +21,14 @@ import androidx.compose.ui.unit.dp
  * This composable is designed to be a direct replacement for `HorizontalDivider` or
  * `VerticalDivider` when the orientation needs to be dynamic.
  *
- * The default styling matches the divider used in the `AzNavRail` footer.
+ * The default color follows the surrounding **font color** ([LocalContentColor]) so the divider
+ * belongs to the same visual family as the text next to it — not a muted outline. The rail and the
+ * standalone `AzDropdownMenu` override this to the accent color at their divider call sites.
  *
  * @param modifier The modifier to be applied to the divider.
  * @param thickness The thickness of the divider line. Defaults to `1.dp`.
- * @param color The color of the divider line. Defaults to a semi-transparent outline color
- * from the `MaterialTheme`.
+ * @param color The color of the divider line. Defaults to [LocalContentColor.current] — the
+ * ambient text/foreground color inherited from the enclosing composition.
  * @param horizontalPadding The padding applied to the left and right of the divider.
  * Defaults to `16.dp`.
  * @param verticalPadding The padding applied to the top and bottom of the divider.
@@ -36,7 +38,7 @@ import androidx.compose.ui.unit.dp
 fun AzDivider(
     modifier: Modifier = Modifier,
     thickness: Dp = 1.dp,
-    color: Color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+    color: Color = LocalContentColor.current,
     horizontalPadding: Dp = 16.dp,
     verticalPadding: Dp = 8.dp
 ) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
@@ -430,23 +431,33 @@ private fun AzDropdownMenuRow(
     ) {
         androidx.compose.foundation.layout.BoxWithConstraints(Modifier.weight(1f)) {
             val availableWidthPx = with(density) { maxWidth.toPx() }
+            val baseFontSizePx = with(density) {
+                val fs = mergedStyle.fontSize
+                if (fs.isSpecified) fs.toPx()
+                else MaterialTheme.typography.titleLarge.fontSize.toPx()
+            }
             Column(horizontalAlignment = columnAlignment) {
                 text.split('\n').forEach { line ->
-                    val kerning = if (!justifyMenuItems || line.length < 2) androidx.compose.ui.unit.TextUnit.Unspecified
+                    val (scale, kerningPx) = if (!justifyMenuItems || line.length < 2) 1f to 0f
                     else {
                         val naturalWidthPx = try {
                             textMeasurer.measure(text = line, style = mergedStyle).size.width.toFloat()
                         } catch (_: Throwable) { availableWidthPx }
-                        val extraPx = availableWidthPx - naturalWidthPx
-                        if (extraPx <= 0f) androidx.compose.ui.unit.TextUnit.Unspecified
-                        else with(density) { (extraPx / (line.length - 1)).toSp() }
+                        com.hereliesaz.aznavrail.internal.solveHybridJustify(
+                            naturalWidthPx = naturalWidthPx,
+                            rowWidthPx = availableWidthPx,
+                            charCount = line.length,
+                            baseFontSizePx = baseFontSizePx,
+                        )
                     }
+                    val scaledFontSize = if (scale == 1f) mergedStyle.fontSize
+                        else with(density) { (baseFontSizePx * scale).toSp() }
                     Text(
                         text = line,
-                        style = mergedStyle,
+                        style = mergedStyle.copy(fontSize = scaledFontSize),
                         color = if (enabled) textColor else textColor.copy(alpha = 0.5f),
                         textAlign = textAlign,
-                        letterSpacing = kerning,
+                        letterSpacing = with(density) { kerningPx.toSp() },
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -910,7 +921,7 @@ fun AzDropdownMenu(
                         }
                         // The expanded-menu design carries the rail's footer (About / Feedback / @HereLiesAz).
                         if (config.design == AzDropdownDesign.MENU && config.showFooter) {
-                            AzDivider()
+                            AzDivider(color = MaterialTheme.colorScheme.primary)
                             AzDropdownFooter(
                                 repoUrl = effectiveRepoUrl,
                                 onAboutClick = if (config.inAppAbout && effectiveRepoUrl.isNotBlank()) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -856,8 +856,9 @@ fun AzNavRail(
                     // the last item's own kinetic entrance kicks off. Use the same top-level count the
                     // menu itself uses for its staggered entrance.
                     val footerMenuCount = scope.navItems.count { !it.isSubItem }
+                    val dividerColor = scope.activeColor.takeOrElse { MaterialTheme.colorScheme.primary }
                     Column {
-                        AzDivider()
+                        AzDivider(color = dividerColor)
                         Footer(
                             appName = appName,
                             onToggle = { toggleExpanded() },

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AboutOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AboutOverlay.kt
@@ -202,7 +202,7 @@ internal fun AboutOverlay(
                 // BOTTOM HALF — More-from-Az focused-hero carousel + active-app info panel.
                 if (scope.advancedConfig.moreFromAzEnabled) {
                     Spacer(Modifier.height(12.dp))
-                    AzDivider()
+                    AzDivider(color = accent)
                     Spacer(Modifier.height(8.dp))
                     Box(Modifier.weight(1f).fillMaxWidth()) {
                         MoreFromAzHeroCarousel(

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzJustify.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzJustify.kt
@@ -1,0 +1,62 @@
+package com.hereliesaz.aznavrail.internal
+
+/**
+ * Closed-form solver for the hybrid **kerning + font-scale** justification used by the WP7-style
+ * menu drawer. The label fills the row via a mix of letter-spacing *and* a font-size scale, without
+ * ever exceeding the kerning ratio allowed by the current font size.
+ *
+ * Given:
+ *  - `naturalWidthPx` — measured width of the label at its base font size (`baseFontSizePx`),
+ *    single-line, no letter-spacing.
+ *  - `rowWidthPx`     — available row width the label should fill.
+ *  - `charCount`      — number of characters in the label (`≥ 2`).
+ *  - `maxTrackingRatio` — the largest allowed `letterSpacing / fontSize` before we grow the font.
+ *  - `maxFontScale` — hard cap on how much the font can grow (protects against runaway growth
+ *    when the label is very short relative to the row).
+ *
+ * Returns the pair (`fontScale`, `letterSpacingPx`) that lands the label exactly on
+ * `rowWidthPx`, subject to the two constraints. If the label is already wider than the row
+ * the result is `(1f, 0f)` — no justification, let the label render at its natural size.
+ *
+ * ### Math (closed form, one branch)
+ *
+ * With `n = charCount`, `W₀ = naturalWidthPx`, `f₀ = baseFontSizePx`, `W = rowWidthPx`,
+ * `α = maxTrackingRatio`, and unknowns `s` (font scale) & `k` (letter-spacing px):
+ *
+ *  - Total width: `s·W₀ + (n − 1)·k = W`
+ *  - Kerning cap: `k ≤ α · s · f₀`
+ *
+ * **Phase A** (kerning suffices) — try `s = 1`, `k = (W − W₀) / (n − 1)`. If `k ≤ α · f₀`
+ * we accept it and return.
+ *
+ * **Phase B** (kerning saturated) — set `k = α · s · f₀`, substitute:
+ * `s · W₀ + (n − 1) · α · s · f₀ = W`, so `s = W / (W₀ + (n − 1) · α · f₀)`. Then
+ * `k = α · s · f₀`. Clamp `s` at [`1`, `maxFontScale`]; if it clamped high, the label ends up
+ * shorter than the row (accept a small gap rather than distort further).
+ */
+internal fun solveHybridJustify(
+    naturalWidthPx: Float,
+    rowWidthPx: Float,
+    charCount: Int,
+    baseFontSizePx: Float,
+    maxTrackingRatio: Float = 0.15f,
+    maxFontScale: Float = 1.5f,
+): Pair<Float, Float> {
+    if (charCount < 2 || naturalWidthPx <= 0f || rowWidthPx <= 0f) return 1f to 0f
+    if (naturalWidthPx >= rowWidthPx) return 1f to 0f
+
+    val n = charCount
+    val gaps = (n - 1).toFloat()
+
+    // Phase A: try to fill with kerning alone at s = 1.
+    val kAtScale1 = (rowWidthPx - naturalWidthPx) / gaps
+    if (kAtScale1 <= maxTrackingRatio * baseFontSizePx) {
+        return 1f to kAtScale1
+    }
+
+    // Phase B: kerning saturated → grow the font so `k = α·s·f₀` fills the row exactly.
+    val denom = naturalWidthPx + gaps * maxTrackingRatio * baseFontSizePx
+    val s = (rowWidthPx / denom).coerceIn(1f, maxFontScale)
+    val k = maxTrackingRatio * s * baseFontSizePx
+    return s to k
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MenuItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MenuItem.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.navigation.NavController
@@ -219,8 +220,8 @@ internal fun MenuItem(
         ) {
             val lines = textToShow.split('\n')
             val mergedStyle = MaterialTheme.typography.titleLarge.merge(textStyle)
-            // Measure natural width per line and compute a per-line letter-spacing that fills the row
-            // (kerning-justify). Single-character or overflowing lines are skipped.
+            // Hybrid justify: kerning up to `α·fontSize`, then grow the font past that limit so both
+            // letter-spacing and font-scale reach a stable mix that fills the row. See [solveHybridJustify].
             val textMeasurer = rememberTextMeasurer()
             val density = LocalDensity.current
 
@@ -230,24 +231,33 @@ internal fun MenuItem(
             ) {
                 androidx.compose.foundation.layout.BoxWithConstraints(Modifier.fillMaxWidth()) {
                     val availableWidthPx = with(density) { maxWidth.toPx() }
+                    val baseFontSizePx = with(density) {
+                        mergedStyle.fontSize.takeIf { it.isSpecified }?.toPx()
+                            ?: MaterialTheme.typography.titleLarge.fontSize.toPx()
+                    }
                     Column(horizontalAlignment = columnAlignment) {
                         lines.forEach { line ->
-                            val kerning = if (!justifyMenuItems || line.length < 2) 0.sp
+                            val (scale, kerningPx) = if (!justifyMenuItems || line.length < 2) 1f to 0f
                             else {
                                 val naturalWidthPx = try {
                                     textMeasurer.measure(text = line, style = mergedStyle).size.width.toFloat()
                                 } catch (_: Throwable) { availableWidthPx }
-                                val extraPx = availableWidthPx - naturalWidthPx
-                                if (extraPx <= 0f) 0.sp
-                                else with(density) { (extraPx / (line.length - 1)).toSp() }
+                                solveHybridJustify(
+                                    naturalWidthPx = naturalWidthPx,
+                                    rowWidthPx = availableWidthPx,
+                                    charCount = line.length,
+                                    baseFontSizePx = baseFontSizePx,
+                                )
                             }
+                            val scaledFontSize = if (scale == 1f) mergedStyle.fontSize
+                                else with(density) { (baseFontSizePx * scale).toSp() }
                             Text(
                                 text = line,
-                                style = mergedStyle,
+                                style = mergedStyle.copy(fontSize = scaledFontSize),
                                 color = textColor,
                                 modifier = Modifier.fillMaxWidth(),
                                 textAlign = textAlign,
-                                letterSpacing = kerning,
+                                letterSpacing = with(density) { kerningPx.toSp() },
                             )
                         }
                     }

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -183,9 +183,14 @@ azConfig(
 ```
 
 `SIDE` alignment: labels use `TextAlign.Start` when docked LEFT and `TextAlign.End` when docked
-RIGHT. `justifyMenuItems` measures each label's natural width, computes the extra pixels needed to
-fill the row, and applies it as `letterSpacing` — a Word-style full justification. Labels shorter
-than 2 characters, or already at/past the row width, are skipped.
+RIGHT. `justifyMenuItems` runs a **hybrid kerning + font-scale solver**: it first tries to fill the
+row with `letterSpacing` alone, but never exceeds `α · fontSize` of tracking (default `α = 0.15`);
+once kerning saturates, the font itself scales up so both letter-spacing and font-scale converge on
+the mix that lands the label exactly on the row width. Font growth is capped at `1.5×`. Labels
+shorter than 2 characters, or already at/past the row width, are skipped. `AzDivider` also picks up
+the same font color as the surrounding text (via `LocalContentColor` on Compose and `currentColor`
+on the web), so the divider belongs to the same visual family as the labels next to it — not a
+muted outline.
 
 **React Implementation:** identical fields on `AzNavRailSettings` and on the `AzDropdownMenu` props:
 `dimBehindMenu`, `dimBehindMenuAlpha`, `menuItemAlignment: 'center' | 'side'`, `justifyMenuItems`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -114,9 +114,14 @@ fun azConfig(
 * `menuItemAlignment: AzMenuItemAlignment` (`CENTER` | `SIDE`) — alignment of the drawer's labels
   within their rows. Default `SIDE`: `TextAlign.Start` when docked LEFT, `TextAlign.End` when
   docked RIGHT. Small rail-button labels are unaffected.
-* `justifyMenuItems: Boolean` — when true, each label is measured with a `TextMeasurer` and its
-  `letterSpacing` is set to the amount that fills the row edge-to-edge (Word-style justify).
-  Single-character labels and labels wider than the row are skipped. Default `true`.
+* `justifyMenuItems: Boolean` — when true, each label runs through a **hybrid kerning + font-scale
+  solver** (`internal/AzJustify.kt`): fill the row with `letterSpacing` alone until tracking would
+  exceed `α · fontSize` (`α = 0.15`), then grow the font past that limit so both letter-spacing and
+  font-size converge on the mix that lands the label exactly on the row width. Font growth capped
+  at `1.5×`. Single-character labels and labels wider than the row are skipped. Default `true`.
+* `AzDivider` now defaults its color to `LocalContentColor.current` (Compose) / `currentColor`
+  (web) so the divider inherits the surrounding font color and belongs to the same visual family
+  as the labels next to it. The rail and dropdown call sites pass their accent explicitly.
 
 * `appRepositoryUrl` — **optional** override for the host app's GitHub repo used by the About reader.
   Blank (the default) auto-derives the repo from the app **namespace**: `com.<owner>.<repo>` →

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -183,9 +183,14 @@ azConfig(
 ```
 
 `SIDE` alignment: labels use `TextAlign.Start` when docked LEFT and `TextAlign.End` when docked
-RIGHT. `justifyMenuItems` measures each label's natural width, computes the extra pixels needed to
-fill the row, and applies it as `letterSpacing` — a Word-style full justification. Labels shorter
-than 2 characters, or already at/past the row width, are skipped.
+RIGHT. `justifyMenuItems` runs a **hybrid kerning + font-scale solver**: it first tries to fill the
+row with `letterSpacing` alone, but never exceeds `α · fontSize` of tracking (default `α = 0.15`);
+once kerning saturates, the font itself scales up so both letter-spacing and font-scale converge on
+the mix that lands the label exactly on the row width. Font growth is capped at `1.5×`. Labels
+shorter than 2 characters, or already at/past the row width, are skipped. `AzDivider` also picks up
+the same font color as the surrounding text (via `LocalContentColor` on Compose and `currentColor`
+on the web), so the divider belongs to the same visual family as the labels next to it — not a
+muted outline.
 
 **React Implementation:** identical fields on `AzNavRailSettings` and on the `AzDropdownMenu` props:
 `dimBehindMenu`, `dimBehindMenuAlpha`, `menuItemAlignment: 'center' | 'side'`, `justifyMenuItems`.

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -37,9 +37,13 @@ fun azConfig(
 The menu-drawer knobs only affect the **expanded-menu drawer** labels (the standalone
 `AzDropdownMenu` mirrors them on its own `azConfig`). Small rail-button labels are unaffected.
 `SIDE` alignment resolves to `TextAlign.Start` when docked LEFT and `TextAlign.End` when RIGHT.
-`justifyMenuItems` measures each label's natural width and computes an equal `letterSpacing` so it
-fills the row edge-to-edge (Word-style justify); single-character or already-wider-than-row labels
-are skipped.
+`justifyMenuItems` runs a **hybrid kerning + font-scale solver**: it fills the row with
+`letterSpacing` alone until tracking would exceed `α · fontSize` (default `α = 0.15`); once the
+kerning cap is hit, the font scales up so both letter-spacing and font-size converge on the mix
+that lands the label exactly on the row width. Font growth is capped at `1.5×`. Labels shorter
+than 2 characters, or already at/past the row width, are skipped. `AzDivider`'s default color is
+now `LocalContentColor.current` on Compose and `currentColor` on the web, so the divider matches
+the surrounding font — never a muted outline.
 
 `appRepositoryUrl` is an **optional** override for the About reader's repo. Blank (the default)
 auto-derives the repo from the app **namespace** on Android: `com.<owner>.<repo>` →


### PR DESCRIPTION
## Summary

Two follow-ups on the drawer look:

### 1. `justifyMenuItems` becomes a hybrid kerning + font-scale solver

The previous pass filled the row with `letterSpacing` alone, which over-spreads short labels ("Home" stretched across a 280-wide row looks broken). Replace with a **closed-form solver** that combines kerning **and** font-scale so neither runs away.

Given `naturalWidth = W₀`, `baseFontSize = f₀`, `rowWidth = W`, `charCount = n`, `α = 0.15` (max `tracking / fontSize` ratio):

- **Phase A** — try `s = 1`, `k = (W − W₀) / (n − 1)`. If `k ≤ α · f₀`, accept.
- **Phase B** — kerning saturated → `k = α · s · f₀`; solve `s · W₀ + (n − 1) · α · s · f₀ = W`, so
  `s = W / (W₀ + (n − 1) · α · f₀)` and `k = α · s · f₀`. Clamp `s ∈ [1, 1.5]`; any high clamp leaves the label slightly shorter than the row rather than distorting further.

Extracted as `internal/AzJustify.kt` (Compose) and `src/util/AzJustify.ts` (React). Applied at:

- Compose drawer: `MenuItem.kt`, `AzDropdownMenu.kt` (`AzDropdownMenuRow`).
- React Native drawer: `RailMenuItem.tsx`, `AzDropdownMenu.tsx`.
- Plain web drawer: `web/MenuItem.jsx`, `web/AzDropdownMenu.jsx`.

### 2. `AzDivider` inherits the surrounding font color

Old default was `MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)` (Compose) / `rgba(0,0,0,0.12)` (web) — a dead muted line. Change the default to the **font color** so the divider belongs to the same visual family as the labels next to it:

- Compose: `AzDivider.kt` defaults to `LocalContentColor.current`.
- React Native: `AzDivider.tsx` defaults to `'currentColor'` (fine on web; the rail/dropdown pass an explicit color on native).
- Plain web: `AzDivider.jsx` defaults to `'currentColor'`, `AzDivider.css` cleaned up; the dropdown footer's `border-top` uses `currentColor` too.

The rail's expanded-menu divider, the About-page split divider, and the standalone `AzDropdownMenu`'s footer divider all pass their accent (`scope.activeColor` / `activeColor` / `MaterialTheme.colorScheme.primary`) explicitly so the color is guaranteed regardless of ambient content-color.

### Docs

`README.md`, `docs/API.md`, `docs/DSL.md`, `docs/AZNAVRAIL_COMPLETE_GUIDE.md` (canonical + bundled `resources/` + `assets/` copies), `aznavrail-react/CHANGELOG.md`.

## Test plan

- [ ] `./gradlew :SampleApp:installDebug` — open a short menu label (e.g. "Home") in a wide-width drawer; confirm the label's font grows and letter-spacing is bounded, rather than tracked to gaps.
- [ ] Same on the sample-pwa (`pnpm dev`) — via react-native-web and via the plain-web build.
- [ ] Toggle `justifyMenuItems: false` — labels render at natural size, no scaling.
- [ ] Confirm the divider under the last menu item, in the About page (between docs TOC and hero carousel), and at the top of the dropdown footer all render in the accent color, not gray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_