### PR TITLE
Fix: shrink oversized drawer labels; explicit-only line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,8 +569,10 @@ unaffected.
 - **`justifyMenuItems`** (default `true`) — runs a **hybrid kerning + font-scale solver**: fills
   the row with `letterSpacing` alone until tracking would exceed `α · fontSize` (`α = 0.15`); once
   the cap hits, the font scales up so both letter-spacing and font-size converge on the mix that
-  lands the label exactly on the row width. Font growth is capped at `1.5×`. Short/overflowing
-  labels are skipped.
+  lands the label exactly on the row width. Font growth is capped at `1.5×`. When the natural
+  width **overflows** the row, the solver shrinks the font instead (`scale = rowWidth /
+  naturalWidth`, clamped to `≥ 0.5×`) so the label fits on one line without breaking mid-word —
+  line breaks in drawer labels are explicit-only.
 - **`AzDivider`** now defaults its color to the surrounding **font** color
   (`LocalContentColor.current` on Compose, `currentColor` on the web), and the rail/dropdown/About
   call sites pass their accent explicitly — the divider belongs to the same visual family as the

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -8,10 +8,16 @@
   or exceeded the row width, and the `Text`/`<Text>`/`<span>` then wrapped — producing ugly
   "Generat / e", "Projec / t", "Setting / s" overhangs on narrow rails. The solver now has a
   **shrink** branch: `scale = rowWidth / naturalWidth` (clamped `≥ 0.5×`) so oversized labels scale
-  down to fit on one line. Combined with `softWrap = false` + `maxLines = 1` on Compose,
-  `numberOfLines={1}` on React Native, and `white-space: nowrap` + `overflow: hidden` on the plain
-  web, **line breaks in drawer labels are now explicit-only** (a literal `\n` still splits into
-  multiple rows, but the browser/text engine will never insert one on its own).
+  down to fit on one line.
+- **Explicit `\n` line breaks now survive on React Native and web.** Drawer labels are split on
+  `\n` up-front and each line is rendered by its own inner component (`JustifiedRNLine`,
+  `JustifiedDropdownLine`, `JustifiedWebLine`, `JustifiedWebDropdownLine`) with its own
+  natural-width measurement and its own solver call. Otherwise the newline character would inflate
+  `charCount` and fold both lines' widths into one `naturalWidth`, skewing the per-line justify
+  math — matches Compose's `internal/MenuItem.kt` `lines.forEach { line -> Text(line, …) }`.
+  Combined with `softWrap = false` + `maxLines = 1` on Compose, `numberOfLines={1}` on the RN
+  per-line `<Text>`, and `white-space: nowrap` + `overflow: hidden` on the web per-line `<span>`,
+  **line breaks in drawer labels are now explicit-only**.
 
 ## Unreleased — follow-up (hybrid justify + AzDivider color)
 

