### PR TITLE
Use AutoMirrored Icons.Notes to silence Compose deprecation warning

### DIFF
--- a/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/FormShowcaseScreen.kt
+++ b/SampleApp/src/main/java/com/hereliesaz/SampleApp/screens/FormShowcaseScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.Notes
+import androidx.compose.material.icons.automirrored.filled.Notes
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -79,7 +79,7 @@ fun FormShowcaseScreen() {
             entry(entryName = "username", hint = "Username", leadingIcon = { Icon(Icons.Default.AccountCircle, null) })
             entry(entryName = "email", hint = "Email", initialValue = "you@example.com", keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email))
             entry(entryName = "password", hint = "Password", secret = true, leadingIcon = { Icon(Icons.Default.Lock, null) })
-            entry(entryName = "bio", hint = "Biography (multiline)", multiline = true, leadingIcon = { Icon(Icons.Default.Notes, null) })
+            entry(entryName = "bio", hint = "Biography (multiline)", multiline = true, leadingIcon = { Icon(Icons.AutoMirrored.Filled.Notes, null) })
             entry(entryName = "broken", hint = "Always in error state", isError = true)
             entry(entryName = "frozen", hint = "Disabled entry", enabled = false, initialValue = "read only")
         }


### PR DESCRIPTION
## Summary

JitPack's build log surfaced this Compose deprecation on every SampleApp build:

```
w: FormShowcaseScreen.kt:82:123 'val Icons.Filled.Notes: ImageVector' is deprecated.
Use the AutoMirrored version at Icons.AutoMirrored.Filled.Notes.
```

Swap the import and the call-site to the AutoMirrored variant. The Compose team introduced these AutoMirrored icons so glyphs that carry directional meaning (Notes, ArrowBack, Send, Undo, etc.) flip correctly under RTL layouts.

### Why the JitPack build "failed"

The Gradle build itself succeeded — the log ends with:

```
Publication: com.github.HereLiesAz.AzNavRail:aznavrail:9.12
Build tool exit code: 0
Looking for artifacts...
Found artifact: com.github.HereLiesAz.AzNavRail:aznavrail:9.12
ERROR: Time-out getting container status
Error building
```

That final "Error building" is JitPack's own container-status check timing out after the build completes and the artifact is published. It's a JitPack infrastructure hiccup, not a project issue. This PR only cleans up the warning that showed up in the log.

## Test plan

- [ ] `./gradlew :SampleApp:compileDebugKotlin` — confirm no `Icons.Filled.Notes` deprecation warning.
- [ ] Sample app "Forms Showcase" screen — the multi-line biography entry still shows a Notes icon; visually indistinguishable from before (the auto-mirrored variant is identical in LTR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_

## Summary by Sourcery

Bug Fixes:
- Resolve the deprecated Icons.Filled.Notes usage in the Forms Showcase screen by switching to the auto-mirrored Notes icon.