### PR TITLE
Footer unfolds one stagger tick AFTER the last menu item begins

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,9 +504,9 @@ mode, where there's no docked edge to hinge on, the cascade degrades to a vertic
 
 Default timing lets items **overlap heavily**: `entranceDurationMs = 720` and
 `entranceStaggerMs = 60` mean the next item begins ~60 ms after the previous begins *while* the
-previous is still animating. Once the last item begins, the **footer** (About / Feedback / @HereLiesAz)
-**unfolds like an accordion** from the top edge, so the whole rail-open motion completes in one
-continuous beat.
+previous is still animating. One stagger tick **after** the last item begins, the **footer**
+(About / Feedback / @HereLiesAz) **unfolds like an accordion** from the top edge — the natural next
+beat in the cascade rhythm — so the whole rail-open motion completes as one continuous phrase.
 
 Three surfaces animate:
 

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -44,7 +44,8 @@ knobs (dim, side-alignment, kerning-justify) land as first-class options.
   correct).
 - **Footer unfolds like an accordion.** The rail and dropdown footer (About/Feedback/@HereLiesAz)
   now animate in with `scaleY 0→1` + `opacity 0→1` hinged at the top edge, starting when the
-  **last** menu item starts its own kinetic entrance (delay = `(count - 1) * staggerMs`). Same
+  **last** menu item starts its own kinetic entrance — one extra stagger tick past it (delay =
+  `count * staggerMs`), so the footer is the natural next beat in the cascade rhythm. Same
   Wp7Decelerate easing; the whole footer unfolds as one unit.
 - **About page split into two halves.** The top half is the existing docs TOC (unchanged internals),
   and the bottom half is a **focused-hero More-from-Az carousel** with a size pattern

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -56,7 +56,8 @@ interface AzNavRailProps extends AzNavRailSettings {
 
 /**
  * Unfolds children downward (scaleY 0→1 + fade) with an accordion motion. Kicks off when the LAST
- * menu item starts its own kinetic entrance, i.e. after `(menuItemCount - 1) * staggerMs`.
+ * menu item starts its own kinetic entrance — the footer is the natural next beat in the cascade,
+ * scheduled `menuItemCount * staggerMs` after the drawer opens (one tick past the last item's start).
  */
 const FooterAccordion: React.FC<{
   visible: boolean;
@@ -71,7 +72,7 @@ const FooterAccordion: React.FC<{
       const a = Animated.timing(anim, {
         toValue: 1,
         duration: durationMs,
-        delay: Math.max(0, menuItemCount - 1) * staggerMs,
+        delay: Math.max(0, menuItemCount) * staggerMs,
         easing: RNEasing.bezier(...AzEasing.Wp7Decelerate),
         useNativeDriver: true,
       });

--- a/aznavrail-react/src/AzNavRail.tsx
+++ b/aznavrail-react/src/AzNavRail.tsx
@@ -55,9 +55,9 @@ interface AzNavRailProps extends AzNavRailSettings {
 }
 
 /**
- * Unfolds children downward (scaleY 0→1 + fade) with an accordion motion. Kicks off when the LAST
- * menu item starts its own kinetic entrance — the footer is the natural next beat in the cascade,
- * scheduled `menuItemCount * staggerMs` after the drawer opens (one tick past the last item's start).
+ * Unfolds children downward (scaleY 0→1 + fade) with an accordion motion. Kicks off one stagger
+ * tick AFTER the last menu item starts its own kinetic entrance — the footer is the natural next
+ * beat in the cascade, scheduled `menuItemCount * staggerMs` after the drawer opens.
  */
 const FooterAccordion: React.FC<{
   visible: boolean;

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -474,7 +474,7 @@ const AzDropdownFooter: React.FC<{
       const a = Animated.timing(anim, {
         toValue: 1,
         duration: durationMs,
-        delay: Math.max(0, menuItemCount - 1) * staggerMs,
+        delay: Math.max(0, menuItemCount) * staggerMs,
         easing: RNEasing.bezier(...AzEasing.Wp7Decelerate),
         useNativeDriver: true,
       });

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -288,7 +288,8 @@ const AzDropdownMenu = ({
             <div
               className="az-dropdown-menu-footer az-nav-rail__footer-accordion"
               style={{
-                animationDelay: `${Math.max(0, React.Children.count(children) - 1) * entranceStaggerMs}ms`,
+                // Footer arrives one stagger tick AFTER the last item begins — the next beat.
+                animationDelay: `${Math.max(0, React.Children.count(children)) * entranceStaggerMs}ms`,
                 animationDuration: `${entranceDurationMs}ms`,
               }}
             >

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -288,8 +288,11 @@ const AzDropdownMenu = ({
             <div
               className="az-dropdown-menu-footer az-nav-rail__footer-accordion"
               style={{
-                // Footer arrives one stagger tick AFTER the last item begins — the next beat.
-                animationDelay: `${Math.max(0, React.Children.count(children)) * entranceStaggerMs}ms`,
+                // Footer arrives one stagger tick AFTER the last item begins — the next beat. Use
+                // `React.Children.toArray(...).length` (not `React.Children.count`) so conditional
+                // `{cond && <Item/>}` children with a falsy `cond` don't inflate the delay by
+                // counting as 1 each.
+                animationDelay: `${Math.max(0, React.Children.toArray(children).length) * entranceStaggerMs}ms`,
                 animationDuration: `${entranceDurationMs}ms`,
               }}
             >

--- a/aznavrail-react/src/web/AzNavRail.jsx
+++ b/aznavrail-react/src/web/AzNavRail.jsx
@@ -638,7 +638,8 @@ const AzNavRail = ({
             alignItems: 'center',
             padding: '16px',
             color: activeColor || 'currentColor',
-            animationDelay: `${Math.max(0, menuItems.length - 1) * entranceStaggerMs}ms`,
+            // Footer arrives one stagger tick AFTER the last menu item begins — the next beat.
+            animationDelay: `${Math.max(0, menuItems.length) * entranceStaggerMs}ms`,
             animationDuration: `${entranceDurationMs}ms`,
           }}
         >

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -141,9 +141,9 @@ slide (no docked edge to hinge on).
 The signature look is a **pure 90° `rotationY` sweep** hinged on the docked edge — no fade, no vertical
 slide. Items overlap heavily by default: `entranceDurationMs = 720` and `entranceStaggerMs = 60`
 means the next item begins ~60 ms after the previous one *begins* while the previous one is still
-animating. The footer (About / Feedback / @HereLiesAz) then **unfolds like an accordion** from the
-top edge, starting the moment the last item begins — so the whole rail-open motion completes in one
-continuous beat.
+animating. One stagger tick after the last item begins, the footer (About / Feedback / @HereLiesAz)
+**unfolds like an accordion** from the top edge — the natural next beat in the cascade rhythm — so
+the whole rail-open motion completes as one continuous phrase.
 
 ```kotlin
 azKinetics(

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -504,7 +504,8 @@ private fun AzDropdownFooter(
     LaunchedEffect(visible) {
         val spec = tween<Float>(durationMillis = durationMs, easing = easing)
         if (visible) {
-            delay((menuItemCount - 1).coerceAtLeast(0).toLong() * staggerMs)
+            // One extra stagger tick beyond the last item's start — the footer is the next beat.
+            delay(menuItemCount.coerceAtLeast(0).toLong() * staggerMs)
             launch { scaleY.animateTo(1f, spec) }
             launch { fade.animateTo(1f, spec) }
         } else {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/Footer.kt
@@ -77,7 +77,9 @@ internal fun Footer(
     LaunchedEffect(visible) {
         val spec = tween<Float>(durationMillis = durationMs, easing = easing)
         if (visible) {
-            delay((menuItemCount - 1).coerceAtLeast(0).toLong() * staggerMs)
+            // Footer starts AFTER the last menu item begins — one extra stagger tick so the footer
+            // is the natural next beat in the cascade rhythm (as if it were the (count+1)th item).
+            delay(menuItemCount.coerceAtLeast(0).toLong() * staggerMs)
             launch { scaleY.animateTo(1f, spec) }
             launch { fade.animateTo(1f, spec) }
         } else {

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -141,9 +141,9 @@ slide (no docked edge to hinge on).
 The signature look is a **pure 90° `rotationY` sweep** hinged on the docked edge — no fade, no vertical
 slide. Items overlap heavily by default: `entranceDurationMs = 720` and `entranceStaggerMs = 60`
 means the next item begins ~60 ms after the previous one *begins* while the previous one is still
-animating. The footer (About / Feedback / @HereLiesAz) then **unfolds like an accordion** from the
-top edge, starting the moment the last item begins — so the whole rail-open motion completes in one
-continuous beat.
+animating. One stagger tick after the last item begins, the footer (About / Feedback / @HereLiesAz)
+**unfolds like an accordion** from the top edge — the natural next beat in the cascade rhythm — so
+the whole rail-open motion completes as one continuous phrase.
 
 ```kotlin
 azKinetics(

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -141,9 +141,9 @@ slide (no docked edge to hinge on).
 The signature look is a **pure 90° `rotationY` sweep** hinged on the docked edge — no fade, no vertical
 slide. Items overlap heavily by default: `entranceDurationMs = 720` and `entranceStaggerMs = 60`
 means the next item begins ~60 ms after the previous one *begins* while the previous one is still
-animating. The footer (About / Feedback / @HereLiesAz) then **unfolds like an accordion** from the
-top edge, starting the moment the last item begins — so the whole rail-open motion completes in one
-continuous beat.
+animating. One stagger tick after the last item begins, the footer (About / Feedback / @HereLiesAz)
+**unfolds like an accordion** from the top edge — the natural next beat in the cascade rhythm — so
+the whole rail-open motion completes as one continuous phrase.
 
 ```kotlin
 azKinetics(

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -101,9 +101,8 @@ draggable/relocatable items. The default **Turnstile** entrance is a pure 90° `
 hinged on the docked edge — no fade, no vertical slide. Because the stagger (60 ms) is much smaller
 than the duration (720 ms), items overlap heavily: the next item starts ~60 ms after the previous
 begins while the previous is still animating. The footer (About / Feedback / @HereLiesAz) then
-**unfolds like an accordion** from the top edge, starting the moment the last item begins
-(delay = `count * staggerMs` — one tick past the last item's start, making the footer the natural
-next beat in the cascade).
+**unfolds like an accordion** from the top edge, starting one stagger tick after the last item
+begins (delay = `count * staggerMs` — the footer is the natural next beat in the cascade rhythm).
 
 In React, the rail reads these from `settings` (`itemEntrance`, `itemExit`, `titleEntrance`, …).
 On **native React Native** the hinge is emulated via a `translateX ±(width/2)` correction around

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -102,7 +102,8 @@ hinged on the docked edge — no fade, no vertical slide. Because the stagger (6
 than the duration (720 ms), items overlap heavily: the next item starts ~60 ms after the previous
 begins while the previous is still animating. The footer (About / Feedback / @HereLiesAz) then
 **unfolds like an accordion** from the top edge, starting the moment the last item begins
-(delay = `(count - 1) * staggerMs`).
+(delay = `count * staggerMs` — one tick past the last item's start, making the footer the natural
+next beat in the cascade).
 
 In React, the rail reads these from `settings` (`itemEntrance`, `itemExit`, `titleEntrance`, …).
 On **native React Native** the hinge is emulated via a `translateX ±(width/2)` correction around


### PR DESCRIPTION
## Summary

Previous delay of `(menuItemCount - 1) * staggerMs` fired the footer accordion at the **same** instant the last menu item began — the two motions were simultaneous rather than sequential. Bump the delay to `menuItemCount * staggerMs` so the footer arrives one extra stagger tick past the last item's start: the footer becomes the natural next beat in the cascade rhythm, as if it were the `(count + 1)`th item.

Applied consistently on every surface that carries the accordion:

- Compose rail footer — `aznavrail/…/internal/Footer.kt`.
- Compose dropdown footer — `aznavrail/…/AzDropdownMenu.kt` (`AzDropdownFooter`).
- React Native rail footer accordion — `aznavrail-react/src/AzNavRail.tsx` (`FooterAccordion`).
- React Native dropdown footer — `aznavrail-react/src/components/AzDropdownMenu.tsx` (`AzDropdownFooter`).
- Plain-web rail footer — `aznavrail-react/src/web/AzNavRail.jsx` (`animationDelay`).
- Plain-web dropdown footer — `aznavrail-react/src/web/AzDropdownMenu.jsx` (`animationDelay`).

### Docs

`README.md`, `docs/DSL.md`, `docs/AZNAVRAIL_COMPLETE_GUIDE.md` (canonical + bundled `resources/` + `assets/` copies), and `aznavrail-react/CHANGELOG.md` updated to describe the new timing.

## Test plan

- [ ] `./gradlew :SampleApp:installDebug` — expand the rail, watch the last item swing in and confirm the footer starts one stagger step later (a beat past the last item's start), not simultaneously.
- [ ] Same in the sample-pwa (`pnpm dev`), and in the standalone `AzDropdownMenu` on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_

## Summary by Sourcery

Adjust footer accordion timing across rail and dropdown surfaces so it unfolds one stagger tick after the last menu item begins, making it the next beat in the entrance cascade.

Enhancements:
- Align footer animation delay calculations on native, React Native, and web implementations to use full menu item count for scheduling.
- Ensure web dropdown footer delay correctly ignores falsy conditional children when computing staggered timing.

Documentation:
- Update README, DSL guide, complete guide, and React changelog to document the revised footer entrance timing and cascade behavior.