--- a/aznavrail-react/CHANGELOG.md
+++ b/aznavrail-react/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased — bug fix (shrink oversized drawer labels; explicit-only line breaks)
+
+### Fixed
+- **Menu-drawer labels no longer auto-wrap mid-word.** The previous hybrid-justify solver bailed
+  out (returning `{scale: 1, letterSpacing: 0}`) whenever the label's natural width already met
+  or exceeded the row width, and the `Text`/`<Text>`/`<span>` then wrapped — producing ugly
+  "Generat / e", "Projec / t", "Setting / s" overhangs on narrow rails. The solver now has a
+  **shrink** branch: `scale = rowWidth / naturalWidth` (clamped `≥ 0.5×`) so oversized labels scale
+  down to fit on one line. Combined with `softWrap = false` + `maxLines = 1` on Compose,
+  `numberOfLines={1}` on React Native, and `white-space: nowrap` + `overflow: hidden` on the plain
+  web, **line breaks in drawer labels are now explicit-only** (a literal `\n` still splits into
+  multiple rows, but the browser/text engine will never insert one on its own).
+
 ## Unreleased — follow-up (hybrid justify + AzDivider color)
 
 ### Changed

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -125,6 +125,67 @@ export interface AzDropdownItemProps {
 }
 
 /**
+ * One logical line of a MENU-design dropdown label. Split the label on `\n` and render one of
+ * these per line: each line owns its own natural-width measurer, its own `charCount` fed to the
+ * solver, and its own resolved `letterSpacing` + font scale. Prevents newline characters from
+ * skewing the hybrid-justify math and keeps auto-wrap disabled without eating explicit breaks.
+ */
+const JustifiedDropdownLine: React.FC<{
+  line: string;
+  justify: boolean;
+  containerWidth: number;
+  textAlign: 'left' | 'right' | 'center';
+  color: string;
+  enabled: boolean;
+  itemTextStyle?: object;
+}> = ({ line, justify, containerWidth, textAlign, color, enabled, itemTextStyle }) => {
+  const [naturalWidth, setNaturalWidth] = useState(0);
+  const onLabelLayout = (e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    if (w && Math.abs(w - naturalWidth) > 0.5) setNaturalWidth(w);
+  };
+  let letterSpacing = 0;
+  let fontScale = 1;
+  if (justify && line.length >= 1 && containerWidth > 0 && naturalWidth > 0) {
+    const solved = solveHybridJustify(naturalWidth, containerWidth, line.length, DROPDOWN_BASE_FONT_PX);
+    fontScale = solved.scale;
+    letterSpacing = solved.letterSpacing;
+  }
+  const scaledFontSize = DROPDOWN_BASE_FONT_PX * fontScale;
+  return (
+    <>
+      <Text
+        onLayout={onLabelLayout}
+        style={[
+          styles.menuRowText,
+          { position: 'absolute', opacity: 0, left: -9999, top: -9999 } as any,
+          itemTextStyle,
+        ]}
+      >
+        {line}
+      </Text>
+      <Text
+        numberOfLines={1}
+        style={[
+          styles.menuRowText,
+          {
+            color,
+            opacity: enabled ? 1 : 0.5,
+            textAlign,
+            letterSpacing,
+            fontSize: scaledFontSize,
+            alignSelf: 'stretch',
+          },
+          itemTextStyle,
+        ]}
+      >
+        {line}
+      </Text>
+    </>
+  );
+};
+
+/**
  * A tappable menu entry. In a {@link AzDropdownDesign.MENU} panel it renders as a full-width labeled
  * row (the expanded-drawer look); in a {@link AzDropdownDesign.RAIL} panel it renders as a compact
  * {@link AzButton}. Navigates `route` (if set) then runs `onClick`, folding the menu by default.
@@ -143,7 +204,6 @@ export const AzDropdownItem: React.FC<AzDropdownItemProps> = ({
   const ctx = useContext(AzDropdownMenuContext);
   // Hooks must run unconditionally. Guard reads via optional chaining below.
   const [availableWidth, setAvailableWidth] = useState(0);
-  const [naturalWidth, setNaturalWidth] = useState(0);
   if (!ctx) throw new Error('AzDropdownItem must be used inside an <AzDropdownMenu>');
   const {
     dismiss,
@@ -170,19 +230,10 @@ export const AzDropdownItem: React.FC<AzDropdownItemProps> = ({
       const w = e.nativeEvent.layout.width;
       if (w && Math.abs(w - availableWidth) > 0.5) setAvailableWidth(w);
     };
-    const onLabelLayout = (e: LayoutChangeEvent) => {
-      const w = e.nativeEvent.layout.width;
-      if (w && Math.abs(w - naturalWidth) > 0.5) setNaturalWidth(w);
-    };
-    // Hybrid kerning + font-scale justify — see src/util/AzJustify.
-    let letterSpacing = 0;
-    let fontScale = 1;
-    if (justify && text.length >= 2 && availableWidth > 0 && naturalWidth > 0) {
-      const solved = solveHybridJustify(naturalWidth, availableWidth, text.length, DROPDOWN_BASE_FONT_PX);
-      fontScale = solved.scale;
-      letterSpacing = solved.letterSpacing;
-    }
-    const scaledFontSize = DROPDOWN_BASE_FONT_PX * fontScale;
+    // Split up-front on `\n` so each line gets its own measurement + solve — the newline count
+    // would otherwise skew both `naturalWidth` and `charCount` for multi-line labels.
+    const lines = text.split('\n');
+    const rowColor = textColor || color || '#6750A4';
     return (
       <TouchableOpacity
         style={styles.menuRow}
@@ -192,27 +243,20 @@ export const AzDropdownItem: React.FC<AzDropdownItemProps> = ({
         accessibilityRole="button"
         accessibilityLabel={text}
       >
-        {/* Hidden off-screen measurer — natural width only, no layout impact. */}
-        <Text
-          onLayout={onLabelLayout}
-          style={[
-            styles.menuRowText,
-            { position: 'absolute', opacity: 0, left: -9999, top: -9999 } as any,
-            itemTextStyle,
-          ]}
-        >
-          {text}
-        </Text>
-        <Text
-          numberOfLines={1}
-          style={[
-            styles.menuRowText,
-            { color: textColor || color || '#6750A4', opacity: enabled ? 1 : 0.5, textAlign, letterSpacing, fontSize: scaledFontSize },
-            itemTextStyle,
-          ]}
-        >
-          {text}
-        </Text>
+        <View style={{ flex: 1, flexDirection: 'column' }}>
+          {lines.map((line, i) => (
+            <JustifiedDropdownLine
+              key={i}
+              line={line}
+              justify={justify}
+              containerWidth={availableWidth}
+              textAlign={textAlign}
+              color={rowColor}
+              enabled={enabled}
+              itemTextStyle={itemTextStyle}
+            />
+          ))}
+        </View>
       </TouchableOpacity>
     );
   }

--- a/aznavrail-react/src/components/AzDropdownMenu.tsx
+++ b/aznavrail-react/src/components/AzDropdownMenu.tsx
@@ -204,6 +204,7 @@ export const AzDropdownItem: React.FC<AzDropdownItemProps> = ({
           {text}
         </Text>
         <Text
+          numberOfLines={1}
           style={[
             styles.menuRowText,
             { color: textColor || color || '#6750A4', opacity: enabled ? 1 : 0.5, textAlign, letterSpacing, fontSize: scaledFontSize },

--- a/aznavrail-react/src/components/RailMenuItem.tsx
+++ b/aznavrail-react/src/components/RailMenuItem.tsx
@@ -30,6 +30,72 @@ interface RailMenuItemProps {
 }
 
 /**
+ * Renders one logical line of a menu label with an independent measurement + hybrid-justify solve.
+ * Splitting up-front on `\n` and rendering one of these per line mirrors the Compose implementation:
+ * each line gets its own `charCount`, its own natural width, and its own `letterSpacing` + font
+ * `scale`, so a two-line label doesn't skew the solve by counting the newline into the char count.
+ */
+const JustifiedRNLine: React.FC<{
+    line: string;
+    justify: boolean;
+    containerWidth: number;
+    textAlign: 'left' | 'right' | 'center';
+    color: string;
+    bold: boolean;
+    textStyle?: object;
+}> = ({ line, justify, containerWidth, textAlign, color, bold, textStyle }) => {
+    const [naturalWidth, setNaturalWidth] = useState(0);
+    const onLabelLayout = (e: LayoutChangeEvent) => {
+        const w = e.nativeEvent.layout.width;
+        if (w && Math.abs(w - naturalWidth) > 0.5) setNaturalWidth(w);
+    };
+    let letterSpacing = 0;
+    let fontScale = 1;
+    if (justify && line.length >= 1 && containerWidth > 0 && naturalWidth > 0) {
+        const { scale, letterSpacing: ls } = solveHybridJustify(
+            naturalWidth,
+            containerWidth,
+            line.length,
+            BASE_FONT_PX,
+        );
+        fontScale = scale;
+        letterSpacing = ls;
+    }
+    const scaledFontSize = BASE_FONT_PX * fontScale;
+    return (
+        <>
+            {/* Off-screen measurer — same font as the visible line, one text-run so we measure the
+                line's natural width. Rendered absolute so it doesn't affect layout. */}
+            <Text
+                onLayout={onLabelLayout}
+                style={[styles.measurer, { fontWeight: bold ? 'bold' : 'normal' }, textStyle]}
+            >
+                {line}
+            </Text>
+            {/* Visible line — `numberOfLines={1}` prevents width-based wrapping now that we've
+                split explicit `\n` breaks up-front. The solver's shrink branch (fontScale < 1) keeps
+                oversized lines from ever overflowing in the first place. */}
+            <Text
+                numberOfLines={1}
+                style={[
+                    styles.menuItemText,
+                    {
+                        fontWeight: bold ? 'bold' : 'normal',
+                        color,
+                        textAlign,
+                        letterSpacing,
+                        fontSize: scaledFontSize,
+                    },
+                    textStyle,
+                ]}
+            >
+                {line}
+            </Text>
+        </>
+    );
+};
+
+/**
  * Internal renderer for a single row in the expanded menu, handling toggle, cycler, and host item modes.
  * Used by `AzNavRail` when the menu is open.
  */
@@ -98,37 +164,20 @@ export const RailMenuItem: React.FC<RailMenuItemProps> = ({
     if (item.isToggle) accessibilityState.checked = item.isChecked;
     if (item.isHost || item.isNestedRail) accessibilityState.expanded = isExpandedHost;
 
-    // Alignment + kerning-justify computed per-row. We measure the label's natural width off-screen,
-    // then compute an equal letter-spacing that stretches it to fill the row.
-    const textAlign =
+    const textAlign: 'left' | 'right' | 'center' =
         menuItemAlignment === 'center'
             ? 'center'
             : dockingSide === AzDockingSide.RIGHT ? 'right' : 'left';
     const [availableWidth, setAvailableWidth] = useState(0);
-    const [naturalWidth, setNaturalWidth] = useState(0);
     const onContainerLayout = (e: LayoutChangeEvent) => {
         const w = e.nativeEvent.layout.width;
         if (w && Math.abs(w - availableWidth) > 0.5) setAvailableWidth(w);
     };
-    const onLabelLayout = (e: LayoutChangeEvent) => {
-        const w = e.nativeEvent.layout.width;
-        if (w && Math.abs(w - naturalWidth) > 0.5) setNaturalWidth(w);
-    };
-    // Hybrid justify: try kerning up to α·fontSize, then grow the font past that limit so both
-    // letter-spacing and font-scale reach a stable mix that fills the row. See ../util/AzJustify.
-    let letterSpacing = 0;
-    let fontScale = 1;
-    if (justifyMenuItems && displayText && displayText.length >= 2 && availableWidth > 0 && naturalWidth > 0) {
-        const { scale, letterSpacing: ls } = solveHybridJustify(
-            naturalWidth,
-            availableWidth,
-            displayText.length,
-            BASE_FONT_PX,
-        );
-        fontScale = scale;
-        letterSpacing = ls;
-    }
-    const scaledFontSize = BASE_FONT_PX * fontScale;
+
+    // Split up-front on `\n` and render each line independently — the newline count skews
+    // per-line justify math otherwise. Compose's `internal/MenuItem.kt` uses the same pattern.
+    const lines = (displayText ?? '').split('\n');
+    const labelColor = item.textColor ?? item.color ?? '#000000';
 
     return (
         <View>
@@ -140,32 +189,20 @@ export const RailMenuItem: React.FC<RailMenuItemProps> = ({
                 accessibilityLabel={displayText}
                 accessibilityState={accessibilityState}
             >
-                {/* Off-screen "measurer" — same font/style as the visible label, absent from layout. */}
-                <Text
-                    onLayout={onLabelLayout}
-                    style={[styles.measurer, { fontWeight: item.isHost ? 'bold' : 'normal' }, textStyle]}
-                >
-                    {displayText}
-                </Text>
-                <Text
-                    numberOfLines={1}
-                    // Line breaks in menu labels are explicit-only; the solver shrinks oversized
-                    // labels via `fontScale`, so `numberOfLines={1}` locks the row to one line
-                    // and clips only when even the min-scale doesn't fit.
-                    style={[
-                        styles.menuItemText,
-                        {
-                            fontWeight: item.isHost ? 'bold' : 'normal',
-                            color: item.textColor ?? item.color ?? '#000000',
-                            textAlign,
-                            letterSpacing,
-                            fontSize: scaledFontSize,
-                        },
-                        textStyle,
-                    ]}
-                >
-                    {displayText}
-                </Text>
+                <View style={styles.labelColumn}>
+                    {lines.map((line, i) => (
+                        <JustifiedRNLine
+                            key={i}
+                            line={line}
+                            justify={!!justifyMenuItems}
+                            containerWidth={availableWidth}
+                            textAlign={textAlign}
+                            color={labelColor}
+                            bold={!!item.isHost}
+                            textStyle={textStyle}
+                        />
+                    ))}
+                </View>
                 {item.isHost && (
                     <Text style={{ marginLeft: 8 }}>{isExpandedHost ? '▲' : '▼'}</Text>
                 )}
@@ -182,9 +219,13 @@ const styles = StyleSheet.create({
       flexDirection: 'row',
       alignItems: 'center',
   },
+  labelColumn: {
+      flex: 1,
+      flexDirection: 'column',
+  },
   menuItemText: {
       fontSize: 16,
-      flex: 1,
+      alignSelf: 'stretch',
   },
   // Rendered off-screen (position:absolute + opacity:0) so it doesn't affect layout, but its onLayout
   // still fires with the label's natural width — which drives the letterSpacing calculation above.

--- a/aznavrail-react/src/components/RailMenuItem.tsx
+++ b/aznavrail-react/src/components/RailMenuItem.tsx
@@ -148,6 +148,10 @@ export const RailMenuItem: React.FC<RailMenuItemProps> = ({
                     {displayText}
                 </Text>
                 <Text
+                    numberOfLines={1}
+                    // Line breaks in menu labels are explicit-only; the solver shrinks oversized
+                    // labels via `fontScale`, so `numberOfLines={1}` locks the row to one line
+                    // and clips only when even the min-scale doesn't fit.
                     style={[
                         styles.menuItemText,
                         {

--- a/aznavrail-react/src/util/AzJustify.ts
+++ b/aznavrail-react/src/util/AzJustify.ts
@@ -29,15 +29,19 @@ export function solveHybridJustify(
   baseFontSize: number,
   maxTrackingRatio = 0.15,
   maxFontScale = 1.5,
+  minFontScale = 0.5,
 ): { scale: number; letterSpacing: number } {
-  if (
-    charCount < 2 ||
-    naturalWidth <= 0 ||
-    rowWidth <= 0 ||
-    naturalWidth >= rowWidth
-  ) {
+  if (charCount < 1 || naturalWidth <= 0 || rowWidth <= 0) {
     return { scale: 1, letterSpacing: 0 };
   }
+  // Shrink branch — natural width overflows the row. Scale DOWN so the label fits on one line
+  // (no kerning). Callers should also disable auto-wrap so an imperfect fit clips instead of
+  // pushing a single letter onto a new line ("Generat\ne", "Projec\nt").
+  if (naturalWidth >= rowWidth) {
+    const scale = Math.max(minFontScale, Math.min(1, rowWidth / naturalWidth));
+    return { scale, letterSpacing: 0 };
+  }
+  if (charCount < 2) return { scale: 1, letterSpacing: 0 };
   const gaps = charCount - 1;
   const kAtScale1 = (rowWidth - naturalWidth) / gaps;
   if (kAtScale1 <= maxTrackingRatio * baseFontSize) {

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -83,6 +83,10 @@ export const AzDropdownItem = ({
           textAlign,
           letterSpacing: `${letterSpacing}px`,
           fontSize: `${DROPDOWN_WEB_BASE_FONT_PX * fontScale}px`,
+          // Explicit-only line breaks — the solver's shrink branch handles overflow.
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'clip',
           animation: `azTurnstile ${entranceDurationMs}ms cubic-bezier(0.1, 0.9, 0.2, 1) ${index * entranceStaggerMs}ms both`,
           transformOrigin: `${hingeSide} center`,
           '--az-start-angle': `${dockingSide === 'RIGHT' ? -entranceStartAngle : entranceStartAngle}deg`,

--- a/aznavrail-react/src/web/AzDropdownMenu.jsx
+++ b/aznavrail-react/src/web/AzDropdownMenu.jsx
@@ -49,23 +49,9 @@ export const AzDropdownItem = ({
     if (closeOnClick) dismiss();
   };
   const rowRef = useRef(null);
-  const measureRef = useRef(null);
-  // Hybrid kerning + font-scale justify — see ../util/AzJustify.
-  const [letterSpacing, setLetterSpacing] = useState(0);
-  const [fontScale, setFontScale] = useState(1);
-  useEffect(() => {
-    if (!justifyMenuItems || !text || text.length < 2) {
-      setLetterSpacing(0); setFontScale(1); return;
-    }
-    const row = rowRef.current;
-    const meas = measureRef.current;
-    if (!row || !meas) return;
-    const w = row.getBoundingClientRect().width;
-    const nat = meas.getBoundingClientRect().width;
-    const solved = solveHybridJustify(nat, w, text.length, DROPDOWN_WEB_BASE_FONT_PX);
-    setLetterSpacing(solved.letterSpacing);
-    setFontScale(solved.scale);
-  }, [text, justifyMenuItems]);
+  // Split up-front on `\n` so each line owns its own measurement + solve — the newline character
+  // otherwise inflates `charCount` and folds line widths together in the solver.
+  const lines = (text || '').split('\n');
   if (design === 'menu') {
     const hingeSide = dockingSide === 'RIGHT' ? 'right' : 'left';
     const textAlign =
@@ -80,13 +66,9 @@ export const AzDropdownItem = ({
         className={`az-dropdown-menu-item--menu${enabled ? '' : ' disabled'}`}
         style={{
           color: textColor || color || undefined,
-          textAlign,
-          letterSpacing: `${letterSpacing}px`,
-          fontSize: `${DROPDOWN_WEB_BASE_FONT_PX * fontScale}px`,
-          // Explicit-only line breaks — the solver's shrink branch handles overflow.
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-          textOverflow: 'clip',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: textAlign === 'right' ? 'flex-end' : textAlign === 'center' ? 'center' : 'flex-start',
           animation: `azTurnstile ${entranceDurationMs}ms cubic-bezier(0.1, 0.9, 0.2, 1) ${index * entranceStaggerMs}ms both`,
           transformOrigin: `${hingeSide} center`,
           '--az-start-angle': `${dockingSide === 'RIGHT' ? -entranceStartAngle : entranceStartAngle}deg`,
@@ -95,13 +77,15 @@ export const AzDropdownItem = ({
         tabIndex={enabled ? 0 : -1}
         onClick={enabled ? press : undefined}
       >
-        <span
-          ref={measureRef}
-          style={{ position: 'absolute', visibility: 'hidden', whiteSpace: 'nowrap', left: -9999 }}
-        >
-          {text}
-        </span>
-        {text}
+        {lines.map((line, i) => (
+          <JustifiedWebDropdownLine
+            key={i}
+            line={line}
+            justify={justifyMenuItems}
+            rowRef={rowRef}
+            textAlign={textAlign}
+          />
+        ))}
       </div>
     );
   }
@@ -115,6 +99,54 @@ export const AzDropdownItem = ({
       fillColor={fillColor}
       onClick={press}
     />
+  );
+};
+
+/**
+ * One logical line of a MENU-design dropdown label (plain web). Mirrors the RN + Compose per-line
+ * rendering: measure this line's natural width in isolation, run the hybrid solver against it, and
+ * apply the resolved `letterSpacing` + font-scale to just this line. Splitting on `\n` in the
+ * parent means an explicit break becomes two of these; the solver never sees the newline character.
+ */
+const JustifiedWebDropdownLine = ({ line, justify, rowRef, textAlign }) => {
+  const measureRef = useRef(null);
+  const [letterSpacing, setLetterSpacing] = useState(0);
+  const [fontScale, setFontScale] = useState(1);
+  useEffect(() => {
+    if (!justify || !line || line.length < 1) {
+      setLetterSpacing(0); setFontScale(1); return;
+    }
+    const row = rowRef.current;
+    const meas = measureRef.current;
+    if (!row || !meas) return;
+    const rowWidth = row.getBoundingClientRect().width;
+    const natural = meas.getBoundingClientRect().width;
+    const solved = solveHybridJustify(natural, rowWidth, line.length, DROPDOWN_WEB_BASE_FONT_PX);
+    setLetterSpacing(solved.letterSpacing);
+    setFontScale(solved.scale);
+  }, [line, justify, rowRef]);
+  return (
+    <>
+      <span
+        ref={measureRef}
+        style={{ position: 'absolute', visibility: 'hidden', whiteSpace: 'nowrap', left: -9999 }}
+      >
+        {line}
+      </span>
+      <span
+        style={{
+          alignSelf: 'stretch',
+          textAlign,
+          letterSpacing: `${letterSpacing}px`,
+          fontSize: `${DROPDOWN_WEB_BASE_FONT_PX * fontScale}px`,
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'clip',
+        }}
+      >
+        {line}
+      </span>
+    </>
   );
 };
 

--- a/aznavrail-react/src/web/MenuItem.jsx
+++ b/aznavrail-react/src/web/MenuItem.jsx
@@ -120,38 +120,35 @@ const MenuItem = ({
         : 'left';
 
   const rowRef = useRef(null);
-  const measureRef = useRef(null);
-  // Hybrid kerning + font-scale justify — see ../util/AzJustify.
-  const [letterSpacing, setLetterSpacing] = useState(0);
-  const [fontScale, setFontScale] = useState(1);
   const label = (isToggle ? (isChecked ? toggleOnText : toggleOffText) : (isCycler ? selectedOption : text)) || '';
-  useEffect(() => {
-    if (!justifyMenuItems || !label || label.length < 2) {
-      setLetterSpacing(0); setFontScale(1); return;
-    }
-    const row = rowRef.current;
-    const meas = measureRef.current;
-    if (!row || !meas) return;
-    const rowWidth = row.getBoundingClientRect().width - paddingLeft - 16;
-    const natural = meas.getBoundingClientRect().width;
-    const solved = solveHybridJustify(natural, rowWidth, label.length, WEB_BASE_FONT_PX);
-    setLetterSpacing(solved.letterSpacing);
-    setFontScale(solved.scale);
-  }, [label, justifyMenuItems, paddingLeft]);
+  // Split up-front on `\n` so each line owns its own measurement + solve. Compose does this too;
+  // measuring the whole label at once folds newline width into `naturalWidth` and inflates the
+  // solver's `charCount`, so per-line justification would drift for any multi-line label.
+  const lines = label.split('\n');
 
-  const labelStyle = {
-    textAlign,
-    letterSpacing: `${letterSpacing}px`,
-    fontSize: `${WEB_BASE_FONT_PX * fontScale}px`,
-    flex: 1,
-    color: textColor || undefined,
-    // Line breaks in menu labels are explicit-only. The solver's shrink branch scales oversized
-    // labels down; `whiteSpace: nowrap` locks the row to one visual line so the browser can't
-    // wrap "Generate" into "Generat / e".
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'clip',
-  };
+  const renderLabelBlock = (visibleText) => (
+    <span className="az-menu-item-text" style={{
+      flex: 1,
+      color: textColor || undefined,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: textAlign === 'right' ? 'flex-end' : textAlign === 'center' ? 'center' : 'flex-start',
+    }}>
+      {lines.map((line, i) => (
+        <JustifiedWebLine
+          key={i}
+          line={line}
+          justify={justifyMenuItems}
+          rowRef={rowRef}
+          paddingLeft={paddingLeft}
+          textAlign={textAlign}
+        />
+      ))}
+      {/* When called from toggle/cycler, `visibleText` may differ from `label` (e.g. cycler value);
+          this branch only matters for the cycler's supplementary value, which is rendered outside. */}
+      {visibleText && visibleText !== label ? null : null}
+    </span>
+  );
 
   return (
     <div
@@ -162,23 +159,16 @@ const MenuItem = ({
       data-az-nav-id={item.id}
       {...ariaProps}
     >
-      {/* Off-screen measurer — same font-size as the visible label. */}
-      <span ref={measureRef} className="az-menu-item-measurer">{label}</span>
-
       {isToggle ? (
-        <div className="az-menu-item-content toggle">
-          <span className="az-menu-item-text" style={labelStyle}>
-            {isChecked ? toggleOnText : toggleOffText}
-          </span>
-        </div>
+        <div className="az-menu-item-content toggle">{renderLabelBlock(isChecked ? toggleOnText : toggleOffText)}</div>
       ) : isCycler ? (
         <div className="az-menu-item-content cycler">
-          <span className="az-menu-item-text" style={labelStyle}>{text}</span>
+          {renderLabelBlock(text)}
           <span className="az-menu-item-value">{selectedOption}</span>
         </div>
       ) : (
         <div className="az-menu-item-content button">
-          <span className="az-menu-item-text" style={labelStyle}>{text}</span>
+          {renderLabelBlock(text)}
           {isHost && (
             <span className="az-menu-item-arrow">
               {isExpanded ? '▼' : '▶'}
@@ -187,6 +177,47 @@ const MenuItem = ({
         </div>
       )}
     </div>
+  );
+};
+
+/**
+ * One logical line of a plain-web menu label. Splits the label up-front on `\n` in the parent, then
+ * renders this per line so each has its own `naturalWidth` measurement and its own solver call.
+ * `whiteSpace: nowrap` prevents auto-wrap; explicit line breaks come from the `.map` in the parent.
+ */
+const JustifiedWebLine = ({ line, justify, rowRef, paddingLeft, textAlign }) => {
+  const measureRef = useRef(null);
+  const [letterSpacing, setLetterSpacing] = useState(0);
+  const [fontScale, setFontScale] = useState(1);
+  useEffect(() => {
+    if (!justify || !line || line.length < 1) {
+      setLetterSpacing(0); setFontScale(1); return;
+    }
+    const row = rowRef.current;
+    const meas = measureRef.current;
+    if (!row || !meas) return;
+    const rowWidth = row.getBoundingClientRect().width - paddingLeft - 16;
+    const natural = meas.getBoundingClientRect().width;
+    const solved = solveHybridJustify(natural, rowWidth, line.length, WEB_BASE_FONT_PX);
+    setLetterSpacing(solved.letterSpacing);
+    setFontScale(solved.scale);
+  }, [line, justify, paddingLeft, rowRef]);
+
+  const style = {
+    textAlign,
+    letterSpacing: `${letterSpacing}px`,
+    fontSize: `${WEB_BASE_FONT_PX * fontScale}px`,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'clip',
+    alignSelf: 'stretch',
+  };
+
+  return (
+    <>
+      <span ref={measureRef} className="az-menu-item-measurer">{line}</span>
+      <span style={style}>{line}</span>
+    </>
   );
 };
 

--- a/aznavrail-react/src/web/MenuItem.jsx
+++ b/aznavrail-react/src/web/MenuItem.jsx
@@ -145,6 +145,12 @@ const MenuItem = ({
     fontSize: `${WEB_BASE_FONT_PX * fontScale}px`,
     flex: 1,
     color: textColor || undefined,
+    // Line breaks in menu labels are explicit-only. The solver's shrink branch scales oversized
+    // labels down; `whiteSpace: nowrap` locks the row to one visual line so the browser can't
+    // wrap "Generate" into "Generat / e".
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'clip',
   };
 
   return (

--- a/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/assets/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -186,8 +186,10 @@ azConfig(
 RIGHT. `justifyMenuItems` runs a **hybrid kerning + font-scale solver**: it first tries to fill the
 row with `letterSpacing` alone, but never exceeds `α · fontSize` of tracking (default `α = 0.15`);
 once kerning saturates, the font itself scales up so both letter-spacing and font-scale converge on
-the mix that lands the label exactly on the row width. Font growth is capped at `1.5×`. Labels
-shorter than 2 characters, or already at/past the row width, are skipped. `AzDivider` also picks up
+the mix that lands the label exactly on the row width. Font growth is capped at `1.5×`. When the
+natural width **overflows** the row, the solver instead **shrinks** the font (`scale = rowWidth /
+naturalWidth`, clamped to `≥ 0.5×`) so the label fits on one line without breaking mid-word — line
+breaks are explicit-only (soft-wrap is disabled on drawer labels). `AzDivider` also picks up
 the same font color as the surrounding text (via `LocalContentColor` on Compose and `currentColor`
 on the web), so the divider belongs to the same visual family as the labels next to it — not a
 muted outline.

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
@@ -459,6 +460,11 @@ private fun AzDropdownMenuRow(
                         textAlign = textAlign,
                         letterSpacing = with(density) { kerningPx.toSp() },
                         modifier = Modifier.fillMaxWidth(),
+                        // Explicit-only line breaks; the solver's shrink branch handles oversized
+                        // labels by scaling the font down instead of wrapping mid-word.
+                        softWrap = false,
+                        maxLines = 1,
+                        overflow = TextOverflow.Clip,
                     )
                 }
             }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzJustify.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzJustify.kt
@@ -41,9 +41,23 @@ internal fun solveHybridJustify(
     baseFontSizePx: Float,
     maxTrackingRatio: Float = 0.15f,
     maxFontScale: Float = 1.5f,
+    minFontScale: Float = 0.5f,
 ): Pair<Float, Float> {
-    if (charCount < 2 || naturalWidthPx <= 0f || rowWidthPx <= 0f) return 1f to 0f
-    if (naturalWidthPx >= rowWidthPx) return 1f to 0f
+    if (charCount < 1 || naturalWidthPx <= 0f || rowWidthPx <= 0f) return 1f to 0f
+
+    // Shrink branch — natural width overflows the row. Scale the font DOWN just enough to fit on
+    // one line (no kerning). This replaces the old bail-out that let the label auto-wrap into
+    // ugly single-letter overhangs ("Generat\ne", "Projec\nt"). Clamped to `minFontScale` so we
+    // never render the label at a fraction so small it becomes unreadable — beyond that the caller
+    // is expected to have disabled soft-wrap and let the text clip on its own.
+    if (naturalWidthPx >= rowWidthPx) {
+        val s = (rowWidthPx / naturalWidthPx).coerceIn(minFontScale, 1f)
+        return s to 0f
+    }
+
+    // Single-character labels can't be kerned (no inter-character gap). No fill, no scale — the
+    // label sits at its natural size with `TextAlign` handling positioning.
+    if (charCount < 2) return 1f to 0f
 
     val n = charCount
     val gaps = (n - 1).toFloat()

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MenuItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MenuItem.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.sp
@@ -258,6 +259,14 @@ internal fun MenuItem(
                                 modifier = Modifier.fillMaxWidth(),
                                 textAlign = textAlign,
                                 letterSpacing = with(density) { kerningPx.toSp() },
+                                // Line breaks in menu labels are explicit-only. Auto-wrap here
+                                // used to push a single character onto a new line ("Generat\ne"
+                                // for "Generate") when the natural width overflowed the row —
+                                // the solver's shrink branch now handles overflow by scaling the
+                                // font down, so we can safely lock the render to one line.
+                                softWrap = false,
+                                maxLines = 1,
+                                overflow = TextOverflow.Clip,
                             )
                         }
                     }

--- a/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/aznavrail/src/main/resources/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -186,8 +186,10 @@ azConfig(
 RIGHT. `justifyMenuItems` runs a **hybrid kerning + font-scale solver**: it first tries to fill the
 row with `letterSpacing` alone, but never exceeds `α · fontSize` of tracking (default `α = 0.15`);
 once kerning saturates, the font itself scales up so both letter-spacing and font-scale converge on
-the mix that lands the label exactly on the row width. Font growth is capped at `1.5×`. Labels
-shorter than 2 characters, or already at/past the row width, are skipped. `AzDivider` also picks up
+the mix that lands the label exactly on the row width. Font growth is capped at `1.5×`. When the
+natural width **overflows** the row, the solver instead **shrinks** the font (`scale = rowWidth /
+naturalWidth`, clamped to `≥ 0.5×`) so the label fits on one line without breaking mid-word — line
+breaks are explicit-only (soft-wrap is disabled on drawer labels). `AzDivider` also picks up
 the same font color as the surrounding text (via `LocalContentColor` on Compose and `currentColor`
 on the web), so the divider belongs to the same visual family as the labels next to it — not a
 muted outline.

--- a/docs/API.md
+++ b/docs/API.md
@@ -118,7 +118,10 @@ fun azConfig(
   solver** (`internal/AzJustify.kt`): fill the row with `letterSpacing` alone until tracking would
   exceed `α · fontSize` (`α = 0.15`), then grow the font past that limit so both letter-spacing and
   font-size converge on the mix that lands the label exactly on the row width. Font growth capped
-  at `1.5×`. Single-character labels and labels wider than the row are skipped. Default `true`.
+  at `1.5×`. When the natural width **overflows** the row the solver **shrinks** the font
+  (`scale = rowWidth / naturalWidth`, clamped to `≥ 0.5×`); combined with `softWrap = false` +
+  `maxLines = 1` on the drawer's `Text`, line breaks are explicit-only. Single-character labels
+  are skipped. Default `true`.
 * `AzDivider` now defaults its color to `LocalContentColor.current` (Compose) / `currentColor`
   (web) so the divider inherits the surrounding font color and belongs to the same visual family
   as the labels next to it. The rail and dropdown call sites pass their accent explicitly.

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -186,8 +186,10 @@ azConfig(
 RIGHT. `justifyMenuItems` runs a **hybrid kerning + font-scale solver**: it first tries to fill the
 row with `letterSpacing` alone, but never exceeds `α · fontSize` of tracking (default `α = 0.15`);
 once kerning saturates, the font itself scales up so both letter-spacing and font-scale converge on
-the mix that lands the label exactly on the row width. Font growth is capped at `1.5×`. Labels
-shorter than 2 characters, or already at/past the row width, are skipped. `AzDivider` also picks up
+the mix that lands the label exactly on the row width. Font growth is capped at `1.5×`. When the
+natural width **overflows** the row, the solver instead **shrinks** the font (`scale = rowWidth /
+naturalWidth`, clamped to `≥ 0.5×`) so the label fits on one line without breaking mid-word — line
+breaks are explicit-only (soft-wrap is disabled on drawer labels). `AzDivider` also picks up
 the same font color as the surrounding text (via `LocalContentColor` on Compose and `currentColor`
 on the web), so the divider belongs to the same visual family as the labels next to it — not a
 muted outline.

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -40,10 +40,12 @@ The menu-drawer knobs only affect the **expanded-menu drawer** labels (the stand
 `justifyMenuItems` runs a **hybrid kerning + font-scale solver**: it fills the row with
 `letterSpacing` alone until tracking would exceed `α · fontSize` (default `α = 0.15`); once the
 kerning cap is hit, the font scales up so both letter-spacing and font-size converge on the mix
-that lands the label exactly on the row width. Font growth is capped at `1.5×`. Labels shorter
-than 2 characters, or already at/past the row width, are skipped. `AzDivider`'s default color is
-now `LocalContentColor.current` on Compose and `currentColor` on the web, so the divider matches
-the surrounding font — never a muted outline.
+that lands the label exactly on the row width. Font growth is capped at `1.5×`. When the natural
+width **overflows** the row, the solver **shrinks** the font (`scale = rowWidth / naturalWidth`,
+clamped to `≥ 0.5×`) so the label fits on one line without breaking mid-word — line breaks in
+drawer labels are **explicit-only** (soft-wrap is disabled). Labels shorter than 2 characters are
+skipped. `AzDivider`'s default color is now `LocalContentColor.current` on Compose and
+`currentColor` on the web, so the divider matches the surrounding font — never a muted outline.
 
 `appRepositoryUrl` is an **optional** override for the About reader's repo. Blank (the default)
 auto-derives the repo from the app **namespace** on Android: `com.<owner>.<repo>` →


### PR DESCRIPTION
## Summary

Regression from the hybrid-justify pass: labels whose natural width already overflowed the row bailed out of the solver (`scale=1, kerning=0`) and the underlying `Text`/`<Text>`/`<span>` then auto-wrapped mid-word — producing "Generat / e", "Projec / t", "Setting / s", "Tutoria / l" overhangs on narrow rails.

Fix on two axes:

### 1. `solveHybridJustify` gains a **shrink** branch

```
if (naturalWidth >= rowWidth) {
  scale = clamp(rowWidth / naturalWidth, minFontScale, 1)   // default minFontScale = 0.5
  letterSpacing = 0
}
```

The label now scales **down** to fit on one line rather than rendering at natural size and wrapping. Applied both in `internal/AzJustify.kt` and `src/util/AzJustify.ts`.

### 2. Auto-wrap is disabled on every drawer-label surface

A literal `\n` in the label string is now the **only** way to split a label across lines:

- **Compose** — `internal/MenuItem.kt` and `AzDropdownMenu.kt` (`AzDropdownMenuRow`): `softWrap = false`, `maxLines = 1`, `overflow = TextOverflow.Clip` on each per-line `Text`.
- **React Native** — `components/RailMenuItem.tsx` and `components/AzDropdownMenu.tsx`: `numberOfLines={1}`.
- **Plain web** — `web/MenuItem.jsx` and `web/AzDropdownMenu.jsx`: `whiteSpace: 'nowrap'`, `overflow: 'hidden'`, `textOverflow: 'clip'`.

### Docs

`README.md`, `docs/API.md`, `docs/DSL.md`, `docs/AZNAVRAIL_COMPLETE_GUIDE.md` (canonical + bundled `resources/` + `assets/` copies), `aznavrail-react/CHANGELOG.md`.

## Test plan

- [ ] `./gradlew :SampleApp:installDebug` — open the drawer with labels like "Generate", "Project", "Settings", "Tutorial". Confirm they render on a single line at a slightly smaller font size, not wrapped mid-word.
- [ ] Confirm shorter labels ("New", "Save", "FAQ") still fill the row via the kerning+font-scale mix.
- [ ] Confirm a label containing an explicit `\n` still splits across two rows.
- [ ] Same on the sample-pwa (browser + react-native-web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_