### PR TITLE
Dissolve overlay fixes + Compose Multiplatform sibling module (Phase A/B/C, Phase D partial)

### DIFF
--- a/aznavrail-cmp/build.gradle.kts
+++ b/aznavrail-cmp/build.gradle.kts
@@ -16,6 +16,7 @@ version = System.getenv("JITPACK_VERSION") ?: libs.versions.aznavrail.get()
 // warnings as script errors, so declaring the coordinates explicitly avoids the whole class of
 // script-compilation failures.
 val cmpVersion = libs.versions.composeMultiplatform.get()
+val activityComposeCmpVersion = libs.versions.activityComposeCmp.get()
 
 kotlin {
     jvmToolchain(17)
@@ -41,6 +42,9 @@ kotlin {
                 implementation("org.jetbrains.compose.material3:material3:$cmpVersion")
                 implementation("org.jetbrains.compose.ui:ui:$cmpVersion")
                 implementation("org.jetbrains.compose.components:components-resources:$cmpVersion")
+                // JetBrains multiplatform fork of androidx.activity — provides BackHandler in
+                // commonMain across every target.
+                implementation("org.jetbrains.androidx.activity:activity-compose:$activityComposeCmpVersion")
             }
         }
     }

--- a/aznavrail-cmp/build.gradle.kts
+++ b/aznavrail-cmp/build.gradle.kts
@@ -46,11 +46,11 @@ kotlin {
     }
 }
 
-// AGP 9 exposes the LibraryExtension via the `androidLibrary` name (new DSL) instead of the
-// deprecated `android` extension. Under `-Werror`/strict-deprecation script compilation used by the
-// KMP plugin, referencing `android { ... }` becomes an error; `androidLibrary { ... }` is the
-// clean path.
-androidLibrary {
+// This project pins `android.newDsl=false` in `gradle.properties`, so the AGP 9 `androidLibrary`
+// extension isn't registered — only the deprecated `android { }` DSL is available. The DSL
+// generates a `w:` deprecation warning; with no `e:` errors left in this script that warning is
+// tolerated and the script compiles.
+android {
     namespace = "com.hereliesaz.aznavrail.cmp"
     compileSdk = 36
 

--- a/aznavrail-cmp/build.gradle.kts
+++ b/aznavrail-cmp/build.gradle.kts
@@ -18,6 +18,7 @@ version = System.getenv("JITPACK_VERSION") ?: libs.versions.aznavrail.get()
 val cmpVersion = libs.versions.composeMultiplatform.get()
 val activityComposeCmpVersion = libs.versions.activityComposeCmp.get()
 val coil3Version = libs.versions.coil3.get()
+val navigationComposeCmpVersion = libs.versions.navigationComposeCmp.get()
 
 kotlin {
     jvmToolchain(17)
@@ -50,6 +51,10 @@ kotlin {
                 // port). Consumers can add `coil-network-ktor3`/`coil-network-okhttp` for URL
                 // loading; the base `coil-compose` handles model→painter without an engine.
                 implementation("io.coil-kt.coil3:coil-compose:$coil3Version")
+                // JetBrains multiplatform fork of AndroidX Navigation — the API is
+                // package-compatible with `androidx.navigation`, so files ported from the Android
+                // sibling generally need no import changes.
+                implementation("org.jetbrains.androidx.navigation:navigation-compose:$navigationComposeCmpVersion")
             }
         }
     }

--- a/aznavrail-cmp/build.gradle.kts
+++ b/aznavrail-cmp/build.gradle.kts
@@ -17,6 +17,7 @@ version = System.getenv("JITPACK_VERSION") ?: libs.versions.aznavrail.get()
 // script-compilation failures.
 val cmpVersion = libs.versions.composeMultiplatform.get()
 val activityComposeCmpVersion = libs.versions.activityComposeCmp.get()
+val coil3Version = libs.versions.coil3.get()
 
 kotlin {
     jvmToolchain(17)
@@ -45,6 +46,10 @@ kotlin {
                 // JetBrains multiplatform fork of androidx.activity — provides BackHandler in
                 // commonMain across every target.
                 implementation("org.jetbrains.androidx.activity:activity-compose:$activityComposeCmpVersion")
+                // Coil 3 — multiplatform image loader (replaces Android-only Coil 2 in the CMP
+                // port). Consumers can add `coil-network-ktor3`/`coil-network-okhttp` for URL
+                // loading; the base `coil-compose` handles model→painter without an engine.
+                implementation("io.coil-kt.coil3:coil-compose:$coil3Version")
             }
         }
     }

--- a/aznavrail-cmp/build.gradle.kts
+++ b/aznavrail-cmp/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.compose.multiplatform)
@@ -7,6 +9,13 @@ plugins {
 
 group = "com.github.HereLiesAz.AzNavRail"
 version = System.getenv("JITPACK_VERSION") ?: libs.versions.aznavrail.get()
+
+// Direct Maven coordinates for the JetBrains Compose Multiplatform artifacts. The `compose.runtime`
+// / `compose.foundation` / etc. plugin accessors are deprecated in CMP 1.11+ ("Specify dependency
+// directly") and Gradle Kotlin DSL script compilation on the KMP variant treats deprecation
+// warnings as script errors, so declaring the coordinates explicitly avoids the whole class of
+// script-compilation failures.
+val cmpVersion = libs.versions.composeMultiplatform.get()
 
 kotlin {
     jvmToolchain(17)
@@ -19,7 +28,7 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    @OptIn(org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl::class)
+    @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()
     }
@@ -27,17 +36,21 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
-                implementation(compose.foundation)
-                implementation(compose.material3)
-                implementation(compose.ui)
-                implementation(compose.components.resources)
+                implementation("org.jetbrains.compose.runtime:runtime:$cmpVersion")
+                implementation("org.jetbrains.compose.foundation:foundation:$cmpVersion")
+                implementation("org.jetbrains.compose.material3:material3:$cmpVersion")
+                implementation("org.jetbrains.compose.ui:ui:$cmpVersion")
+                implementation("org.jetbrains.compose.components:components-resources:$cmpVersion")
             }
         }
     }
 }
 
-android {
+// AGP 9 exposes the LibraryExtension via the `androidLibrary` name (new DSL) instead of the
+// deprecated `android` extension. Under `-Werror`/strict-deprecation script compilation used by the
+// KMP plugin, referencing `android { ... }` becomes an error; `androidLibrary { ... }` is the
+// clean path.
+androidLibrary {
     namespace = "com.hereliesaz.aznavrail.cmp"
     compileSdk = 36
 

--- a/aznavrail-cmp/build.gradle.kts
+++ b/aznavrail-cmp/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.android.library)
+}
+
+group = "com.github.HereLiesAz.AzNavRail"
+version = System.getenv("JITPACK_VERSION") ?: libs.versions.aznavrail.get()
+
+kotlin {
+    jvmToolchain(17)
+
+    androidTarget()
+
+    jvm("desktop")
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    @OptIn(org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material3)
+                implementation(compose.ui)
+                implementation(compose.components.resources)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "com.hereliesaz.aznavrail.cmp"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/aznavrail-cmp/src/androidMain/AndroidManifest.xml
+++ b/aznavrail-cmp/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/aznavrail-cmp/src/androidMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.android.kt
+++ b/aznavrail-cmp/src/androidMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.android.kt
@@ -1,0 +1,7 @@
+package com.hereliesaz.aznavrail.internal
+
+import android.util.Log
+
+internal actual fun platformLogE(tag: String, message: String, throwable: Throwable?) {
+    Log.e(tag, message, throwable)
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzButton.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzButton.kt
@@ -1,0 +1,245 @@
+// FILE: ./aznavrail/src/main/java/com/hereliesaz/aznavrail/AzButton.kt
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
+import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzComposableContent
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * A standalone button component that matches the aesthetic of the AzNavRail.
+ *
+ * It automatically handles text resizing to fit the container and supports various shapes,
+ * including circular and rectangular variants. Internally delegates to the same primitive
+ * ([AzNavRailButton]) used by every rail/menu button so visual parity is guaranteed.
+ *
+ * Example:
+ * ```
+ * AzButton(
+ *     onClick = { viewModel.save() },
+ *     text = "Save",
+ *     shape = AzButtonShape.RECTANGLE,
+ * )
+ * ```
+ *
+ * @param onClick Callback invoked when the button is clicked.
+ * @param text The text to display when [itemContent] is null.
+ * @param modifier The modifier to apply to the button.
+ * @param color The border/icon color in the unselected state.
+ * @param activeColor The color used when the button is pressed.
+ * @param textColor Overrides the computed text color. Falls back to [color] when null.
+ * @param fillColor Overrides the translucent background fill. Falls back to a computed
+ *   light/dark inversion of [color] when null.
+ * @param colors Optional [ButtonColors] slot reserved for Material compatibility (currently unused).
+ * @param shape The geometric shape of the button (Circle, Square, Rectangle, None).
+ * @param enabled Whether the button is enabled and interactive.
+ * @param isLoading If true, hides the text and overlays an [AzLoad] spinner.
+ * @param contentPadding Custom padding for the button content. Defaults to 8dp on every side.
+ * @param itemContent Optional custom composable to render in place of [text]. Wrapped into an
+ *   [AzComposableContent] internally so the renderer can apply alpha/scale uniformly.
+ */
+@Composable
+fun AzButton(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary,
+    activeColor: Color = MaterialTheme.colorScheme.primary,
+    textColor: Color? = null,
+    fillColor: Color? = null,
+    colors: ButtonColors? = null,
+    shape: AzButtonShape = AzButtonShape.CIRCLE,
+    enabled: Boolean = true,
+    isLoading: Boolean = false,
+    contentPadding: PaddingValues? = null,
+    itemContent: @Composable (() -> Unit)? = null
+) {
+    val composableContent = itemContent?.let {
+        AzComposableContent { _ -> it() }
+    }
+    AzNavRailButton(
+        onClick = onClick,
+        text = text,
+        modifier = modifier,
+        color = color,
+        activeColor = activeColor,
+        textColor = textColor,
+        fillColor = fillColor,
+        colors = colors,
+        size = AzNavRailDefaults.ButtonWidth,
+        shape = shape,
+        enabled = enabled,
+        isSelected = false,
+        isLoading = isLoading,
+        contentPadding = contentPadding ?: PaddingValues(8.dp),
+        itemContent = composableContent
+    )
+}
+
+/**
+ * A standalone toggle button that switches between two text states.
+ *
+ * The toggle's visual text and the callback are driven by [isChecked]. The component is
+ * intentionally stateless — store the boolean in your own state holder and feed it back here.
+ *
+ * Example:
+ * ```
+ * var dark by remember { mutableStateOf(false) }
+ * AzToggle(
+ *     isChecked = dark,
+ *     onToggle = { dark = it },
+ *     toggleOnText = "Dark",
+ *     toggleOffText = "Light",
+ * )
+ * ```
+ *
+ * @param isChecked The current state of the toggle.
+ * @param onToggle Callback invoked with the inverted state when the button is tapped.
+ * @param toggleOnText Text shown when [isChecked] is true.
+ * @param toggleOffText Text shown when [isChecked] is false.
+ * @param modifier The modifier to apply to the button container.
+ * @param color The base border/icon color in the unselected state.
+ * @param activeColor The color used when the toggle is pressed.
+ * @param textColor Overrides the computed text color. Falls back to [color] when null.
+ * @param fillColor Overrides the translucent background fill.
+ * @param colors Reserved Material [ButtonColors] slot (currently unused).
+ * @param shape The geometric shape of the button.
+ * @param enabled Whether the toggle is interactive.
+ * @param itemContent Optional custom composable to render instead of the toggle text.
+ */
+@Composable
+fun AzToggle(
+    isChecked: Boolean,
+    onToggle: (Boolean) -> Unit,
+    toggleOnText: String,
+    toggleOffText: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary,
+    activeColor: Color = MaterialTheme.colorScheme.primary,
+    textColor: Color? = null,
+    fillColor: Color? = null,
+    colors: ButtonColors? = null,
+    shape: AzButtonShape = AzButtonShape.CIRCLE,
+    enabled: Boolean = true,
+    itemContent: @Composable (() -> Unit)? = null
+) {
+    val text = if (isChecked) toggleOnText else toggleOffText
+    val composableContent = itemContent?.let {
+        AzComposableContent { _ -> it() }
+    }
+    AzNavRailButton(
+        onClick = { onToggle(!isChecked) },
+        text = text,
+        color = color,
+        activeColor = activeColor,
+        textColor = textColor,
+        fillColor = fillColor,
+        colors = colors,
+        size = AzNavRailDefaults.ButtonWidth,
+        shape = shape,
+        enabled = enabled,
+        isSelected = false,
+        itemContent = composableContent
+    )
+}
+
+/**
+ * A standalone cycler button that rotates through a list of string options.
+ *
+ * The cycler implements a 1000ms commit delay: each tap advances the displayed option
+ * immediately, but [onCycle] only fires after the user has stopped tapping for one second.
+ * This lets a user quickly skip past several options without firing intermediate selection
+ * callbacks (useful when the underlying state mutation is expensive).
+ *
+ * Example:
+ * ```
+ * var quality by remember { mutableStateOf("Auto") }
+ * AzCycler(
+ *     options = listOf("Auto", "Low", "Medium", "High"),
+ *     selectedOption = quality,
+ *     onCycle = { quality = it },
+ * )
+ * ```
+ *
+ * @param options The list of options to cycle through. Must be non-empty.
+ * @param selectedOption The currently committed option from the consumer's state.
+ * @param onCycle Callback invoked with the settled option after the 1000ms quiet period.
+ * @param modifier The modifier to apply.
+ * @param color The base border/icon color.
+ * @param activeColor The color used when the cycler is pressed.
+ * @param textColor Overrides the computed text color.
+ * @param fillColor Overrides the translucent background fill.
+ * @param colors Reserved Material [ButtonColors] slot (currently unused).
+ * @param shape The geometric shape of the button.
+ * @param enabled Whether the cycler is interactive.
+ * @param itemContent Optional custom composable to render instead of the option text.
+ */
+@Composable
+fun AzCycler(
+    options: List<String>,
+    selectedOption: String,
+    onCycle: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary,
+    activeColor: Color = MaterialTheme.colorScheme.primary,
+    textColor: Color? = null,
+    fillColor: Color? = null,
+    colors: ButtonColors? = null,
+    shape: AzButtonShape = AzButtonShape.CIRCLE,
+    enabled: Boolean = true,
+    itemContent: @Composable (() -> Unit)? = null
+) {
+    var displayedOption by rememberSaveable(selectedOption) { mutableStateOf(selectedOption) }
+    var job by remember { mutableStateOf<Job?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+
+    val composableContent = itemContent?.let {
+        AzComposableContent { _ -> it() }
+    }
+
+    LaunchedEffect(selectedOption) {
+        job?.cancel()
+        job = null
+        displayedOption = selectedOption
+    }
+
+    AzNavRailButton(
+        onClick = {
+            job?.cancel()
+            val currentIndex = options.indexOf(displayedOption)
+            val nextIndex = (currentIndex + 1) % options.size
+            displayedOption = options[nextIndex]
+            job = coroutineScope.launch {
+                delay(1000L)
+                onCycle(displayedOption)
+            }
+        },
+        text = displayedOption,
+        color = color,
+        activeColor = activeColor,
+        textColor = textColor,
+        fillColor = fillColor,
+        colors = colors,
+        size = AzNavRailDefaults.ButtonWidth,
+        shape = shape,
+        enabled = enabled,
+        isSelected = false,
+        itemContent = composableContent
+    )
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzDivider.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzDivider.kt
@@ -1,0 +1,62 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * A divider that automatically adjusts its orientation based on the available space.
+ * It renders as a [HorizontalDivider] in a vertical layout (e.g., a `Column`)
+ * and a [VerticalDivider] in a horizontal layout (e.g., a `Row`).
+ *
+ * This composable is designed to be a direct replacement for `HorizontalDivider` or
+ * `VerticalDivider` when the orientation needs to be dynamic.
+ *
+ * The default color follows the surrounding **font color** ([LocalContentColor]) so the divider
+ * belongs to the same visual family as the text next to it — not a muted outline. The rail and the
+ * standalone `AzDropdownMenu` override this to the accent color at their divider call sites.
+ *
+ * @param modifier The modifier to be applied to the divider.
+ * @param thickness The thickness of the divider line. Defaults to `1.dp`.
+ * @param color The color of the divider line. Defaults to [LocalContentColor.current] — the
+ * ambient text/foreground color inherited from the enclosing composition.
+ * @param horizontalPadding The padding applied to the left and right of the divider.
+ * Defaults to `16.dp`.
+ * @param verticalPadding The padding applied to the top and bottom of the divider.
+ * Defaults to `8.dp`.
+ */
+@Composable
+fun AzDivider(
+    modifier: Modifier = Modifier,
+    thickness: Dp = 1.dp,
+    color: Color = LocalContentColor.current,
+    horizontalPadding: Dp = 16.dp,
+    verticalPadding: Dp = 8.dp
+) {
+    BoxWithConstraints(
+        modifier = modifier.padding(horizontal = horizontalPadding, vertical = verticalPadding)
+    ) {
+        if (maxHeight > maxWidth) {
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth(),
+                thickness = thickness,
+                color = color
+            )
+        } else {
+            VerticalDivider(
+                modifier = Modifier.fillMaxHeight(),
+                thickness = thickness,
+                color = color
+            )
+        }
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzForm.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzForm.kt
@@ -1,0 +1,254 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.toMutableStateMap
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+
+/**
+ * Scope for defining the structure of an [AzForm].
+ */
+class AzFormScope {
+    internal val entries = mutableListOf<AzFormEntry>()
+
+    /**
+     * Adds a text entry field to the form.
+     *
+     * @param entryName The unique name key for this field, used in the result map.
+     * @param hint The hint text to display when the field is empty.
+     * @param multiline Whether the field supports multiple lines of text.
+     * @param secret Whether the field is for sensitive input (password), masking the text.
+     * @param leadingIcon An optional composable to display at the start of the field.
+     * @param isError Whether the field is in an error state.
+     * @param enabled Whether the field is enabled and interactive.
+     * @param keyboardOptions Custom keyboard configuration.
+     * @param keyboardActions Custom keyboard actions.
+     */
+    fun entry(
+        entryName: String,
+        hint: String,
+        multiline: Boolean = false,
+        secret: Boolean = false,
+        leadingIcon: @Composable (() -> Unit)? = null,
+        isError: Boolean = false,       
+        enabled: Boolean = true,
+        keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+        keyboardActions: KeyboardActions = KeyboardActions.Default,
+        initialValue: String = ""
+    ) {
+        entries.add(AzFormEntry(
+            entryName = entryName,
+            hint = hint,
+            multiline = multiline,
+            secret = secret,
+            leadingIcon = leadingIcon,
+            isError = isError,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            enabled = enabled,
+            initialValue = initialValue
+        ))
+    }
+}
+
+internal data class AzFormEntry(
+    val entryName: String,
+    val hint: String,
+    val multiline: Boolean,
+    val secret: Boolean,
+    val leadingIcon: @Composable (() -> Unit)?,
+    val isError: Boolean,
+    val keyboardOptions: KeyboardOptions,
+    val keyboardActions: KeyboardActions,
+    val enabled: Boolean,
+    val initialValue: String = ""
+)
+
+/**
+ * A container composable that groups multiple [AzTextBox] fields into a single form.
+ *
+ * The form manages the state of all its fields and provides a single submit action.
+ * It automatically handles focus traversal (Next) and submission (Send) for the last field.
+ *
+ * @param formName A unique name for the form, used as a context for autocomplete history.
+ * @param modifier The modifier to be applied to the form container.
+ * @param outlined Whether the text fields in the form should be outlined.
+ * @param outlineColor The color of the outlines and icons.
+ * @param trailingIcon An optional composable to display at the end of every text box in the form.
+ * @param keyboardOptions Default keyboard options for all fields in the form.
+ * @param keyboardActions Default keyboard actions for all fields in the form.
+ * @param onSubmit A callback invoked when the form is submitted, providing a map of [entryName] to value.
+ * @param submitButtonContent A composable for the submit button's content.
+ * @param content The DSL block to define form entries.
+ *
+ * @see AzTextBox
+ * @see AzFormScope
+ */
+@Composable
+fun AzForm(
+    formName: String,
+    modifier: Modifier = Modifier,
+    outlined: Boolean = true,
+    outlineColor: Color = MaterialTheme.colorScheme.primary,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    onSubmit: (Map<String, String>) -> Unit,
+    submitButtonContent: @Composable () -> Unit = { Text("Submit") },
+    content: AzFormScope.() -> Unit
+) {
+    val scope = remember(formName, content) { AzFormScope().apply(content) }
+    val focusManager = LocalFocusManager.current
+    val formData = rememberSaveable(
+        saver = listSaver<SnapshotStateMap<String, String>, Pair<String, String>>(
+            save = { it.toList() },
+            restore = { it.toMutableStateMap() }
+        )
+    ) {
+        mutableStateMapOf<String, String>().apply {
+            scope.entries.forEach { entry ->
+                this[entry.entryName] = entry.initialValue
+            }
+        }
+    }
+
+    Column(modifier = modifier) {
+        scope.entries.forEachIndexed { index, entry ->
+            // Determine ImeAction
+            val defaultImeAction = if (index == scope.entries.lastIndex) ImeAction.Send else ImeAction.Next
+            val imeAction = if (entry.keyboardOptions.imeAction == ImeAction.Default) {
+                if (keyboardOptions.imeAction == ImeAction.Default) defaultImeAction else keyboardOptions.imeAction
+            } else {
+                entry.keyboardOptions.imeAction
+            }
+
+            // Determine KeyboardActions
+            val finalKeyboardActions = if (entry.keyboardActions == KeyboardActions.Default && keyboardActions == KeyboardActions.Default) {
+                 if (imeAction == ImeAction.Next) {
+                     KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) })
+                 } else if (imeAction == ImeAction.Send) {
+                     KeyboardActions(onSend = { onSubmit(formData.toMap()) })
+                 } else {
+                     KeyboardActions.Default
+                 }
+            } else if (entry.keyboardActions != KeyboardActions.Default) {
+                entry.keyboardActions
+            } else {
+                keyboardActions
+            }
+
+            val finalKeyboardOptions = entry.keyboardOptions.copy(imeAction = imeAction)
+
+            if (index == scope.entries.lastIndex) {
+                Row(verticalAlignment = Alignment.Bottom) {
+                    Box(modifier = Modifier.weight(1f)) {
+                        FormEntryTextBox(
+                            entry = entry,
+                            value = formData[entry.entryName] ?: "",
+                            onValueChange = { formData[entry.entryName] = it },
+                            outlined = outlined,
+                            outlineColor = outlineColor,
+                            historyContext = formName,
+                            trailingIcon = trailingIcon,
+                            keyboardOptions = finalKeyboardOptions,
+                            keyboardActions = finalKeyboardActions
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    CompositionLocalProvider(LocalContentColor provides outlineColor) {
+                        // Restore 6.99 visual style (rounded) for submit button in form
+                        val shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp)
+                        Box(
+                            modifier = Modifier
+                                .clickable { onSubmit(formData.toMap()) }
+                                .background(AzTextBoxDefaults.getBackgroundColor().copy(alpha = AzTextBoxDefaults.getBackgroundOpacity()), shape)
+                                .then(
+                                    if (!outlined) {
+                                        Modifier.border(1.dp, outlineColor, shape)
+                                    } else {
+                                        Modifier
+                                    }
+                                )
+                                .padding(horizontal = 12.dp, vertical = 8.dp)
+                        ) {
+                            submitButtonContent()
+                        }
+                    }
+                }
+            } else {
+                FormEntryTextBox(
+                    entry = entry,
+                    value = formData[entry.entryName] ?: "",
+                    onValueChange = { formData[entry.entryName] = it },
+                    outlined = outlined,
+                    outlineColor = outlineColor,
+                    historyContext = formName,
+                    trailingIcon = trailingIcon,
+                    keyboardOptions = finalKeyboardOptions,
+                    keyboardActions = finalKeyboardActions
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun FormEntryTextBox(
+    entry: AzFormEntry,
+    value: String,
+    onValueChange: (String) -> Unit,
+    outlined: Boolean,
+    outlineColor: Color,
+    historyContext: String,
+    trailingIcon: @Composable (() -> Unit)?,
+    keyboardOptions: KeyboardOptions,
+    keyboardActions: KeyboardActions
+) {
+    AzTextBox(
+        value = value,
+        onValueChange = onValueChange,
+        historyContext = historyContext,
+        hint = entry.hint,
+        outlined = outlined,
+        multiline = entry.multiline,
+        secret = entry.secret,
+        leadingIcon = entry.leadingIcon,
+        trailingIcon = trailingIcon,
+        isError = entry.isError,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        enabled = entry.enabled,
+        outlineColor = outlineColor,
+        submitButtonContent = null,
+        onSubmit = { /* Individual onSubmit is not used in a form context */ }
+    )
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzLoad.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzLoad.kt
@@ -1,0 +1,61 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * A standard loading spinner component for AzNavRail.
+ *
+ * It renders a rotating circular border with "loading..." text in the center.
+ * This component is used by [AzNavRail] when `isLoading` is set to true in `azAdvanced`,
+ * and by [AzButton] when its `isLoading` state is true.
+ *
+ * It uses a simple Y-axis rotation animation.
+ */
+@Composable
+fun AzLoad() {
+    val infiniteTransition = rememberInfiniteTransition()
+    val rotationY by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        )
+    )
+
+    Box(
+        modifier = Modifier
+            .size(120.dp)
+            .graphicsLayer {
+                this.rotationY = rotationY
+            }
+            .border(
+                width = 2.dp,
+                color = MaterialTheme.colorScheme.primary,
+                shape = CircleShape
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "loading...",
+            style = TextStyle(
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 16.sp
+            )
+        )
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -1,0 +1,257 @@
+// FILE: ./aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.rememberAsyncImagePainter
+import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
+import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzComposableContent
+import com.hereliesaz.aznavrail.util.text.AutoSizeText
+
+/**
+ * The internal button primitive for every item rendered in the navigation rail or nested rail.
+ *
+ * Handles shape enforcement, color transitions on press/selection, custom content rendering
+ * (Color, Image, resource ID, or [AzComposableContent]), and the loading state. All rail buttons
+ * share the strict [AzNavRailDefaults.ButtonWidth] — only height varies by shape.
+ *
+ * @param onClick Click handler, or null to make the button non-interactive.
+ * @param text Text displayed when [itemContent] is null.
+ * @param modifier Applied to the button container.
+ * @param size Button size in dp; typically [AzNavRailDefaults.ButtonWidth].
+ * @param color Base border/icon color (unselected state).
+ * @param activeColor Color used when the button is pressed or selected.
+ * @param textColor Overrides computed text/icon color.
+ * @param fillColor Overrides the translucent fill color for the button background.
+ * @param colors Unused Material [ButtonColors] slot (reserved for future compatibility).
+ * @param shape Determines the geometric shape of the button.
+ * @param enabled Whether the button can be interacted with.
+ * @param isSelected Whether the button is in the selected/active state.
+ * @param isLoading When true, the button content is hidden and [AzLoad] is shown in its place.
+ * @param contentPadding Padding applied around text content (ignored when [itemContent] is set).
+ * @param itemContent Arbitrary content to render inside the button instead of [text]. Accepts
+ *   [Color], [AzComposableContent], [Int] (resource ID), [String], an
+ *   [androidx.compose.ui.graphics.vector.ImageVector] or
+ *   [androidx.compose.ui.graphics.painter.Painter] (vector graphics), or any image model
+ *   loadable by Coil (Bitmap, URL, File, Uri, …). All non-text graphics fill the button
+ *   shape (Crop) and are clipped to it.
+ * @param onLongClick Long-press handler.
+ * @param onGloballyPositioned Reports the window-space bounds of the button after layout.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun AzNavRailButton(
+    onClick: (() -> Unit)?,
+    text: String,
+    modifier: Modifier = Modifier,
+    size: Dp = AzNavRailDefaults.ButtonWidth,
+    color: Color = MaterialTheme.colorScheme.primary,
+    activeColor: Color = MaterialTheme.colorScheme.primary,
+    textColor: Color? = null,
+    fillColor: Color? = null,
+    colors: ButtonColors? = null,
+    shape: AzButtonShape = AzButtonShape.CIRCLE,
+    enabled: Boolean = true,
+    isSelected: Boolean = false,
+    isLoading: Boolean = false,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+    itemContent: Any? = null,
+    onLongClick: (() -> Unit)? = null,
+    onGloballyPositioned: ((Rect) -> Unit)? = null,
+    rotationDegrees: Float = 0f
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    val buttonShape: Shape = when (shape) {
+        AzButtonShape.CIRCLE -> CircleShape
+        AzButtonShape.SQUARE -> RectangleShape
+        AzButtonShape.RECTANGLE -> RectangleShape
+        AzButtonShape.NONE -> RectangleShape
+    }
+
+    val isRotated = rotationDegrees != 0f && (rotationDegrees % 180 != 0f)
+
+    // STRICT WIDTH COMPLIANCE for all shapes. Swapped in landscape to maintain "physical" size.
+    val buttonModifier = when (shape) {
+        AzButtonShape.CIRCLE, AzButtonShape.SQUARE -> modifier
+            .size(size)
+            .aspectRatio(1f)
+        AzButtonShape.RECTANGLE, AzButtonShape.NONE -> {
+            if (isRotated) {
+                modifier.width(40.dp).height(size)
+            } else {
+                modifier.width(size).height(40.dp)
+            }
+        }
+    }
+
+    // Apply rotation back to keep text upright "in place"
+    val finalModifier = buttonModifier.graphicsLayer {
+        rotationZ = -rotationDegrees
+    }
+
+    val clippedModifier = finalModifier.clip(buttonShape)
+
+    val disabledColor = color.copy(alpha = 0.38f)
+    val targetColor = if (isPressed || isSelected) activeColor else color
+    val finalColor = if (enabled) targetColor else disabledColor
+
+    val computedFillColor = if (finalColor == Color.Black) Color.White else Color.Black
+    val computedActiveFillColor = if (activeColor == Color.Black) Color.White else Color.Black
+
+    val baseFillColor = fillColor ?: computedFillColor
+    val activeFillColor = fillColor ?: computedActiveFillColor
+
+    val containerColor = if (isSelected && !isPressed) {
+        activeFillColor.copy(alpha = 0.12f)
+    } else {
+        baseFillColor.copy(alpha = 0.25f)
+    }
+
+    val finalTextColor = textColor ?: finalColor
+
+    val clickableModifier = if (enabled && (onClick != null || onLongClick != null)) {
+        Modifier.combinedClickable(
+            interactionSource = interactionSource,
+            indication = null,
+            onClick = { onClick?.invoke() },
+            onLongClick = { onLongClick?.invoke() }
+        )
+    } else {
+        Modifier
+    }
+
+    Surface(
+        shape = buttonShape,
+        color = containerColor,
+        contentColor = finalColor,
+        border = if (shape == AzButtonShape.NONE) null else BorderStroke(3.dp, finalColor),
+        modifier = clippedModifier
+            .onGloballyPositioned { coordinates ->
+                onGloballyPositioned?.invoke(coordinates.boundsInWindow())
+            }
+            .then(clickableModifier)
+    ) {
+        Box(
+            // If itemContent is present (Color/Img), we force 0 padding to Fill/Crop. Otherwise, apply text padding.
+            modifier = if (itemContent != null) Modifier else Modifier.padding(contentPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Box(
+                modifier = Modifier.alpha(if (isLoading) 0f else 1f),
+                contentAlignment = Alignment.Center
+            ) {
+                if (itemContent != null) {
+                    ItemContentRenderer(itemContent, finalTextColor, enabled)
+                } else {
+                    AutoSizeText(
+                        text = text,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            textAlign = TextAlign.Center,
+                            color = finalTextColor
+                        ),
+                        modifier = Modifier.fillMaxSize(),
+                        maxLines = if (text.contains("\n")) Int.MAX_VALUE else 1,
+                        softWrap = false,
+                        alignment = Alignment.Center,
+                        lineSpaceRatio = 0.9f
+                    )
+                }
+            }
+            if (isLoading) AzLoad()
+        }
+    }
+}
+
+@Composable
+private fun ItemContentRenderer(itemContent: Any, color: Color, enabled: Boolean) {
+    when (itemContent) {
+        // Zero padding, completely fills shape
+        is Color -> Box(modifier = Modifier.fillMaxSize().alpha(if (enabled) 1f else 0.5f).background(itemContent))
+        is AzComposableContent -> itemContent.content(enabled)
+        // Note: the Android sibling special-cases `Int` as a drawable resource id (via
+        // `context.resources.getResourceName`) and renders it with the Android-only
+        // `painterResource(Int)`. CMP has no equivalent Int-as-resource concept — callers who want
+        // to render a drawable should pass a Painter directly (see the `is Painter` branch below).
+        is Int -> TextContent(itemContent.toString(), color)
+        is String -> TextContent(itemContent, color)
+        // Vector graphics. Coil cannot render an ImageVector/Painter (it throws
+        // "Unsupported type: ImageVector"), so these must be drawn with foundation Image
+        // before the Coil fallback. Tinted with the button color so monochrome icons
+        // (e.g. Icons.Default.*) adopt the rail's color, and cropped to fill the shape.
+        is ImageVector -> Image(
+            imageVector = itemContent,
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(color),
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize().alpha(if (enabled) 1f else 0.5f)
+        )
+        is Painter -> Image(
+            painter = itemContent,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize().alpha(if (enabled) 1f else 0.5f)
+        )
+        else -> {
+            Image(
+                painter = rememberAsyncImagePainter(model = itemContent),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    }
+}
+
+@Composable
+private fun TextContent(text: String, color: Color) {
+    AutoSizeText(
+        text = text,
+        style = MaterialTheme.typography.bodySmall.copy(textAlign = TextAlign.Center, color = color),
+        maxLines = 1,
+        softWrap = false,
+        alignment = Alignment.Center,
+        lineSpaceRatio = 0.9f
+    )
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -1,0 +1,1402 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Rect
+import com.hereliesaz.aznavrail.tutorial.AzGuidanceSnapshot
+import com.hereliesaz.aznavrail.tutorial.AzGuideShape
+import com.hereliesaz.aznavrail.tutorial.AzInstructionStep
+import com.hereliesaz.aznavrail.tutorial.toHighlight
+import androidx.compose.animation.core.Easing
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
+import com.hereliesaz.aznavrail.model.AzAdvancedConfig
+import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzEasing
+import com.hereliesaz.aznavrail.model.AzEntrance
+import com.hereliesaz.aznavrail.model.AzExit
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
+import com.hereliesaz.aznavrail.model.AzItemConfig
+import com.hereliesaz.aznavrail.model.AzMenuItemAlignment
+import com.hereliesaz.aznavrail.model.AzNavItem
+import com.hereliesaz.aznavrail.model.AzNestedRailAlignment
+// (Removed `import java.util.Collections.emptySet` — java.util.Collections isn't multiplatform.
+// The file uses `emptySet()` which resolves to `kotlin.collections.emptySet` without the import.)
+
+/**
+ * The primary DSL scope for configuring the AzNavRail.
+ *
+ * This interface provides methods to define navigation items, menus, settings, and advanced behaviors.
+ * It is used within the content lambda of [AzNavRail] and [AzHostActivityLayout].
+ *
+ * The methods come in two flavors:
+ * - `azRail*` — add an item that is visible on the collapsed rail strip.
+ * - `azMenu*` — add an item that is only visible inside the expanded drawer menu.
+ *
+ * Items must each declare a unique [String] `id`; duplicates throw at DSL build time.
+ *
+ * Typical usage from inside [AzHostActivityLayout]:
+ * ```
+ * AzHostActivityLayout(navController = navController) {
+ *     azSettings(displayAppNameInHeader = true)
+ *     azRailItem(id = "home", text = "Home", route = "home")
+ *     azRailToggle(
+ *         id = "dark",
+ *         isChecked = darkTheme,
+ *         toggleOnText = "Dark",
+ *         toggleOffText = "Light",
+ *         onClick = { darkTheme = !darkTheme },
+ *     )
+ *     azDivider()
+ *     azMenuItem(id = "settings", text = "Settings", route = "settings")
+ * }
+ * ```
+ */
+interface AzNavRailScope {
+    // Legacy/DSL split methods
+
+    /**
+     * Configures the behavioral and layout properties of the rail.
+     *
+     * @param dockingSide The side of the screen where the rail is docked (Left/Right).
+     * @param packButtons Whether to pack buttons tightly (true) or space them out (false).
+     * @param noMenu If true, disables the side menu drawer; all items are treated as rail items.
+     * @param vibrate Whether to provide haptic feedback on interactions.
+     * @param displayAppName If true, displays the app name in the header instead of the icon.
+     * @param activeClassifiers A set of strings used to highlight items programmatically.
+     * @param usePhysicalDocking If true, anchors the rail to the physical side of the device (rotates with device).
+     * @param expandedWidth The width of the rail when expanded (menu visible).
+     * @param collapsedWidth The width of the rail when collapsed.
+     * @param showFooter Whether to show the footer (Privacy, Terms, Help) in the menu.
+     * @param appRepositoryUrl Optional explicit override for the host app's GitHub repository used by
+     *   the "About" screen. Leave blank (the default) to auto-derive it from the app's namespace
+     *   (`com.<owner>.<repo>` → `github.com/<owner>/<repo>`); set it only when the namespace doesn't
+     *   match the repo. **Not required.**
+     */
+    fun azConfig(dockingSide: AzDockingSide = AzDockingSide.LEFT, packButtons: Boolean = false, noMenu: Boolean = false, vibrate: Boolean = false, displayAppName: Boolean = false, activeClassifiers: Set<String> = emptySet(), usePhysicalDocking: Boolean = false, expandedWidth: Dp = 160.dp, collapsedWidth: Dp = 100.dp, showFooter: Boolean = true, appRepositoryUrl: String = "", dimBehindMenu: Boolean = false, dimBehindMenuAlpha: Float = 0.4f, menuItemAlignment: AzMenuItemAlignment = AzMenuItemAlignment.SIDE, justifyMenuItems: Boolean = true)
+
+    /**
+     * Configures the visual theme of the rail.
+     *
+     * @param activeColor The color used for active/selected items.
+     * @param defaultShape The default shape for buttons (Circle, Square, Rectangle, None).
+     * @param headerIconShape The shape of the header icon (Circle, Rounded, None).
+     * @param translucentBackground The translucent background color for the rail and popup menus.
+     * @param helpLineColors List of colors to use for the connecting lines in the Help overlay.
+     * @param headerIconSize The exact diameter (width and height) of the app icon in the header.
+     *   When [Dp.Unspecified] (the default) the icon sizes itself to the rail width as before.
+     */
+    fun azTheme(activeColor: Color = Color.Unspecified, defaultShape: AzButtonShape = AzButtonShape.CIRCLE, headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE, translucentBackground: Color = Color.Unspecified, helpLineColors: List<Color> = emptyList(), headerIconSize: Dp = Dp.Unspecified)
+
+    /**
+     * Configures AzNavRail's WP7-style **kinetic typography** — the staggered turnstile entrance/exit on
+     * the expanded menu items, the press-tilt, and the big screen-boundary title's sweep. All of it is
+     * config-driven; there is no free-composable escape hatch.
+     *
+     * Defaults animate (this is the library's signature look). Pass [AzEntrance.None]/[AzExit.None] to
+     * opt a surface back out.
+     *
+     * @param itemEntrance Entrance played by each expanded-menu item when the menu opens.
+     * @param itemExit Exit played by each item when the menu collapses (items are held mounted through
+     *   the close so they can animate out).
+     * @param itemTextStyle Optional style merged over each menu item's label (big/light/wide Metro type).
+     * @param entranceStaggerMs Per-item cascade delay, multiplied by the item's position.
+     * @param entranceDurationMs Duration of each item's entrance/exit animation.
+     * @param entranceEasing Easing for the entrance/exit (defaults to [AzEasing.Wp7Decelerate]).
+     * @param entranceStartAngle Starting `rotationY` for the [AzEntrance.Turnstile] sweep, in degrees.
+     * @param tiltOnPress When true, menu items tilt in 3D toward the press point (the WP7 "tilt effect");
+     *   automatically suppressed for draggable/relocatable items. Defaults to false on the rail to avoid
+     *   competing with its drag gestures.
+     * @param maxTiltDegrees Maximum tilt angle for [tiltOnPress].
+     * @param titleEntrance Entrance for the big screen-boundary title, replayed each time the active
+     *   screen changes. Defaults to [AzEntrance.Turnstile]; use [AzEntrance.None] for a static title.
+     * @param titleTextStyle Optional style merged over the title's default (displayMedium, bold).
+     */
+    fun azKinetics(
+        itemEntrance: AzEntrance = AzEntrance.Turnstile,
+        itemExit: AzExit = AzExit.Turnstile,
+        itemTextStyle: TextStyle? = null,
+        entranceStaggerMs: Int = 60,
+        entranceDurationMs: Int = 720,
+        entranceEasing: Easing = AzEasing.Wp7Decelerate,
+        entranceStartAngle: Float = 90f,
+        tiltOnPress: Boolean = false,
+        maxTiltDegrees: Float = 10f,
+        titleEntrance: AzEntrance = AzEntrance.Turnstile,
+        titleTextStyle: TextStyle? = null
+    )
+
+    /**
+     * Configures advanced features like loading states, help screens, and overlays.
+     *
+     * @param isLoading Whether to show a full-screen loading spinner.
+     * @param helpEnabled Whether to show the interactive help overlay.
+     * @param onDismissHelp Callback invoked when the help screen is dismissed.
+     * @param overlayService The class of the service to use for the system overlay (FAB mode).
+     * @param onUndock Callback invoked when the rail is undocked (FAB mode activated).
+     * @param enableRailDragging Whether to allow the user to detach and drag the rail (FAB mode).
+     * @param onRailDrag Callback invoked during rail drag events.
+     * @param onOverlayDrag Callback invoked during overlay drag events.
+     * @param onItemGloballyPositioned Callback invoked with the bounds of items (used for tutorials/help).
+     * @param secLoc Optional developer configuration key to enable the Secret Screens.
+     * @param secLocPort The network port used for the location history sync server. Defaults to 10203.
+     * @param helpList An optional map of Item ID to help text.
+     */
+    fun azAdvanced(isLoading: Boolean = false, helpEnabled: Boolean = false, onDismissHelp: (() -> Unit)? = null, overlayService: Any? = null, onUndock: (() -> Unit)? = null, enableRailDragging: Boolean = false, onRailDrag: ((Float, Float) -> Unit)? = null, onOverlayDrag: ((Float, Float) -> Unit)? = null, onItemGloballyPositioned: ((String, Rect) -> Unit)? = null, secLoc: String? = null, secLocPort: Int = 10203, helpList: Map<String, Any> = emptyMap(), onInteraction: ((String, com.hereliesaz.aznavrail.model.AzNavItem) -> Unit)? = null)
+
+    /**
+     * Configures the built-in **About** screen and the **"More from Az"** carousel.
+     *
+     * When [inAppAbout] is true (the default), tapping the footer's "About" item opens an in-app,
+     * themed markdown reader that auto-discovers this app's documentation (`.md` files in the repo
+     * root and `docs/` folder). The repository is derived automatically from the app's namespace
+     * (`com.<owner>.<repo>` → `github.com/<owner>/<repo>`); [azConfig]'s `appRepositoryUrl` is only
+     * an optional override. A table of contents is built and each doc rendered inline, with a GitHub
+     * repo button pinned at the bottom. Set [inAppAbout] to false to restore the legacy behavior of
+     * opening the repository URL in a browser.
+     *
+     * When [moreFromAzEnabled] is true (the default), the About screen also offers a "More from Az"
+     * entry that opens a carousel of the library author's other apps, fetched at runtime from
+     * [moreFromAzJsonUrl] (a CI-versioned JSON manifest). Public GitHub repos only.
+     *
+     * @param inAppAbout Whether the footer "About" opens the in-app reader (true) or a browser (false).
+     * @param moreFromAzEnabled Whether the "More from Az" carousel entry is shown.
+     * @param moreFromAzJsonUrl Raw URL of the `more-from-az.json` manifest.
+     * @param moreRailItem When true, pins a "More" item at the bottom of the collapsed rail that
+     *   opens the "More from Az" carousel directly.
+     */
+    fun azAbout(inAppAbout: Boolean = true, moreFromAzEnabled: Boolean = true, moreFromAzJsonUrl: String = "https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json", moreRailItem: Boolean = false)
+
+    /**
+     * Registers a status-driven guidance **status** — a named boolean [predicate] that becomes a node
+     * in the app's flowchart (see `tutorial/AzStatus.kt`). The predicate may read Compose snapshot
+     * state (observed instantly) or a plain source like `StateFlow.value` (observed within a poll).
+     * Built-in `az.*` statuses (rail/host/item/route/onscreen/sheet) and active classifiers are also
+     * statuses — you only register the ones your app domain needs.
+     */
+    fun azStatus(id: String, predicate: () -> Boolean)
+
+    /**
+     * Registers a guidance **edge**: while status [from] is true, the shown instruction tells the user
+     * how to make status [to] true (an interactive hop). A passive edge ([to] = `null`) just shows the
+     * instruction while [from] holds. AzNavHost auto-generates edges for rail affordances; author edges
+     * here for transitions into your own custom statuses.
+     *
+     * Choose what the callout is placed next to, in precedence order:
+     *  - [highlightTargetId] — a host-registered arbitrary on-screen shape (see [azGuidanceTarget]);
+     *  - [highlightSelector] — a rail item id resolved every frame (for runtime/dynamic items);
+     *  - [highlightItemId] — a static rail item id, or the [AZ_ITEM_ACTIVE][com.hereliesaz.aznavrail.tutorial.AZ_ITEM_ACTIVE]
+     *    token to spotlight the currently-active item.
+     *
+     * Provide [steps] to make the edge **paged**: several sub-pointers under one milestone, revealed one
+     * at a time (informational steps advance on tap; a step with `advanceWhen` advances reactively). When
+     * [steps] is given, [text]/[highlight*] describe only the fallback first callout; the steps drive it.
+     */
+    fun azEdge(
+        from: String,
+        to: String? = null,
+        text: String? = null,
+        title: String? = null,
+        highlightItemId: String? = null,
+        highlightTargetId: String? = null,
+        highlightSelector: (() -> String?)? = null,
+        steps: List<AzInstructionStep> = emptyList(),
+    )
+
+    /**
+     * Registers a **moving on-screen highlight target** the guidance overlay can spotlight by id (via
+     * `azEdge(highlightTargetId = id)`). [shape] returns the current [AzGuideShape] in **window-space px**
+     * (circle / rounded-rect / path), recomputed every frame, so the spotlight can track an object drawn
+     * over a camera/AR canvas. Return `null` while the target is absent (the callout degrades to
+     * text-only). Read Compose snapshot state inside [shape] for smooth tracking.
+     */
+    fun azGuidanceTarget(id: String, shape: () -> AzGuideShape?)
+
+    /**
+     * Suppresses all guidance while [predicate] is true — drive it from your own gesture state so a
+     * callout never pops over an in-progress pinch/drag. When [predicate] flips back to false, guidance
+     * re-shows after a [settleMs] settle delay. Several suppressors compose (OR); the largest [settleMs]
+     * wins. Like a status predicate, [predicate] may read Compose state (instant) or a plain
+     * `var`/`StateFlow.value` (resolved within a poll).
+     */
+    fun azSuppressGuide(settleMs: Long = 700, predicate: () -> Boolean)
+
+    /**
+     * Replaces the built-in guidance callout body with host-drawn content (the dim + spotlight punch-out
+     * still draw). [renderer] receives the current [AzGuidanceSnapshot] and the resolved target bounds
+     * (window-space px, or `null` when text-only) — for apps drawing bespoke callouts over a canvas.
+     */
+    fun azGuideRenderer(renderer: @Composable (AzGuidanceSnapshot, Rect?) -> Unit)
+
+    /**
+     * Declares a guidance **goal** — a [target] status the framework routes toward when the developer
+     * activates it on the guidance controller. Several goals may be active at once; each active goal's
+     * next-hop instruction is shown simultaneously, placed next to its own target. [autoStartWhen]
+     * self-activates the goal once that status becomes true (onboarding-style).
+     */
+    fun azGoal(id: String, target: String, label: String? = null, autoStartWhen: String? = null)
+
+    /**
+     * A comprehensive configuration method combining settings, theme, and advanced options.
+     * This mirrors the structure used in the `AZNAVRAIL_COMPLETE_GUIDE.md`.
+     */
+    fun azSettings(
+        displayAppNameInHeader: Boolean = false,
+        packRailButtons: Boolean = false,
+        expandedRailWidth: Dp = 280.dp,
+        collapsedRailWidth: Dp = 136.dp,
+        showFooter: Boolean = true,
+        isLoading: Boolean = false,
+        defaultShape: AzButtonShape = AzButtonShape.CIRCLE,
+        enableRailDragging: Boolean = false,
+        headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
+        headerIconSize: Dp = Dp.Unspecified,
+        onUndock: (() -> Unit)? = null,
+        overlayService: Any? = null,
+        onOverlayDrag: ((Float, Float) -> Unit)? = null,
+        onItemGloballyPositioned: ((String, Rect) -> Unit)? = null,
+        helpEnabled: Boolean = false,
+        onDismissHelp: (() -> Unit)? = null,
+        activeColor: Color? = null,
+        vibrate: Boolean = false,
+        dockingSide: AzDockingSide = AzDockingSide.LEFT,
+        noMenu: Boolean = false,
+        usePhysicalDocking: Boolean = false,
+        secLoc: String? = null,
+        secLocPort: Int = 10203,
+        helpList: Map<String, Any> = emptyMap(),
+        helpLineColors: List<Color> = emptyList(),
+        onInteraction: ((String, com.hereliesaz.aznavrail.model.AzNavItem) -> Unit)? = null
+    )
+
+    /**
+     * Adds an item to the expandable menu drawer.
+     *
+     * @param id Unique identifier for the item.
+     * @param text The text to display.
+     * @param route The navigation route to navigate to when clicked.
+     * @param content Optional custom content (Color, Image, Resource ID).
+     * @param color Optional specific color for this item.
+     * @param shape Optional specific shape for this item.
+     * @param disabled Whether the item is disabled.
+     * @param screenTitle The title to display in the header when this item is active.
+     * @param info Description text for the Help/Info screen.
+     * @param onClick Callback invoked when the item is clicked.
+     */
+    fun azMenuItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds an explicit Help trigger item to the rail.
+     * When clicked, this item toggles the interactive Help/Info overlay.
+     *
+     * @param id Unique identifier.
+     * @param text Text display.
+     * @param content Custom content.
+     * @param color Custom color.
+     * @param shape Custom shape.
+     */
+    fun azHelpRailItem(id: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null)
+
+    /**
+     * Adds an explicit Help trigger item as a SubItem to a Host Item.
+     * When clicked, this item toggles the interactive Help/Info overlay.
+     *
+     * @param id Unique identifier.
+     * @param hostId The unique identifier of the parent Host Item.
+     * @param text Text display.
+     * @param content Custom content.
+     * @param color Custom color.
+     * @param shape Custom shape.
+     */
+    fun azHelpSubItem(id: String, hostId: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null)
+
+    /**
+     * Adds an item to the always-visible rail.
+     *
+     * @param id Unique identifier for the item.
+     * @param text The text to display (often hidden in rail mode unless shape is RECTANGLE/NONE).
+     * @param route The navigation route to navigate to when clicked.
+     * @param content Optional custom content (Color, Image, Resource ID).
+     * @param color Optional specific color for this item.
+     * @param shape Optional specific shape for this item.
+     * @param disabled Whether the item is disabled.
+     * @param screenTitle The title to display in the header when this item is active.
+     * @param info Description text for the Help/Info screen.
+     * @param classifiers Additional strings to identify this item for highlighting.
+     * @param onFocus Callback invoked when the item receives focus.
+     * @param onClick Callback invoked when the item is clicked.
+     */
+    fun azRailItem(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a Nested Rail item. This item opens a secondary popup rail when clicked.
+     *
+     * @param id Unique identifier.
+     * @param text Text display.
+     * @param route The navigation route (optional).
+     * @param content Custom content.
+     * @param color Custom color.
+     * @param shape Custom shape.
+     * @param alignment Orientation of the nested rail (VERTICAL or HORIZONTAL).
+     * @param disabled Whether the item is disabled.
+     * @param screenTitle Title to display when active.
+     * @param info Help info string.
+     * @param classifiers Active classifiers.
+     * @param onFocus Focus callback.
+     * @param keepNestedRailOpen If true, the nested rail remains open until the parent item is tapped again.
+     * @param nestedContent DSL block to define the items within the nested rail.
+     */
+    fun azNestedRail(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, alignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onFocus: (() -> Unit)? = null, keepNestedRailOpen: Boolean = false, nestedContent: AzNavRailScope.() -> Unit)
+
+    /**
+     * Adds a toggle switch item to the menu.
+     *
+     * @param isChecked The current state of the toggle.
+     * @param toggleOnText Text to display when checked.
+     * @param toggleOffText Text to display when unchecked.
+     */
+    fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a toggle switch item to the rail.
+     *
+     * @param id Unique identifier.
+     * @param isChecked The current state of the toggle.
+     * @param toggleOnText Text to display when checked.
+     * @param toggleOffText Text to display when unchecked.
+     * @param route Optional navigation route.
+     * @param color Custom color.
+     * @param shape Custom shape.
+     * @param disabled Whether the item is disabled.
+     * @param screenTitle Title to display when active.
+     * @param info Help info string.
+     * @param onClick Click callback.
+     */
+    fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a cycler item (multi-state button) to the menu.
+     *
+     * @param options List of possible string options.
+     * @param selectedOption The currently selected option.
+     * @param disabledOptions List of options that cannot be selected.
+     */
+    fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a cycler item to the always-visible rail.
+     *
+     * Each tap advances [selectedOption] within [options]; the click callback fires after the
+     * cycler debounce window so consumers see one commit per "stop", not one per tap.
+     *
+     * @param id Unique identifier.
+     * @param options Full option list shown on the rail.
+     * @param selectedOption Current selection; must be a member of [options].
+     * @param route Optional navigation route triggered when the cycler is committed.
+     * @param color Border/icon color override.
+     * @param shape Button-shape override.
+     * @param disabled If true, the cycler is non-interactive.
+     * @param disabledOptions Members of [options] that should be skipped during cycling.
+     * @param screenTitle Title shown when this item is active.
+     * @param info Help text for this item.
+     * @param classifiers Strings for programmatic highlighting via [azConfig] activeClassifiers.
+     * @param menuOptions Alternate option labels used when the same item renders in the menu.
+     * @param textColor Text color override.
+     * @param fillColor Translucent fill color override.
+     * @param onClick Callback fired on commit.
+     */
+    fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a visual divider line to the menu list. Has no effect on the collapsed rail.
+     */
+    fun azDivider()
+
+    /**
+     * Adds a Host Item to the menu. Host items can contain sub-items which expand inline.
+     *
+     * @param id Unique identifier.
+     * @param text Text display.
+     * @param route Optional navigation route.
+     * @param content Custom content.
+     * @param color Custom color.
+     * @param shape Custom shape.
+     * @param disabled Whether the item is disabled.
+     * @param screenTitle Title to display when active.
+     * @param info Help info string.
+     * @param onClick Click callback.
+     */
+    fun azMenuHostItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a Host Item to the rail. Sub-items targeting [id] via their
+     * `hostId` parameter expand inline beneath this host when it is tapped
+     * (rail flavor).
+     *
+     * Parameters mirror [azMenuHostItem]; see that method's docs for details.
+     */
+    fun azRailHostItem(
+        id: String,
+        text: String,
+        route: String? = null,
+        content: Any? = null,
+        color: Color? = null,
+        shape: AzButtonShape? = null,
+        disabled: Boolean = false,
+        screenTitle: String? = null,
+        info: String? = null,
+        classifiers: Set<String> = emptySet(),
+        menuText: String? = null,
+        textColor: Color? = null,
+        fillColor: Color? = null,
+        initiallyExpanded: Boolean = false,
+        expandWhen: (() -> Boolean)? = null,
+        onExpandedChange: ((Boolean) -> Unit)? = null,
+        onClick: (() -> Unit)? = null
+    )
+
+    /**
+     * Adds a Sub Item to a Host Item in the menu.
+     *
+     * @param hostId The ID of the parent Host Item.
+     */
+    fun azMenuSubItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a Sub Item to a Host Item in the rail. Parameters mirror [azMenuSubItem]; on the rail
+     * the sub-item only renders while its host is expanded.
+     *
+     * @param onFocus Called when the sub-item gains focus.
+     */
+    fun azRailSubItem(id: String, hostId: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a Sub Item that is itself a Host Item in the menu. It is a child of [hostId] (so it only
+     * appears when that parent host is expanded) and, like any host, expands to reveal its own
+     * sub-items (which target this item's [id] via their `hostId`). Hosts can nest to any depth.
+     *
+     * @param hostId The ID of the parent Host Item this sub-host belongs to.
+     */
+    fun azMenuSubHostItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a Sub Item that is itself a Host Item to the rail. It is a child of
+     * [hostId] (so it only renders while that parent host is expanded) and,
+     * like any host, expands inline to reveal its own sub-items. Parameters
+     * mirror [azMenuSubHostItem]. Hosts can nest to any depth.
+     *
+     * @param hostId The ID of the parent Host Item this sub-host belongs to.
+     */
+    fun azRailSubHostItem(
+        id: String,
+        hostId: String,
+        text: String,
+        route: String? = null,
+        content: Any? = null,
+        color: Color? = null,
+        shape: AzButtonShape? = null,
+        disabled: Boolean = false,
+        screenTitle: String? = null,
+        info: String? = null,
+        classifiers: Set<String> = emptySet(),
+        menuText: String? = null,
+        textColor: Color? = null,
+        fillColor: Color? = null,
+        initiallyExpanded: Boolean = false,
+        expandWhen: (() -> Boolean)? = null,
+        onExpandedChange: ((Boolean) -> Unit)? = null,
+        onClick: (() -> Unit)? = null
+    )
+
+    /**
+     * Adds a Sub Toggle to a Host Item in the menu. The toggle only renders when its host is
+     * expanded.
+     *
+     * @param id Unique identifier.
+     * @param hostId The ID of the parent Host Item.
+     * @param isChecked Current state.
+     * @param toggleOnText Label shown when checked.
+     * @param toggleOffText Label shown when unchecked.
+     * @param onClick Fired on toggle.
+     */
+    fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a Sub Toggle to a Host Item in the rail. Parameters mirror [azMenuSubToggle]; only
+     * visible while the parent host is expanded on the rail.
+     */
+    fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a Sub Cycler to a Host Item in the menu.
+     *
+     * @param id Unique identifier.
+     * @param hostId The ID of the parent Host Item.
+     * @param options Full option list.
+     * @param selectedOption Current selection; must be in [options].
+     * @param disabledOptions Options that should be skipped during cycling.
+     * @param onClick Fired on commit.
+     */
+    fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a Sub Cycler to a Host Item in the rail. Parameters mirror [azMenuSubCycler]; the
+     * cycler only renders while the parent host is expanded on the rail.
+     */
+    fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+
+    /**
+     * Adds a Relocatable Item to a Host Item in the rail.
+     * This item supports drag-and-drop reordering within its cluster.
+     *
+     * @param id Unique identifier.
+     * @param hostId The ID of the parent Host Item.
+     * @param text Text display.
+     * @param route Optional navigation route.
+     * @param content Custom content.
+     * @param color Custom color.
+     * @param shape Custom shape.
+     * @param disabled Whether the item is disabled.
+     * @param screenTitle Title to display when active.
+     * @param info Help info string.
+     * @param classifiers Active classifiers.
+     * @param onFocus Focus callback.
+     * @param onClick Click callback (selection).
+     * @param onRelocate Callback invoked when the item is moved. Provides old index, new index, and the new ID order.
+     * @param nestedRailAlignment The alignment of the nested rail (VERTICAL or HORIZONTAL).
+     * @param nestedContent DSL block to define the items within the nested rail.
+     * @param keepNestedRailOpen If true, the nested rail remains open until the parent item is tapped again.
+     * @param hiddenMenu Scope to define context menu actions available via tap-when-focused.
+     * @param forceHiddenMenuOpen Programmatic control to explicitly show or hide the hidden menu.
+     * @param onHiddenMenuDismiss Callback invoked when the hidden menu dismisses itself.
+     */
+    fun azRailRelocItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null, onRelocate: ((Int, Int, List<String>) -> Unit)? = null, nestedRailAlignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, keepNestedRailOpen: Boolean = false, nestedContent: (AzNavRailScope.() -> Unit)? = null, forceHiddenMenuOpen: Boolean = false, onHiddenMenuDismiss: (() -> Unit)? = null, hiddenMenu: HiddenMenuScope.() -> Unit = {})
+}
+
+/**
+ * Scope for defining the hidden menu of a [AzNavItem] (specifically for relocatable items).
+ */
+interface HiddenMenuScope {
+    /**
+     * Adds a clickable list item to the hidden menu.
+     *
+     * @param text The text to display.
+     * @param onClick The action to perform when clicked.
+     */
+    fun listItem(text: String, onClick: () -> Unit)
+    /**
+     * Adds a navigation list item to the hidden menu.
+     *
+     * @param text The text to display.
+     * @param route The route to navigate to.
+     */
+    fun listItem(text: String, route: String)
+    /**
+     * Adds a text input item to the hidden menu.
+     *
+     * @param hint The hint text for the input field.
+     * @param onValueChange Callback invoked when the input value changes.
+     */
+    fun inputItem(hint: String, onValueChange: (String) -> Unit)
+    /**
+     * Adds a text input item to the hidden menu with an initial value.
+     *
+     * @param hint The hint text for the input field.
+     * @param initialValue The pre-filled initial value.
+     * @param onValueChange Callback invoked when the input value changes.
+     */
+    fun inputItem(hint: String, initialValue: String, onValueChange: (String) -> Unit)
+}
+
+/** Internal implementation of [HiddenMenuScope] that wires items into the parent scope's callback maps. */
+internal class HiddenMenuScopeImpl(
+    private val parentId: String,
+    private val targetOnClickMap: MutableMap<String, () -> Unit>,
+    private val targetOnValueChangeMap: MutableMap<String, (String) -> Unit>
+) : HiddenMenuScope {
+    var items: MutableList<com.hereliesaz.aznavrail.model.HiddenMenuItem>? = null
+
+    override fun listItem(text: String, onClick: () -> Unit) {
+        val list = items ?: mutableListOf<com.hereliesaz.aznavrail.model.HiddenMenuItem>().also { items = it }
+        val id = "${parentId}_hidden_item_${list.size}"
+        list.add(com.hereliesaz.aznavrail.model.HiddenMenuItem(id = id, text = text))
+        targetOnClickMap[id] = onClick
+    }
+
+    override fun listItem(text: String, route: String) {
+        val list = items ?: mutableListOf<com.hereliesaz.aznavrail.model.HiddenMenuItem>().also { items = it }
+        val id = "${parentId}_hidden_item_${list.size}"
+        list.add(com.hereliesaz.aznavrail.model.HiddenMenuItem(id = id, text = text, route = route))
+    }
+
+    override fun inputItem(hint: String, onValueChange: (String) -> Unit) {
+        inputItem(hint, "", onValueChange)
+    }
+
+    override fun inputItem(hint: String, initialValue: String, onValueChange: (String) -> Unit) {
+        val list = items ?: mutableListOf<com.hereliesaz.aznavrail.model.HiddenMenuItem>().also { items = it }
+        val id = "${parentId}_hidden_item_${list.size}"
+        list.add(com.hereliesaz.aznavrail.model.HiddenMenuItem(id = id, text = "", isInput = true, hint = hint, initialValue = initialValue))
+        targetOnValueChangeMap[id] = onValueChange
+    }
+}
+
+/**
+ * Concrete implementation of [AzNavRailScope] that accumulates item state for the rail.
+ *
+ * Instances are created and owned by [AzNavRail] or [AzHostActivityLayout]. The [reset] method
+ * must be called before re-applying the DSL lambda on each recomposition.
+ *
+ * @param globalIdSet Shared set used for cross-scope duplicate-ID detection (e.g., nested rails).
+ */
+class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSetOf()) : AzNavRailScope {
+    /** Live list of all [AzNavItem] entries configured via the DSL. */
+    val navItems = mutableStateListOf<AzNavItem>()
+    /** Maps item IDs to their click callbacks. */
+    val onClickMap = mutableMapOf<String, () -> Unit>()
+    /** Maps item IDs to their focus callbacks. */
+    val onFocusMap = mutableMapOf<String, () -> Unit>()
+    /** Maps hidden-menu item IDs to click callbacks, keyed by generated sub-IDs. */
+    val hiddenMenuOnClickMap = mutableMapOf<String, () -> Unit>()
+    /** Maps hidden-menu input item IDs to value-change callbacks. */
+    val hiddenMenuOnValueChangeMap = mutableMapOf<String, (String) -> Unit>()
+    /** Maps relocatable item IDs to reorder callbacks. */
+    val onRelocateMap = mutableMapOf<String, (Int, Int, List<String>) -> Unit>()
+    /**
+     * Maps host item IDs to their reactive expansion condition. Populated by the DSL and cleared
+     * on each [reset]; the [com.hereliesaz.aznavrail.AzNavRail] composable observes these via
+     * `snapshotFlow` to apply bidirectional, edge-triggered expansion.
+     */
+    val expandWhenMap = mutableMapOf<String, () -> Boolean>()
+    /**
+     * Maps host item IDs to an expansion-change callback. Populated by the DSL and cleared on
+     * each [reset]; the [com.hereliesaz.aznavrail.AzNavRail] composable fires each callback
+     * whenever the corresponding host's expansion state transitions.
+     */
+    val onExpandedChangeMap = mutableMapOf<String, (Boolean) -> Unit>()
+
+    // --- Status-driven guidance framework (see tutorial/AzStatus.kt). All cleared on each reset. ---
+    /** Developer status predicates: a status id → `() -> Boolean`, observed reactively by the engine. */
+    val statusPredicates = mutableMapOf<String, () -> Boolean>()
+    /** Flowchart edges authored via `azEdge` (AzNavHost adds auto-edges for rail affordances at render). */
+    val guidanceEdges = mutableListOf<com.hereliesaz.aznavrail.tutorial.AzEdge>()
+    /** Developer-declared guidance goals authored via `azGoal`. */
+    val guidanceGoals = mutableListOf<com.hereliesaz.aznavrail.tutorial.AzGoal>()
+    /** Moving on-screen highlight targets authored via `azGuidanceTarget`: id → shape lambda (window px). */
+    val guidanceTargets = mutableMapOf<String, () -> AzGuideShape?>()
+    /** Host guidance suppressors authored via `azSuppressGuide`: `settleMs to predicate`. */
+    val guidanceSuppressors = mutableListOf<Pair<Long, () -> Boolean>>()
+    /** Optional host callout renderer authored via `azGuideRenderer`. */
+    var guidanceRenderer: (@Composable (AzGuidanceSnapshot, Rect?) -> Unit)? = null
+
+    /**
+     * Persisted reloc-item ordering keyed by `hostId`. Survives [reset] so drag-and-drop
+     * reorders stick across recomposition (the DSL is re-applied on every recomposition and
+     * would otherwise restore the original declaration order). Updated from `RailItems` on
+     * drag end and re-applied via [applyRelocReorders] after the DSL block runs.
+     */
+    val savedRelocOrders: androidx.compose.runtime.snapshots.SnapshotStateMap<String, List<String>> = mutableStateMapOf()
+    /** Cache of window-space bounds for each item, populated as items are laid out. */
+    val itemBoundsCache = mutableStateMapOf<String, Rect>()
+    /** Transient selected options for cyclers during the debounce window. */
+    val transientCyclerOptions = mutableStateMapOf<String, String>()
+    /** Active [NavController], set externally by [AzHostActivityLayout]. */
+    var navController: NavController? = null
+    /** The ID of the nested rail currently open as a popup, or null if none. */
+    var nestedRailOpenId: String? by mutableStateOf(null)
+
+    /** Clears all accumulated state so the DSL lambda can be reapplied cleanly. */
+    fun reset() {
+        navItems.clear()
+        onClickMap.clear()
+        onFocusMap.clear()
+        hiddenMenuOnClickMap.clear()
+        hiddenMenuOnValueChangeMap.clear()
+        onRelocateMap.clear()
+        expandWhenMap.clear()
+        onExpandedChangeMap.clear()
+        statusPredicates.clear()
+        guidanceEdges.clear()
+        guidanceGoals.clear()
+        guidanceTargets.clear()
+        guidanceSuppressors.clear()
+        guidanceRenderer = null
+        itemBoundsCache.clear()
+        // Without this, IDs registered on pass N stay in the set on pass N+1 and
+        // the next recomposition crashes the moment any ID re-registers.
+        globalIdSet.clear()
+        // Note: savedRelocOrders is intentionally NOT cleared. Drag-and-drop reorders
+        // must persist across recomposition so users can drop items into a new order
+        // and have them stay there.
+    }
+
+    /**
+     * Re-applies persisted reloc orderings (from [savedRelocOrders]) on top of [navItems].
+     *
+     * After the DSL re-runs and re-populates [navItems] in declaration order, this method
+     * walks each `hostId → orderedIds` entry and rewrites the corresponding cluster of reloc
+     * items in-place. Items missing from the saved order are ignored; clusters whose IDs no
+     * longer match the saved set are skipped to avoid corrupting state.
+     *
+     * Called by `AzHostActivityLayout` (and `AzNavRail` when there is no host) after
+     * applying the DSL lambda.
+     */
+    fun applyRelocReorders() {
+        if (savedRelocOrders.isEmpty()) return
+        val staleHosts = mutableListOf<String>()
+        savedRelocOrders.forEach { (hostId, savedOrder) ->
+            // Index every reloc item belonging to this host along with its position in navItems.
+            val indexed = navItems.mapIndexedNotNull { idx, item ->
+                if (item.isRelocItem && item.hostId == hostId) idx to item else null
+            }
+            if (indexed.isEmpty()) {
+                staleHosts.add(hostId)
+                return@forEach
+            }
+            val currentIds = indexed.map { it.second.id }.toSet()
+            // If saved set and current set diverge, drop the saved order rather than risk swapping
+            // unrelated items. The next reorder will rebuild it.
+            if (currentIds != savedOrder.toSet()) {
+                staleHosts.add(hostId)
+                return@forEach
+            }
+            val byId = indexed.associate { it.second.id to it.second }
+            val positions = indexed.map { it.first }
+            // Write items back in saved order at the same positions they currently occupy.
+            positions.forEachIndexed { i, pos ->
+                navItems[pos] = byId.getValue(savedOrder[i])
+            }
+        }
+        staleHosts.forEach { savedRelocOrders.remove(it) }
+    }
+
+    // Config
+    /** Width of the rail panel when expanded (menu visible). */
+    var expandedWidth: Dp = 160.dp
+    /** Width of the collapsed rail (icon-only strip). */
+    var collapsedWidth: Dp = 100.dp
+    /** Whether the footer (About, Feedback, @HereLiesAz) is shown when the menu is expanded. */
+    var showFooter: Boolean = true
+    /**
+     * Optional explicit override for the host app's GitHub repository used by the "About" screen.
+     * Blank (the default) means auto-derive it from the app namespace at render time. Never defaults
+     * to the AzNavRail library repo.
+     */
+    var appRepositoryUrl: String = ""
+    /** Logical docking side used to calculate the visual side and slide-in direction. */
+    var dockingSide: AzDockingSide = AzDockingSide.LEFT
+    /** If true, buttons are packed with no spacing between them. */
+    var packButtons: Boolean = false
+    /** If true, the side menu drawer is disabled; the rail operates icon-only. */
+    var noMenu: Boolean = false
+    /** If true, haptic feedback is triggered on header tap and drag events. */
+    var vibrate: Boolean = false
+    /** If true, the header area shows the app name instead of the app icon. */
+    var displayAppName: Boolean = false
+    /** Set of classifier strings; items whose classifiers overlap are shown as active. */
+    var activeClassifiers: Set<String> = emptySet()
+    /** If true, the docking side tracks the physical device edge, adapting to rotation. */
+    var usePhysicalDocking: Boolean = false
+
+    // -- Menu drawer look/feel (side-align, kerning-justify, dim scrim) --
+    /** When true, expanding the drawer draws a dim scrim over the rest of the app. */
+    var dimBehindMenu: Boolean = false
+    /** Alpha of the [dimBehindMenu] scrim (0..1). Default 0.4. Ignored when [dimBehindMenu] is false. */
+    var dimBehindMenuAlpha: Float = 0.4f
+    /** How menu-drawer labels are horizontally aligned within their rows. Default [AzMenuItemAlignment.SIDE]. */
+    var menuItemAlignment: AzMenuItemAlignment = AzMenuItemAlignment.SIDE
+    /** When true, menu-drawer labels are full-justified via computed letter-spacing. Default true. */
+    var justifyMenuItems: Boolean = true
+
+    // Theme
+    /** Color applied to selected/active items and connecting lines. [Color.Unspecified] falls back to [MaterialTheme.colorScheme.primary]. */
+    var activeColor: Color = Color.Unspecified
+    /** Default button shape; individual items can override this. */
+    var defaultShape: AzButtonShape = AzButtonShape.CIRCLE // Restored: default is circle
+    /** Shape applied to the app icon in the rail header. */
+    var headerIconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE // Default per legacy, overridden in UI
+    /**
+     * Exact diameter (width and height) of the app icon in the header. [Dp.Unspecified] (the
+     * default) keeps the legacy behaviour of sizing the icon to the rail width.
+     */
+    var headerIconSize: Dp = Dp.Unspecified
+    /** Background color for popup overlays (nested rails, hidden menus). [Color.Unspecified] uses the surface color. */
+    var translucentBackground: Color = Color.Unspecified
+    /** Colors used for the connecting lines drawn in the Help overlay. Falls back to a built-in rainbow palette. */
+    var helpLineColors: List<Color> = emptyList()
+
+    // Kinetic typography (set by [azKinetics]). Defaults animate — the library's signature WP7 look.
+    /** Entrance played by each expanded-menu item when the menu opens. */
+    var itemEntrance: AzEntrance = AzEntrance.Turnstile
+    /** Exit played by each expanded-menu item when the menu collapses. */
+    var itemExit: AzExit = AzExit.Turnstile
+    /** Optional style merged over each menu item's label. */
+    var itemTextStyle: TextStyle? = null
+    /** Per-item cascade delay (ms), multiplied by position. */
+    var entranceStaggerMs: Int = 60
+    /** Duration (ms) of each item's entrance/exit. */
+    var entranceDurationMs: Int = 720
+    /** Easing for the entrance/exit. */
+    var entranceEasing: Easing = AzEasing.Wp7Decelerate
+    /** Starting `rotationY` (deg) for the turnstile sweep. */
+    var entranceStartAngle: Float = 90f
+    /** When true, menu items tilt toward the press point (suppressed for draggable items). */
+    var tiltOnPress: Boolean = false
+    /** Maximum tilt angle (deg) for [tiltOnPress]. */
+    var maxTiltDegrees: Float = 10f
+    /** Entrance for the big screen-boundary title, replayed when the active screen changes. */
+    var titleEntrance: AzEntrance = AzEntrance.Turnstile
+    /** Optional style merged over the big screen title's default ([displayMedium], bold). */
+    var titleTextStyle: TextStyle? = null
+
+    // Advanced
+    /** Aggregated advanced configuration populated by [azAdvanced] and [azSettings] calls. */
+    var advancedConfig: AzAdvancedConfig = AzAdvancedConfig()
+
+
+    override fun azConfig(dockingSide: AzDockingSide, packButtons: Boolean, noMenu: Boolean, vibrate: Boolean, displayAppName: Boolean, activeClassifiers: Set<String>, usePhysicalDocking: Boolean, expandedWidth: Dp, collapsedWidth: Dp, showFooter: Boolean, appRepositoryUrl: String, dimBehindMenu: Boolean, dimBehindMenuAlpha: Float, menuItemAlignment: AzMenuItemAlignment, justifyMenuItems: Boolean) {
+        this.dockingSide = dockingSide
+        this.packButtons = packButtons
+        this.noMenu = noMenu
+        this.vibrate = vibrate
+        this.displayAppName = displayAppName
+        this.activeClassifiers = activeClassifiers
+        this.usePhysicalDocking = usePhysicalDocking
+        this.expandedWidth = expandedWidth
+        this.collapsedWidth = collapsedWidth
+        this.showFooter = showFooter
+        this.appRepositoryUrl = appRepositoryUrl
+        this.dimBehindMenu = dimBehindMenu
+        this.dimBehindMenuAlpha = dimBehindMenuAlpha
+        this.menuItemAlignment = menuItemAlignment
+        this.justifyMenuItems = justifyMenuItems
+    }
+
+    override fun azAbout(inAppAbout: Boolean, moreFromAzEnabled: Boolean, moreFromAzJsonUrl: String, moreRailItem: Boolean) {
+        this.advancedConfig = this.advancedConfig.copy(
+            inAppAbout = inAppAbout,
+            moreFromAzEnabled = moreFromAzEnabled,
+            moreFromAzJsonUrl = moreFromAzJsonUrl,
+            moreFromAzRailItem = moreRailItem
+        )
+    }
+
+    override fun azStatus(id: String, predicate: () -> Boolean) {
+        statusPredicates[id] = predicate
+    }
+
+    override fun azEdge(
+        from: String,
+        to: String?,
+        text: String?,
+        title: String?,
+        highlightItemId: String?,
+        highlightTargetId: String?,
+        highlightSelector: (() -> String?)?,
+        steps: List<AzInstructionStep>,
+    ) {
+        val instruction = if (steps.isNotEmpty()) {
+            // Paged edge: the fallback instruction mirrors the first step so a non-paged renderer still
+            // shows something; the `steps` list drives the paging.
+            val first = steps.first()
+            com.hereliesaz.aznavrail.tutorial.AzInstruction(
+                text = first.text,
+                title = first.title ?: title,
+                highlight = first.toHighlight(),
+                side = first.side,
+            )
+        } else {
+            com.hereliesaz.aznavrail.tutorial.AzInstruction(
+                text = text ?: "",
+                title = title,
+                highlight = com.hereliesaz.aznavrail.tutorial.resolveAzHighlight(highlightItemId, highlightSelector, highlightTargetId),
+            )
+        }
+        guidanceEdges += com.hereliesaz.aznavrail.tutorial.AzEdge(from = from, to = to, instruction = instruction, steps = steps)
+    }
+
+    override fun azGuidanceTarget(id: String, shape: () -> AzGuideShape?) {
+        guidanceTargets[id] = shape
+    }
+
+    override fun azSuppressGuide(settleMs: Long, predicate: () -> Boolean) {
+        guidanceSuppressors += settleMs to predicate
+    }
+
+    override fun azGuideRenderer(renderer: @Composable (AzGuidanceSnapshot, Rect?) -> Unit) {
+        guidanceRenderer = renderer
+    }
+
+    override fun azGoal(id: String, target: String, label: String?, autoStartWhen: String?) {
+        guidanceGoals += com.hereliesaz.aznavrail.tutorial.AzGoal(id = id, target = target, label = label, autoStartWhen = autoStartWhen)
+    }
+
+    override fun azTheme(activeColor: Color, defaultShape: AzButtonShape, headerIconShape: AzHeaderIconShape, translucentBackground: Color, helpLineColors: List<Color>, headerIconSize: Dp) {
+        this.activeColor = activeColor
+        this.defaultShape = defaultShape
+        this.headerIconShape = headerIconShape
+        this.translucentBackground = translucentBackground
+        this.helpLineColors = helpLineColors
+        this.headerIconSize = headerIconSize
+    }
+
+    override fun azKinetics(
+        itemEntrance: AzEntrance,
+        itemExit: AzExit,
+        itemTextStyle: TextStyle?,
+        entranceStaggerMs: Int,
+        entranceDurationMs: Int,
+        entranceEasing: Easing,
+        entranceStartAngle: Float,
+        tiltOnPress: Boolean,
+        maxTiltDegrees: Float,
+        titleEntrance: AzEntrance,
+        titleTextStyle: TextStyle?
+    ) {
+        this.itemEntrance = itemEntrance
+        this.itemExit = itemExit
+        this.itemTextStyle = itemTextStyle
+        this.entranceStaggerMs = entranceStaggerMs
+        this.entranceDurationMs = entranceDurationMs
+        this.entranceEasing = entranceEasing
+        this.entranceStartAngle = entranceStartAngle
+        this.tiltOnPress = tiltOnPress
+        this.maxTiltDegrees = maxTiltDegrees
+        this.titleEntrance = titleEntrance
+        this.titleTextStyle = titleTextStyle
+    }
+
+    override fun azAdvanced(isLoading: Boolean, helpEnabled: Boolean, onDismissHelp: (() -> Unit)?, overlayService: Any?, onUndock: (() -> Unit)?, enableRailDragging: Boolean, onRailDrag: ((Float, Float) -> Unit)?, onOverlayDrag: ((Float, Float) -> Unit)?, onItemGloballyPositioned: ((String, Rect) -> Unit)?, secLoc: String?, secLocPort: Int, helpList: Map<String, Any>, onInteraction: ((String, AzNavItem) -> Unit)?) {
+        this.advancedConfig = this.advancedConfig.copy(
+            isLoading = isLoading,
+            helpEnabled = helpEnabled,
+            onDismissHelp = onDismissHelp,
+            overlayService = overlayService,
+            onUndock = onUndock,
+            enableRailDragging = enableRailDragging || overlayService != null || onOverlayDrag != null,
+            onRailDrag = onRailDrag,
+            onOverlayDrag = onOverlayDrag,
+            onItemGloballyPositioned = onItemGloballyPositioned,
+            secLoc = secLoc ?: this.advancedConfig.secLoc,
+            secLocPort = secLocPort,
+            helpList = if (helpList.isNotEmpty()) helpList else this.advancedConfig.helpList,
+            onInteraction = onInteraction ?: this.advancedConfig.onInteraction
+        )
+    }
+
+    override fun azSettings(
+        displayAppNameInHeader: Boolean,
+        packRailButtons: Boolean,
+        expandedRailWidth: Dp,
+        collapsedRailWidth: Dp,
+        showFooter: Boolean,
+        isLoading: Boolean,
+        defaultShape: AzButtonShape,
+        enableRailDragging: Boolean,
+        headerIconShape: AzHeaderIconShape,
+        headerIconSize: Dp,
+        onUndock: (() -> Unit)?,
+        overlayService: Any?,
+        onOverlayDrag: ((Float, Float) -> Unit)?,
+        onItemGloballyPositioned: ((String, Rect) -> Unit)?,
+        helpEnabled: Boolean,
+        onDismissHelp: (() -> Unit)?,
+        activeColor: Color?,
+        vibrate: Boolean,
+        dockingSide: AzDockingSide,
+        noMenu: Boolean,
+        usePhysicalDocking: Boolean,
+        secLoc: String?,
+        secLocPort: Int,
+        helpList: Map<String, Any>,
+        helpLineColors: List<Color>,
+        onInteraction: ((String, AzNavItem) -> Unit)?
+    ) {
+        // Map to internal properties
+        this.displayAppName = displayAppNameInHeader
+        this.packButtons = packRailButtons
+        this.expandedWidth = expandedRailWidth
+        this.collapsedWidth = collapsedRailWidth
+        this.showFooter = showFooter
+        this.defaultShape = defaultShape
+        this.headerIconShape = headerIconShape
+        this.headerIconSize = headerIconSize
+        if (activeColor != null) this.activeColor = activeColor
+        this.vibrate = vibrate
+        this.dockingSide = dockingSide
+        this.noMenu = noMenu
+        this.usePhysicalDocking = usePhysicalDocking
+        this.helpLineColors = helpLineColors
+
+        this.advancedConfig = this.advancedConfig.copy(
+            isLoading = isLoading,
+            enableRailDragging = enableRailDragging || overlayService != null || onOverlayDrag != null,
+            onUndock = onUndock,
+            overlayService = overlayService,
+            onOverlayDrag = onOverlayDrag,
+            onItemGloballyPositioned = onItemGloballyPositioned,
+            helpEnabled = helpEnabled,
+            onDismissHelp = onDismissHelp,
+            secLoc = secLoc ?: this.advancedConfig.secLoc,
+            secLocPort = secLocPort,
+            helpList = if (helpList.isNotEmpty()) helpList else this.advancedConfig.helpList,
+            onInteraction = onInteraction ?: this.advancedConfig.onInteraction
+        )
+    }
+
+    private fun checkId(id: String) {
+        if (!globalIdSet.add(id)) {
+            throw IllegalArgumentException(
+                "Duplicate AzNavRail item ID '$id'. Every `azRailItem` / `azMenuItem` / `azHelpRailItem` / `azNestedRail` / `azRailRelocItem` / toggle / cycler (including those declared inside a nested rail via `nestedContent { ... }`) must have a globally unique `id`, because the rail uses `id` as the key into its `onClickMap`, `onFocusMap`, and `onRelocateMap`. Fix: rename this declaration's `id` to something unique (eg. '$id-2', or '${id}_nested'); or, if this is an accidental copy-paste, remove the duplicate `id = \"$id\"` declaration."
+            )
+        }
+    }
+
+    override fun azMenuItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azHelpRailItem(id: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?) {
+        checkId(id)
+        navItems.add(
+            AzNavItem.Help(
+                id = id,
+                text = text,
+                menuText = menuText,
+                isRailItem = true,
+                content = content,
+                color = color,
+                textColor = textColor,
+                fillColor = fillColor,
+                shape = shape ?: defaultShape
+            )
+        )
+    }
+
+    override fun azHelpSubItem(id: String, hostId: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?) {
+        checkId(id)
+        if (navItems.none { it.id == hostId }) {
+            throw IllegalArgumentException("`azHelpSubItem(id = \"$id\", hostId = \"$hostId\", ...)` references a host that has not been declared yet. Sub-items attach to a previously-registered host so the rail can resolve `hostId` -> host item when rendering. Fix: declare a parent `azMenuHostItem` / `azRailHostItem` / `azHelpRailItem` (or any item) with `id = \"$hostId\"` BEFORE this `azHelpSubItem` call in the `azRailContent { ... }` block; or change the `hostId` argument here to match an id that already exists.")
+        }
+        navItems.add(
+            AzNavItem(
+                id = id,
+                text = text,
+                menuText = menuText,
+                isRailItem = true,
+                isHelpItem = true,
+                isSubItem = true,
+                hostId = hostId,
+                content = content,
+                color = color,
+                textColor = textColor,
+                fillColor = fillColor,
+                shape = shape ?: defaultShape
+            )
+        )
+    }
+
+    override fun azRailItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azNestedRail(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, alignment: AzNestedRailAlignment, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onFocus: (() -> Unit)?, keepNestedRailOpen: Boolean, nestedContent: AzNavRailScope.() -> Unit) {
+        checkId(id)
+        val nestedScope = AzNavRailScopeImpl(this.globalIdSet)
+        nestedScope.azConfig(dockingSide = this.dockingSide, packButtons = this.packButtons, noMenu = this.noMenu, vibrate = this.vibrate, displayAppName = this.displayAppName, activeClassifiers = this.activeClassifiers, expandedWidth = this.expandedWidth, collapsedWidth = this.collapsedWidth, showFooter = this.showFooter, appRepositoryUrl = this.appRepositoryUrl)
+        nestedScope.azTheme(activeColor = this.activeColor, defaultShape = this.defaultShape, headerIconShape = this.headerIconShape, translucentBackground = this.translucentBackground)
+        nestedScope.nestedContent()
+
+        nestedScope.onClickMap.forEach { (k, v) ->
+            if (onClickMap.containsKey(k)) throw IllegalStateException("Scope collision while merging `azNestedRail(id = \"$id\")`: a nested child declared `id = \"$k\"`, but the parent rail already has an item with the same id, so its `onClick` handler would be overwritten. Fix: rename the nested child's `id` to be unique across the whole rail (eg. \"${k}_in_$id\"); or remove the colliding parent declaration. Every id registered inside `nestedContent { ... }` shares the same global id namespace as the parent rail.")
+            onClickMap[k] = v
+        }
+        nestedScope.onFocusMap.forEach { (k, v) -> onFocusMap[k] = v }
+        nestedScope.hiddenMenuOnClickMap.forEach { (k, v) -> hiddenMenuOnClickMap[k] = v }
+        nestedScope.hiddenMenuOnValueChangeMap.forEach { (k, v) -> hiddenMenuOnValueChangeMap[k] = v }
+        nestedScope.onRelocateMap.forEach { (k, v) -> onRelocateMap[k] = v }
+
+        if (onFocus != null) onFocusMap[id] = onFocus
+
+        navItems.add(
+            AzNavItem(
+                id = id, text = text, menuText = menuText, route = route, isRailItem = true, isNestedRail = true,
+                nestedRailAlignment = alignment, nestedRailItems = nestedScope.navItems.toList(),
+                disabled = disabled, screenTitle = screenTitle ?: text,
+                info = info, classifiers = classifiers, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape,
+                keepNestedRailOpen = keepNestedRailOpen
+            )
+        )
+    }
+
+    override fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azDivider() {
+        navItems.add(AzNavItem(id = "divider_${navItems.size}", text = "", isRailItem = false, isDivider = true))
+    }
+
+    override fun azMenuHostItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, expandWhen: (() -> Boolean)?, onExpandedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {
+        if (expandWhen != null) expandWhenMap[id] = expandWhen
+        if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azRailHostItem(
+        id: String,
+        text: String,
+        route: String?,
+        content: Any?,
+        color: Color?,
+        shape: AzButtonShape?,
+        disabled: Boolean,
+        screenTitle: String?,
+        info: String?,
+        classifiers: Set<String>,
+        menuText: String?,
+        textColor: Color?,
+        fillColor: Color?,
+        initiallyExpanded: Boolean,
+        expandWhen: (() -> Boolean)?,
+        onExpandedChange: ((Boolean) -> Unit)?,
+        onClick: (() -> Unit)?
+    ) {
+        if (expandWhen != null) expandWhenMap[id] = expandWhen
+        if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
+        addItem(
+            id = id,
+            text = text,
+            menuText = menuText,
+            config = AzItemConfig(
+                classifiers = classifiers,
+                route = route,
+                screenTitle = screenTitle,
+                info = info,
+                isRailItem = true,
+                disabled = disabled,
+                isHost = true,
+                content = content,
+                color = color,
+                textColor = textColor,
+                fillColor = fillColor,
+                shape = shape,
+                initiallyExpanded = initiallyExpanded
+            ),
+            onClick = onClick ?: {})
+    }
+
+    override fun azMenuSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azRailSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, isSubItem = true, hostId = hostId, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azMenuSubHostItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, expandWhen: (() -> Boolean)?, onExpandedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {
+        checkSubHost(id, hostId, "azMenuSubHostItem")
+        if (expandWhen != null) expandWhenMap[id] = expandWhen
+        if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azRailSubHostItem(
+        id: String,
+        hostId: String,
+        text: String,
+        route: String?,
+        content: Any?,
+        color: Color?,
+        shape: AzButtonShape?,
+        disabled: Boolean,
+        screenTitle: String?,
+        info: String?,
+        classifiers: Set<String>,
+        menuText: String?,
+        textColor: Color?,
+        fillColor: Color?,
+        initiallyExpanded: Boolean,
+        expandWhen: (() -> Boolean)?,
+        onExpandedChange: ((Boolean) -> Unit)?,
+        onClick: (() -> Unit)?
+    ) {
+        checkSubHost(id, hostId, "azRailSubHostItem")
+        if (expandWhen != null) expandWhenMap[id] = expandWhen
+        if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
+        addItem(
+            id = id,
+            text = text,
+            menuText = menuText,
+            config = AzItemConfig(
+                classifiers = classifiers,
+                route = route,
+                screenTitle = screenTitle,
+                info = info,
+                isRailItem = true,
+                disabled = disabled,
+                isHost = true,
+                isSubItem = true,
+                hostId = hostId,
+                content = content,
+                color = color,
+                textColor = textColor,
+                fillColor = fillColor,
+                shape = shape,
+                initiallyExpanded = initiallyExpanded
+            ),
+            onClick = onClick ?: {})
+    }
+
+    /**
+     * Validates a sub-host declaration: the parent [hostId] must already be registered, and a
+     * sub-host may not reference itself (which would expand into an infinite loop).
+     */
+    private fun checkSubHost(id: String, hostId: String, builder: String) {
+        if (hostId == id) {
+            throw IllegalArgumentException("`$builder(id = \"$id\", hostId = \"$hostId\", ...)` references itself as its own host. A sub-host must attach to a different parent host. Fix: pass a `hostId` that matches a previously-declared host item other than \"$id\".")
+        }
+        if (navItems.none { it.id == hostId }) {
+            throw IllegalArgumentException("`$builder(id = \"$id\", hostId = \"$hostId\", ...)` references a host that has not been declared yet. Sub-items attach to a previously-registered host so the rail can resolve `hostId` -> host item when rendering. Fix: declare a parent host (eg. `azRailHostItem` / `azMenuHostItem` / another `azRailSubHostItem`) with `id = \"$hostId\"` BEFORE this call in the `azRailContent { ... }` block; or change the `hostId` argument here to match an id that already exists.")
+        }
+    }
+
+    override fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    }
+
+    override fun azRailRelocItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onFocus: (() -> Unit)?, onClick: (() -> Unit)?, onRelocate: ((Int, Int, List<String>) -> Unit)?, nestedRailAlignment: AzNestedRailAlignment, keepNestedRailOpen: Boolean, nestedContent: (AzNavRailScope.() -> Unit)?, forceHiddenMenuOpen: Boolean, onHiddenMenuDismiss: (() -> Unit)?, hiddenMenu: HiddenMenuScope.() -> Unit) {
+        checkId(id)
+        val hiddenMenuScope = HiddenMenuScopeImpl(id, hiddenMenuOnClickMap, hiddenMenuOnValueChangeMap)
+        hiddenMenuScope.hiddenMenu()
+
+        if (onClick != null) onClickMap[id] = onClick
+        if (onRelocate != null) onRelocateMap[id] = onRelocate
+        if (onFocus != null) onFocusMap[id] = onFocus
+
+        val finalScreenTitle = if (screenTitle == AzNavRailDefaults.NO_TITLE) null else screenTitle ?: text
+
+        val nestedItems = if (nestedContent != null) {
+            val nestedScope = AzNavRailScopeImpl(this.globalIdSet)
+            nestedScope.azConfig(dockingSide = this.dockingSide, packButtons = this.packButtons, noMenu = this.noMenu, vibrate = this.vibrate, displayAppName = this.displayAppName, activeClassifiers = this.activeClassifiers, expandedWidth = this.expandedWidth, collapsedWidth = this.collapsedWidth, showFooter = this.showFooter)
+            nestedScope.azTheme(activeColor = this.activeColor, defaultShape = this.defaultShape, headerIconShape = this.headerIconShape, translucentBackground = this.translucentBackground)
+            nestedScope.nestedContent()
+
+            nestedScope.onClickMap.forEach { (k, v) ->
+                if (onClickMap.containsKey(k)) throw IllegalStateException("Scope collision while merging the `nestedContent` of `azRailRelocItem(id = \"$id\")`: a nested child declared `id = \"$k\"`, but the parent rail already has an item with that id, so its `onClick` would be silently overwritten. Fix: rename the nested child's `id` so it is unique across the whole rail (eg. \"${k}_in_$id\"); or drop the duplicate parent declaration. Ids inside `azRailRelocItem(...) { nestedContent = { ... } }` share the parent rail's id namespace.")
+                onClickMap[k] = v
+            }
+            nestedScope.onFocusMap.forEach { (k, v) -> onFocusMap[k] = v }
+            nestedScope.hiddenMenuOnClickMap.forEach { (k, v) -> hiddenMenuOnClickMap[k] = v }
+            nestedScope.hiddenMenuOnValueChangeMap.forEach { (k, v) -> hiddenMenuOnValueChangeMap[k] = v }
+            nestedScope.onRelocateMap.forEach { (k, v) -> onRelocateMap[k] = v }
+
+            nestedScope.navItems.toList()
+        } else null
+
+        navItems.add(
+            AzNavItem(
+                id = id, text = text, menuText = menuText, route = route, isRailItem = true, isSubItem = true, hostId = hostId,
+                isRelocItem = true, disabled = disabled, screenTitle = finalScreenTitle, info = info,
+                hiddenMenuItems = hiddenMenuScope.items, forceHiddenMenuOpen = forceHiddenMenuOpen, onHiddenMenuDismiss = onHiddenMenuDismiss, classifiers = classifiers, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape,
+                isNestedRail = nestedContent != null, nestedRailAlignment = nestedRailAlignment, nestedRailItems = nestedItems,
+                keepNestedRailOpen = keepNestedRailOpen
+            )
+        )
+    }
+
+    private fun addCycler(id: String, options: List<String>, menuOptions: List<String>? = null, selectedOption: String, disabledOptions: List<String>? = null, config: AzItemConfig, onClick: () -> Unit) {
+        checkId(id)
+        require(menuOptions == null || options.size == menuOptions.size) {
+            "Cycler '$id' has a `menuOptions` list of size ${menuOptions?.size} but its `options` list is of size ${options.size}. When you supply `menuOptions`, it acts as the menu-side label for each entry in `options`, so the two lists must be index-aligned (size N <-> size N). Fix: make `menuOptions` exactly ${options.size} entries long to match `options = $options`; or omit the `menuOptions` argument to reuse `options` as the menu labels."
+        }
+        require(options.contains(selectedOption)) {
+            "Cycler '$id' was given `selectedOption = \"$selectedOption\"`, but that value is not one of the entries in `options = $options`. The cycler advances by indexing into `options`, so the initial selection must be a member of it. Fix: change `selectedOption` to one of $options; or add \"$selectedOption\" to the `options` list."
+        }
+        val finalScreenTitle = if (config.screenTitle == AzNavRailDefaults.NO_TITLE) null else config.screenTitle ?: selectedOption
+        onClickMap[id] = onClick
+        navItems.add(
+            AzNavItem(
+                id = id, text = "", route = config.route, screenTitle = finalScreenTitle, isRailItem = config.isRailItem,
+                classifiers = config.classifiers, isCycler = true, options = options, menuOptions = menuOptions, selectedOption = selectedOption,
+                disabled = config.disabled, disabledOptions = disabledOptions, isSubItem = config.isSubItem,
+                hostId = config.hostId, info = config.info, color = config.color, textColor = config.textColor,
+                fillColor = config.fillColor, shape = config.shape
+            )
+        )
+    }
+
+    private fun addToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, menuToggleOnText: String? = null, menuToggleOffText: String? = null, config: AzItemConfig, onClick: () -> Unit) {
+        checkId(id)
+        require(toggleOnText.isNotBlank() && toggleOffText.isNotBlank()) {
+            "Toggle '$id' has a blank `toggleOnText` (\"$toggleOnText\") and/or `toggleOffText` (\"$toggleOffText\"). These strings ARE the button label depending on `isChecked` -- an empty value would render an invisible button with no affordance. Fix: pass non-blank strings for both `toggleOnText` and `toggleOffText` (eg. `toggleOnText = \"On\", toggleOffText = \"Off\"`); for menu-only override labels use `menuToggleOnText` / `menuToggleOffText` instead of blanking these."
+        }
+        val text = if (isChecked) toggleOnText else toggleOffText
+        val finalScreenTitle = if (config.screenTitle == AzNavRailDefaults.NO_TITLE) null else config.screenTitle ?: text
+        onClickMap[id] = onClick
+        navItems.add(
+            AzNavItem(
+                id = id, text = "", route = config.route, screenTitle = finalScreenTitle, isRailItem = config.isRailItem,
+                classifiers = config.classifiers, isToggle = true, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText,
+                menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, disabled = config.disabled,
+                isSubItem = config.isSubItem, hostId = config.hostId, info = config.info, color = config.color,
+                textColor = config.textColor, fillColor = config.fillColor, shape = config.shape
+            )
+        )
+    }
+
+    private fun addItem(id: String, text: String, menuText: String? = null, config: AzItemConfig, onClick: () -> Unit) {
+        checkId(id)
+        require(text.isNotBlank()) {
+           "Item '$id' was declared with a blank `text` argument. `text` is the rail-button label (and, when `menuText` is null, also the menu label and `screenTitle` fallback) -- a blank value would render an unreadable, unclickable button. Fix: pass a non-blank `text` (eg. `text = \"Settings\"`); if you only want the menu label different, leave `text` non-blank and override with `menuText = \"...\"`; if you intended a divider, use `azDivider()` instead."
+        }
+        val finalScreenTitle = if (config.screenTitle == AzNavRailDefaults.NO_TITLE) null else config.screenTitle ?: text
+        onClickMap[id] = onClick
+        if (config.onFocus != null) onFocusMap[id] = config.onFocus
+        navItems.add(
+            AzNavItem(
+                id = id, text = text, menuText = menuText, route = config.route, screenTitle = finalScreenTitle,
+                isRailItem = config.isRailItem, disabled = config.disabled, isHost = config.isHost,
+                isSubItem = config.isSubItem, hostId = config.hostId, info = config.info,
+                classifiers = config.classifiers, content = config.content, color = config.color,
+                textColor = config.textColor,
+                fillColor = config.fillColor,
+                shape = config.shape,
+                initiallyExpanded = config.initiallyExpanded
+            )
+        )
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzRoller.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzRoller.kt
@@ -1,0 +1,152 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+
+/**
+ * A versatile dropdown component that combines a text filter with a list of options.
+ *
+ * `AzRoller` behaves like a "slot machine" dropdown.
+ * - Clicking the text area allows the user to type and filter the options.
+ * - Clicking the dropdown arrow toggles the full list.
+ * - When typing, the dropdown automatically expands to show filtered results.
+ * - Supports custom values (users can type and submit a value not in the list).
+ *
+ * Pressing the keyboard "Done" key selects the top filtered option (or commits the typed value
+ * verbatim when there are no matches). Selecting from the list or pressing the keyboard always
+ * dismisses the popup and re-syncs `filterText` with [selectedOption].
+ *
+ * Example:
+ * ```
+ * var country by remember { mutableStateOf<String?>(null) }
+ * AzRoller(
+ *     options = listOf("USA", "Canada", "Mexico"),
+ *     selectedOption = country,
+ *     onOptionSelected = { country = it },
+ *     hint = "Country",
+ * )
+ * ```
+ *
+ * @param options The list of options shown in the dropdown.
+ * @param selectedOption The currently selected option; drives the filter text when collapsed.
+ * @param onOptionSelected Callback fired when the user picks (or types) an option.
+ * @param hint The hint text displayed when the input is empty.
+ * @param enabled Whether the component is interactive.
+ * @param isError Whether the component is in an error state.
+ */
+@Composable
+fun AzRoller(
+    options: List<String>,
+    selectedOption: String?,
+    onOptionSelected: (String) -> Unit,
+    hint: String = "",
+    enabled: Boolean = true,
+    isError: Boolean = false
+) {
+    var expanded by remember { mutableStateOf(false) }
+    var filterText by remember { mutableStateOf(selectedOption ?: "") }
+
+    LaunchedEffect(selectedOption, expanded) {
+        if (!expanded) {
+            filterText = selectedOption ?: ""
+        }
+    }
+
+    val filteredOptions = remember(filterText, options) {
+        if (filterText.isEmpty()) options else options.filter { it.contains(filterText, ignoreCase = true) }
+    }
+
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(filteredOptions) {
+        listState.scrollToItem(0)
+    }
+
+    Box(modifier = Modifier.fillMaxWidth()) {
+        AzTextBox(
+            value = filterText,
+            onValueChange = { 
+                filterText = it
+                expanded = true
+            },
+            hint = hint,
+            enabled = enabled,
+            isError = isError,
+            trailingIcon = {
+                Icon(
+                    imageVector = Icons.Default.ArrowDropDown,
+                    contentDescription = "Dropdown",
+                    modifier = Modifier
+                        .testTag("AzRollerRight")
+                        .clickable(enabled = enabled) { 
+                            expanded = !expanded 
+                            if (expanded) filterText = ""
+                        }
+                )
+            },
+            onSubmit = { 
+                if (filteredOptions.isNotEmpty()) {
+                    onOptionSelected(filteredOptions.first())
+                } else {
+                    onOptionSelected(filterText)
+                }
+                expanded = false
+            }
+        )
+
+        if (expanded) {
+            Popup(
+                alignment = Alignment.TopStart,
+                onDismissRequest = { expanded = false },
+                properties = PopupProperties(focusable = false)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+                ) {
+                    LazyColumn(state = listState) {
+                        items(filteredOptions) { option ->
+                            Text(
+                                text = option,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        filterText = option
+                                        onOptionSelected(option)
+                                        expanded = false
+                                    }
+                                    .padding(16.dp),
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzSafeZonesLocals.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzSafeZonesLocals.kt
@@ -1,0 +1,13 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.runtime.compositionLocalOf
+import com.hereliesaz.aznavrail.internal.AzSafeZones
+
+/**
+ * CompositionLocal providing the computed safe-zone insets for the current layout.
+ *
+ * The Android sibling defines this in `AzNavHost.kt`, which drags in AndroidX Navigation and
+ * ContextWrappers. The CMP module keeps just this CompositionLocal — safe-zone insets are pure
+ * layout data and don't need any of the navigation machinery.
+ */
+val LocalAzSafeZones = compositionLocalOf { AzSafeZones() }

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzTextBox.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzTextBox.kt
@@ -1,0 +1,391 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.hereliesaz.aznavrail.util.HistoryStore
+
+/**
+ * Object holding global defaults for [AzTextBox].
+ */
+object AzTextBoxDefaults {
+    private var suggestionLimit: Int = 5
+    private var backgroundColor: Color = Color.Transparent
+    private var backgroundOpacity: Float = 1.0f
+
+    /**
+     * Sets the maximum number of autocomplete suggestions to display.
+     *
+     * @param limit The limit (0-5).
+     */
+    fun setSuggestionLimit(limit: Int) {
+        suggestionLimit = limit.coerceIn(0, 5)
+    }
+
+    /**
+     * Sets the global background color for all text boxes.
+     */
+    fun setBackgroundColor(color: Color) {
+        backgroundColor = color
+    }
+
+    /**
+     * Sets the global background opacity for all text boxes.
+     *
+     * @param opacity The opacity (0.0 - 1.0).
+     */
+    fun setBackgroundOpacity(opacity: Float) {
+        backgroundOpacity = opacity.coerceIn(0f, 1f)
+    }
+
+    internal fun getSuggestionLimit(): Int = suggestionLimit
+    internal fun getBackgroundColor(): Color = backgroundColor
+    internal fun getBackgroundOpacity(): Float = backgroundOpacity
+}
+
+/**
+ * A highly customizable text input box with integrated features like autocomplete, history,
+ * password visibility toggling, and multi-line support.
+ *
+ * It is designed to work seamlessly with [AzForm] but can also be used as a standalone component.
+ *
+ * @param modifier The modifier to be applied to the text box.
+ * @param value The input text to be shown in the text field. If null, the component manages its own state.
+ * @param onValueChange The callback that is triggered when the input value updates.
+ * @param historyContext A context string used to namespace autocomplete history.
+ * @param hint The hint text to display when the input is empty.
+ * @param outlined Whether the text box has a border outline.
+ * @param multiline Whether the text box supports multiple lines and expands vertically.
+ * @param secret Whether the text box is a password field (masked input).
+ * @param isError Whether the input is in an error state.
+ * @param keyboardOptions Custom keyboard configuration.
+ * @param keyboardActions Custom keyboard actions.
+ * @param leadingIcon An optional composable to display at the start of the text box.
+ * @param trailingIcon An optional composable to display at the end of the text box (before system icons).
+ * @param enabled Whether the text box is enabled and interactive.
+ * @param outlineColor The color for the outline, text, and icons.
+ * @param textColor The color for the text (overrides outlineColor).
+ * @param fillColor The background fill color of the text box (overrides AzTextBoxDefaults.backgroundColor).
+ * @param showClearButton Whether to show the clear/reveal button.
+ * @param focusRequester An optional [androidx.compose.ui.focus.FocusRequester] to control focus programmatically.
+ * @param submitButtonContent Optional content for a built-in submit button.
+ * @param onSubmit A callback invoked when the submit button is clicked or "Done" is pressed on the keyboard.
+ *
+ * @see AzForm
+ * @see AzTextBoxDefaults
+ */
+@Composable
+fun AzTextBox(
+    modifier: Modifier = Modifier,
+    value: String? = null,
+    onValueChange: ((String) -> Unit)? = null,
+    historyContext: String = "default",
+    hint: String = "",
+    outlined: Boolean = true,
+    multiline: Boolean = false,
+    secret: Boolean = false,
+    isError: Boolean = false,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    enabled: Boolean = true,
+    outlineColor: Color = MaterialTheme.colorScheme.primary,
+    textColor: Color? = null,
+    fillColor: Color? = null,
+    showClearButton: Boolean = true,
+    focusRequester: androidx.compose.ui.focus.FocusRequester? = null,
+    submitButtonContent: (@Composable () -> Unit)? = null,
+    onSubmit: (String) -> Unit
+) {
+    require(!multiline || !secret) {
+        "AzTextBox cannot be both `multiline = true` and `secret = true` at the same time — " +
+            "a masked password field by definition fits on a single line and would render the " +
+            "expansion behaviour incoherent. Pick one: set `multiline = false` for a password " +
+            "field, or set `secret = false` for a multi-line free-text field."
+    }
+
+    var internalText by remember { mutableStateOf("") }
+
+    // Determine effective text
+    val text = value ?: internalText
+
+    val onTextChange: (String) -> Unit = { newText ->
+        if (value == null) {
+            internalText = newText
+        }
+        onValueChange?.invoke(newText)
+    }
+
+    var suggestions by remember { mutableStateOf<List<String>>(emptyList()) }
+    val suggestionLimit = AzTextBoxDefaults.getSuggestionLimit()
+    val backgroundColor = fillColor ?: AzTextBoxDefaults.getBackgroundColor().copy(alpha = AzTextBoxDefaults.getBackgroundOpacity())
+    var isPasswordVisible by remember { mutableStateOf(false) }
+    var componentHeight by remember { mutableIntStateOf(0) }
+    var componentWidth by remember { mutableIntStateOf(0) }
+
+    val effectiveColor = if (isError) {
+        MaterialTheme.colorScheme.error
+    } else if (!enabled) {
+        outlineColor.copy(alpha = 0.5f)
+    } else {
+        outlineColor
+    }
+
+    val effectiveTextColor = if (isError) {
+        MaterialTheme.colorScheme.error
+    } else if (!enabled) {
+        (textColor ?: outlineColor).copy(alpha = 0.5f)
+    } else {
+        textColor ?: outlineColor
+    }
+
+    LaunchedEffect(suggestionLimit) {
+        HistoryStore.updateSettings(suggestionLimit)
+    }
+
+    LaunchedEffect(text) {
+        suggestions = if (text.isNotBlank() && enabled) {
+            HistoryStore.getSuggestions(text, historyContext)
+        } else {
+            emptyList()
+        }
+    }
+
+    Box(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .background(backgroundColor)
+                .onSizeChanged {
+                    componentHeight = it.height
+                    componentWidth = it.width
+                },
+            verticalAlignment = if (multiline) Alignment.Bottom else Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .then(if (!multiline) Modifier.height(36.dp) else Modifier)
+                    .then(
+                        if (outlined) {
+                            Modifier.border(1.dp, effectiveColor, RectangleShape)
+                        } else {
+                            Modifier
+                        }
+                    ),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                BasicTextField(
+                    value = text,
+                    onValueChange = onTextChange,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .testTag(hint)
+                        .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier),
+                    textStyle = TextStyle(fontSize = 10.sp, color = effectiveTextColor),
+                    singleLine = !multiline,
+                    cursorBrush = SolidColor(effectiveColor),
+                    visualTransformation = if (secret && !isPasswordVisible) PasswordVisualTransformation() else VisualTransformation.None,
+                    keyboardOptions = keyboardOptions,
+                    keyboardActions = keyboardActions,
+                    enabled = enabled
+                ) { innerTextField ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        if (leadingIcon != null) {
+                            CompositionLocalProvider(LocalContentColor provides effectiveColor) {
+                                leadingIcon()
+                                Spacer(modifier = Modifier.width(8.dp))
+                            }
+                        }
+                        Box(modifier = Modifier.weight(1f)) {
+                            if (text.isEmpty()) {
+                                Text(text = hint, fontSize = 10.sp, color = if(enabled) effectiveTextColor.copy(alpha = 0.5f) else effectiveTextColor.copy(alpha = 0.3f))
+                            }
+                            innerTextField()
+                        }
+                        if (trailingIcon != null) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            CompositionLocalProvider(LocalContentColor provides effectiveColor) {
+                                trailingIcon()
+                            }
+                        }
+                        if (isError) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Icon(
+                                imageVector = Icons.Default.Warning,
+                                contentDescription = "Error",
+                                modifier = Modifier.size(16.dp),
+                                tint = effectiveColor
+                            )
+                        }
+                        if (text.isNotEmpty() && enabled && showClearButton) {
+                            val icon = when {
+                                secret && isPasswordVisible -> Icons.Default.VisibilityOff
+                                secret && !isPasswordVisible -> Icons.Default.Visibility
+                                else -> Icons.Default.Clear
+                            }
+                            val contentDescription = when {
+                                secret && isPasswordVisible -> "Hide password"
+                                secret && !isPasswordVisible -> "Show password"
+                                else -> "Clear text"
+                            }
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Icon(
+                                imageVector = icon,
+                                contentDescription = contentDescription,
+                                modifier = Modifier
+                                    .size(16.dp)
+                                    .clickable {
+                                        if (secret) {
+                                            isPasswordVisible = !isPasswordVisible
+                                        } else {
+                                            onTextChange("")
+                                        }
+                                    },
+                                tint = effectiveColor
+                            )
+                        }
+                    }
+                }
+            }
+            if (submitButtonContent != null) {
+                Spacer(modifier = Modifier.width(8.dp))
+                CompositionLocalProvider(LocalContentColor provides effectiveTextColor) {
+                    Box(
+                        modifier = Modifier
+                            .then(if (enabled) Modifier.clickable {
+                                onSubmit(text)
+                                if (!secret) {
+                                    HistoryStore.addEntry(text, historyContext)
+                                }
+                                if (onValueChange == null) {
+                                    onTextChange("")
+                                }
+                            } else Modifier)
+                            .then(
+                                if (!outlined) {
+                                    Modifier.border(1.dp, effectiveColor, RectangleShape)
+                                } else {
+                                    Modifier
+                                }
+                            )
+                            .padding(horizontal = 12.dp, vertical = 8.dp)
+                    ) {
+                        submitButtonContent()
+                    }
+                }
+            }
+        }
+
+        if (suggestions.isNotEmpty() && enabled) {
+            val density = LocalDensity.current
+
+            Popup(
+                alignment = Alignment.TopStart,
+                offset = IntOffset(0, componentHeight),
+                properties = PopupProperties(focusable = false, dismissOnBackPress = true, dismissOnClickOutside = true),
+                onDismissRequest = { suggestions = emptyList() }
+            ) {
+                val surfaceColor = MaterialTheme.colorScheme.surface
+                Column(
+                    modifier = Modifier
+                        .width(with(density) { componentWidth.toDp() })
+                        .background(surfaceColor)
+                        .border(1.dp, effectiveColor.copy(alpha = 0.5f), RectangleShape)
+                ) {
+                    suggestions.forEachIndexed { index, suggestion ->
+                        val suggestionBgColor = if (index % 2 == 0) {
+                            surfaceColor.copy(alpha = 0.9f)
+                        } else {
+                            surfaceColor.copy(alpha = 0.8f)
+                        }
+                        Text(
+                            text = suggestion,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(suggestionBgColor)
+                                .clickable {
+                                    onTextChange(suggestion)
+                                    suggestions = emptyList()
+                                }
+                                .padding(vertical = 8.dp, horizontal = 12.dp)
+                                .fadeRight(),
+                            maxLines = 1,
+                            overflow = TextOverflow.Clip,
+                            fontSize = 10.sp,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun Modifier.fadeRight(): Modifier = this.drawWithContent {
+    drawContent()
+    val safeStartX = maxOf(0f, size.width - 50f)
+    drawRect(
+        brush = Brush.horizontalGradient(
+            colors = listOf(Color.Transparent, Color.Black),
+            startX = safeStartX,
+            endX = size.width
+        ),
+        blendMode = BlendMode.DstIn
+    )
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheet.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheet.kt
@@ -1,0 +1,85 @@
+// FILE: ./aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzBottomSheet.kt
+package com.hereliesaz.aznavrail.bottomsheet
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.hereliesaz.aznavrail.internal.AzBottomSheetShell
+import com.hereliesaz.aznavrail.model.AzSheetConfig
+import com.hereliesaz.aznavrail.model.AzSheetDetent
+
+/**
+ * An in-tree bottom-sheet shell. Renders the LogKitty-style four-detent sheet
+ * (HIDDEN / PEEK / HALF / FULL) anchored to the bottom of the parent, with a drag handle,
+ * accumulated-delta vertical drag gesture, a scrim in the HALF/FULL states, and optional
+ * horizontal-swipe callbacks.
+ *
+ * When used inside [com.hereliesaz.aznavrail.AzHostActivityLayout] via the [com.hereliesaz.aznavrail.AzNavHostScope.azBottomSheet]
+ * DSL, the sheet draws on top of the rail, the menu, and the onscreen content area, and respects
+ * [WindowInsets.navigationBars] so it sits behind the system navigation bar rather than over it.
+ *
+ * The sheet is *not* a background; do not register it via [com.hereliesaz.aznavrail.AzNavHostScope.background].
+ *
+ * @param controller State holder (use [rememberAzSheetController]).
+ * @param modifier Modifier applied to the sheet's root box. The DSL form already applies
+ *   `Modifier.fillMaxSize().windowInsetsPadding(WindowInsets.navigationBars)`.
+ * @param config Static configuration; see [AzSheetConfig] for tunables.
+ * @param onSwipeLeft Optional horizontal-swipe-left callback, gated by [AzSheetConfig.horizontalSwipeEnabled].
+ * @param onSwipeRight Optional horizontal-swipe-right callback, gated by [AzSheetConfig.horizontalSwipeEnabled].
+ * @param content The caller-provided sheet content. Fill it with whatever you like — the shell
+ *   provides only the chrome.
+ */
+@Composable
+fun AzBottomSheet(
+    controller: AzSheetController,
+    modifier: Modifier = Modifier,
+    config: AzSheetConfig = AzSheetConfig(),
+    onSwipeLeft: (() -> Unit)? = null,
+    onSwipeRight: (() -> Unit)? = null,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    if (config.collapseOnBack) {
+        BackHandler(enabled = controller.detent != AzSheetDetent.HIDDEN) {
+            controller.stepDown()
+        }
+    }
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        AzBottomSheetShell(
+            controller = controller,
+            config = config,
+            parentHeight = maxHeight,
+            animate = config.animateInTree,
+            onSwipeLeft = onSwipeLeft,
+            onSwipeRight = onSwipeRight,
+            content = content,
+        )
+    }
+}
+
+/**
+ * Convenience overload that defaults the modifier to one which honours the system navigation-bar
+ * inset, so the sheet sits behind the system nav bar without callers needing to apply it.
+ */
+@Composable
+fun AzBottomSheetInsetAware(
+    controller: AzSheetController,
+    config: AzSheetConfig = AzSheetConfig(),
+    onSwipeLeft: (() -> Unit)? = null,
+    onSwipeRight: (() -> Unit)? = null,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    AzBottomSheet(
+        controller = controller,
+        modifier = Modifier.fillMaxSize().windowInsetsPadding(WindowInsets.navigationBars),
+        config = config,
+        onSwipeLeft = onSwipeLeft,
+        onSwipeRight = onSwipeRight,
+        content = content,
+    )
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/bottomsheet/AzSheetController.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/bottomsheet/AzSheetController.kt
@@ -1,0 +1,121 @@
+// FILE: ./aznavrail/src/main/java/com/hereliesaz/aznavrail/bottomsheet/AzSheetController.kt
+package com.hereliesaz.aznavrail.bottomsheet
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import com.hereliesaz.aznavrail.model.AzSheetDetent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * State holder for an [AzBottomSheet] or [AzBottomSheetWindowHost].
+ *
+ * The controller carries two channels per piece of state:
+ *
+ * - a Compose [androidx.compose.runtime.mutableStateOf] (exposed via [detent] / [isEnabled]) that
+ *   drives recomposition for in-tree consumers; and
+ * - a [StateFlow] ([detentFlow] / [enabledFlow]) consumed by the system-overlay flavor's coroutine
+ *   collector to resize the `WindowManager` window and toggle focusability.
+ *
+ * Both channels stay in sync; mutate either of the two `var` properties from the main thread.
+ *
+ * @property detent The current detent. Setter pushes through [detentFlow].
+ * @property isEnabled When `false`, [stepUp] and [stepDown] are ignored and the sheet collapses to
+ *   [AzSheetDetent.HIDDEN]. The system-overlay flavor uses this as the launcher-pass-through gate
+ *   that mirrors LogKitty's accessibility-driven behavior.
+ */
+@Stable
+class AzSheetController internal constructor(initial: AzSheetDetent) {
+
+    private var _detent by mutableStateOf(initial)
+    private val _detentFlow = MutableStateFlow(initial)
+    private var _isEnabled by mutableStateOf(true)
+    private val _enabledFlow = MutableStateFlow(true)
+
+    var detent: AzSheetDetent
+        get() = _detent
+        set(value) {
+            _detent = value
+            _detentFlow.value = value
+        }
+
+    var isEnabled: Boolean
+        get() = _isEnabled
+        set(value) {
+            _isEnabled = value
+            _enabledFlow.value = value
+            if (!value) detent = AzSheetDetent.HIDDEN
+        }
+
+    /** Emits whenever [detent] is mutated. */
+    val detentFlow: StateFlow<AzSheetDetent> get() = _detentFlow.asStateFlow()
+
+    /** Emits whenever [isEnabled] is mutated. */
+    val enabledFlow: StateFlow<Boolean> get() = _enabledFlow.asStateFlow()
+
+    /** Steps up one detent (HIDDEN → PEEK → HALF → FULL), no-op past FULL or when disabled. */
+    fun stepUp() {
+        if (!_isEnabled) return
+        detent = when (_detent) {
+            AzSheetDetent.HIDDEN -> AzSheetDetent.PEEK
+            AzSheetDetent.PEEK -> AzSheetDetent.HALF
+            AzSheetDetent.HALF -> AzSheetDetent.FULL
+            AzSheetDetent.FULL -> AzSheetDetent.FULL
+        }
+    }
+
+    /** Steps down one detent (FULL → HALF → PEEK → HIDDEN), no-op past HIDDEN. */
+    fun stepDown() {
+        if (!_isEnabled && _detent != AzSheetDetent.HIDDEN) {
+            detent = AzSheetDetent.HIDDEN
+            return
+        }
+        detent = when (_detent) {
+            AzSheetDetent.FULL -> AzSheetDetent.HALF
+            AzSheetDetent.HALF -> AzSheetDetent.PEEK
+            AzSheetDetent.PEEK -> AzSheetDetent.HIDDEN
+            AzSheetDetent.HIDDEN -> AzSheetDetent.HIDDEN
+        }
+    }
+
+    /** Jumps directly to [target]. Ignores [isEnabled] when [target] is HIDDEN; otherwise gated. */
+    fun snapTo(target: AzSheetDetent) {
+        if (target != AzSheetDetent.HIDDEN && !_isEnabled) return
+        detent = target
+    }
+
+    companion object {
+        /**
+         * Constructs an [AzSheetController] directly. Prefer [rememberAzSheetController] inside Compose
+         * so the detent survives recomposition and configuration changes.
+         */
+        operator fun invoke(initial: AzSheetDetent = AzSheetDetent.HIDDEN): AzSheetController =
+            AzSheetController(initial)
+
+        internal val Saver: Saver<AzSheetController, String> = Saver(
+            save = { it.detent.name },
+            restore = { AzSheetController(AzSheetDetent.valueOf(it)) },
+        )
+    }
+}
+
+/**
+ * Remembers an [AzSheetController] that survives recomposition and configuration changes.
+ *
+ * Positional scoping: if you create multiple controllers in the same composition, simply call
+ * this function multiple times — each call gets its own positionally-scoped saved state.
+ *
+ * @param initial The detent to use when the controller is first created.
+ */
+@Composable
+fun rememberAzSheetController(
+    initial: AzSheetDetent = AzSheetDetent.HIDDEN,
+): AzSheetController = rememberSaveable(saver = AzSheetController.Saver) {
+    AzSheetController(initial)
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/cmp/AzCmpPreview.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/cmp/AzCmpPreview.kt
@@ -1,0 +1,19 @@
+package com.hereliesaz.aznavrail.cmp
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+/**
+ * Placeholder composable that gives the aznavrail-cmp module something to compile in every target.
+ * Phase A of the Compose Multiplatform port ships only the module scaffold + gradle wiring; the real
+ * navigation-rail composables (AzNavRail, AzDropdownMenu, AzForm, etc.) will be ported to
+ * `commonMain` in later phases as their Android-platform coupling is resolved via `expect/actual`.
+ */
+@Composable
+fun AzCmpPreview() {
+    Text(
+        text = "aznavrail-cmp Phase A",
+        style = MaterialTheme.typography.titleLarge,
+    )
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzBottomSheetShell.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzBottomSheetShell.kt
@@ -1,0 +1,180 @@
+// FILE: ./aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzBottomSheetShell.kt
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.bottomsheet.AzSheetController
+import com.hereliesaz.aznavrail.model.AzSheetConfig
+import com.hereliesaz.aznavrail.model.AzSheetDetent
+
+/**
+ * Shared visual shell used by both the in-tree `AzBottomSheet` composable and the
+ * system-overlay `AzBottomSheetWindowHost`. Renders:
+ *
+ *  1. A dim scrim above the sheet (catching taps to [AzSheetController.stepDown]) when the detent
+ *     is HALF or FULL, or a transparent tap overlay (no dim) at PEEK that also steps down.
+ *  2. A rounded-top card sized via [heightForDetent], anchored at the bottom of the available space.
+ *  3. A drag-handle pill (when [AzSheetConfig.handleVisible]) plus the always-present hidden swipe
+ *     strip; both attach the accumulated-delta vertical-drag modifier.
+ *  4. The caller-supplied [content] inside the card.
+ *
+ * @param controller Controller backing the sheet's state.
+ * @param config Static configuration.
+ * @param parentHeight The container height used to resolve fraction-based detents.
+ * @param animate When `true`, animates between detent heights. The in-tree path passes
+ *   `config.animateInTree`; the system-overlay path passes `false` since the window itself jumps.
+ * @param onSwipeLeft / [onSwipeRight] Optional horizontal-swipe callbacks gated by
+ *   [AzSheetConfig.horizontalSwipeEnabled].
+ * @param navBarExtensionDp Extra height by which the *card* extends downward into the navigation-bar
+ *   region when the system-overlay host opts into [AzSheetConfig.drawBehindNavBar]. The detent's
+ *   exposed (above-bar) height is resolved against `parentHeight - navBarExtensionDp` and this band
+ *   is added back on, so the card's top edge does not move while its content flows behind the bar.
+ *   Defaults to `0.dp` (the in-tree path never extends the card).
+ * @param content Caller-provided sheet content.
+ */
+@Composable
+internal fun AzBottomSheetShell(
+    controller: AzSheetController,
+    config: AzSheetConfig,
+    parentHeight: Dp,
+    animate: Boolean,
+    onSwipeLeft: (() -> Unit)?,
+    onSwipeRight: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+    navBarExtensionDp: Dp = 0.dp,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    val density = LocalDensity.current
+    // Resolve the detent against the exposed (above-bar) height, then add the nav-bar band back so
+    // the card grows downward by exactly the extension without shifting its top edge.
+    val targetHeight =
+        heightForDetent(controller.detent, (parentHeight - navBarExtensionDp).coerceAtLeast(0.dp), config) + navBarExtensionDp
+    val animatedHeight by animateDpAsState(
+        targetValue = if (animate) targetHeight else targetHeight,
+        label = "az-sheet-height",
+    )
+    val effectiveHeight = if (animate) animatedHeight else targetHeight
+
+    val resolvedBackground = if (config.backgroundColor.isUnspecified()) {
+        MaterialTheme.colorScheme.surface
+    } else {
+        config.backgroundColor
+    }
+    val sheetColor = resolvedBackground.copy(alpha = config.backgroundAlpha)
+
+    val showVisualScrim = controller.detent == AzSheetDetent.HALF || controller.detent == AzSheetDetent.FULL
+    val showTapOverlay = controller.detent == AzSheetDetent.PEEK
+
+    Box(modifier = modifier.fillMaxSize()) {
+        if (showVisualScrim) {
+            // Dim layer at HALF/FULL; tap steps the sheet down one detent.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(config.scrimColor.copy(alpha = config.scrimAlpha))
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { controller.stepDown() }
+            )
+        } else if (showTapOverlay) {
+            // Transparent tap catcher at PEEK; no dim, just catches taps to step down.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { controller.stepDown() }
+            )
+        }
+
+        val swipeMod = if (config.horizontalSwipeEnabled && onSwipeLeft != null && onSwipeRight != null) {
+            Modifier.azSheetHorizontalSwipe(density, 48.dp, onSwipeLeft, onSwipeRight)
+        } else {
+            Modifier
+        }
+
+        // At HIDDEN, tap on the strip reveals PEEK. This makes the affordance work for users
+        // whose first instinct is to tap rather than drag.
+        val hiddenTapMod = if (controller.detent == AzSheetDetent.HIDDEN) {
+            Modifier.clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) { controller.stepUp() }
+        } else {
+            Modifier
+        }
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(effectiveHeight)
+                .clip(RoundedCornerShape(topStart = config.cornerRadiusDp, topEnd = config.cornerRadiusDp))
+                .background(sheetColor)
+                .azSheetVerticalDrag(controller, density, config.dragThresholdDp)
+                .then(swipeMod)
+                .then(hiddenTapMod)
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                if (config.handleVisible) {
+                    // Always render the handle when configured visible — including at HIDDEN —
+                    // so the swipe-up affordance is discoverable. The handle dims at HIDDEN to
+                    // match the "near-invisible strip" intent without becoming untouchable.
+                    val isHidden = controller.detent == AzSheetDetent.HIDDEN
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(if (isHidden) 14.dp else 20.dp)
+                            .wrapContentHeight(Alignment.CenterVertically),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .width(36.dp)
+                                .height(4.dp)
+                                .clip(RoundedCornerShape(2.dp))
+                                .background(
+                                    MaterialTheme.colorScheme.onSurface.copy(
+                                        alpha = if (isHidden) 0.20f else 0.32f
+                                    )
+                                )
+                        )
+                    }
+                }
+                Box(modifier = Modifier
+                    .fillMaxSize()
+                    .imePadding()
+                ) { content() }
+            }
+        }
+    }
+}
+
+private fun Color.isUnspecified(): Boolean = this.value == Color.Unspecified.value

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzJustify.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzJustify.kt
@@ -1,0 +1,76 @@
+package com.hereliesaz.aznavrail.internal
+
+/**
+ * Closed-form solver for the hybrid **kerning + font-scale** justification used by the WP7-style
+ * menu drawer. The label fills the row via a mix of letter-spacing *and* a font-size scale, without
+ * ever exceeding the kerning ratio allowed by the current font size.
+ *
+ * Given:
+ *  - `naturalWidthPx` — measured width of the label at its base font size (`baseFontSizePx`),
+ *    single-line, no letter-spacing.
+ *  - `rowWidthPx`     — available row width the label should fill.
+ *  - `charCount`      — number of characters in the label (`≥ 2`).
+ *  - `maxTrackingRatio` — the largest allowed `letterSpacing / fontSize` before we grow the font.
+ *  - `maxFontScale` — hard cap on how much the font can grow (protects against runaway growth
+ *    when the label is very short relative to the row).
+ *
+ * Returns the pair (`fontScale`, `letterSpacingPx`) that lands the label exactly on
+ * `rowWidthPx`, subject to the two constraints. If the label is already wider than the row
+ * the result is `(1f, 0f)` — no justification, let the label render at its natural size.
+ *
+ * ### Math (closed form, one branch)
+ *
+ * With `n = charCount`, `W₀ = naturalWidthPx`, `f₀ = baseFontSizePx`, `W = rowWidthPx`,
+ * `α = maxTrackingRatio`, and unknowns `s` (font scale) & `k` (letter-spacing px):
+ *
+ *  - Total width: `s·W₀ + (n − 1)·k = W`
+ *  - Kerning cap: `k ≤ α · s · f₀`
+ *
+ * **Phase A** (kerning suffices) — try `s = 1`, `k = (W − W₀) / (n − 1)`. If `k ≤ α · f₀`
+ * we accept it and return.
+ *
+ * **Phase B** (kerning saturated) — set `k = α · s · f₀`, substitute:
+ * `s · W₀ + (n − 1) · α · s · f₀ = W`, so `s = W / (W₀ + (n − 1) · α · f₀)`. Then
+ * `k = α · s · f₀`. Clamp `s` at [`1`, `maxFontScale`]; if it clamped high, the label ends up
+ * shorter than the row (accept a small gap rather than distort further).
+ */
+internal fun solveHybridJustify(
+    naturalWidthPx: Float,
+    rowWidthPx: Float,
+    charCount: Int,
+    baseFontSizePx: Float,
+    maxTrackingRatio: Float = 0.15f,
+    maxFontScale: Float = 1.5f,
+    minFontScale: Float = 0.5f,
+): Pair<Float, Float> {
+    if (charCount < 1 || naturalWidthPx <= 0f || rowWidthPx <= 0f) return 1f to 0f
+
+    // Shrink branch — natural width overflows the row. Scale the font DOWN just enough to fit on
+    // one line (no kerning). This replaces the old bail-out that let the label auto-wrap into
+    // ugly single-letter overhangs ("Generat\ne", "Projec\nt"). Clamped to `minFontScale` so we
+    // never render the label at a fraction so small it becomes unreadable — beyond that the caller
+    // is expected to have disabled soft-wrap and let the text clip on its own.
+    if (naturalWidthPx >= rowWidthPx) {
+        val s = (rowWidthPx / naturalWidthPx).coerceIn(minFontScale, 1f)
+        return s to 0f
+    }
+
+    // Single-character labels can't be kerned (no inter-character gap). No fill, no scale — the
+    // label sits at its natural size with `TextAlign` handling positioning.
+    if (charCount < 2) return 1f to 0f
+
+    val n = charCount
+    val gaps = (n - 1).toFloat()
+
+    // Phase A: try to fill with kerning alone at s = 1.
+    val kAtScale1 = (rowWidthPx - naturalWidthPx) / gaps
+    if (kAtScale1 <= maxTrackingRatio * baseFontSizePx) {
+        return 1f to kAtScale1
+    }
+
+    // Phase B: kerning saturated → grow the font so `k = α·s·f₀` fills the row exactly.
+    val denom = naturalWidthPx + gaps * maxTrackingRatio * baseFontSizePx
+    val s = (rowWidthPx / denom).coerceIn(1f, maxFontScale)
+    val k = maxTrackingRatio * s * baseFontSizePx
+    return s to k
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzKinetics.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzKinetics.kt
@@ -1,0 +1,185 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzEntrance
+import com.hereliesaz.aznavrail.model.AzExit
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Returns a [Modifier] that plays a Windows-Phone-7 entrance/exit and an optional [tiltOnPress] 3D
+ * tilt, all written through a single [graphicsLayer] block so they never clobber each other (or an
+ * existing [baseRotationZ]).
+ *
+ * The animation is driven by [visible]: when it is `true` the item plays its [entrance] (staggered by
+ * [index]); when it flips `false` it plays its [exit] (reverse-staggered, last item first). Callers
+ * that want an exit must keep the item composed until the exit finishes — see the "closing state" in
+ * `AzDropdownMenu`/`AzNavRail`.
+ *
+ * When [floating] is true (the rail in FAB mode) there is no docked edge to hinge a turnstile from, so
+ * the cascade degrades to a vertical up/down slide while keeping the per-item stagger.
+ *
+ * The tilt gesture only *observes* pointer events (never consumes them), so the item's own
+ * `clickable`/`onClick` still fires.
+ *
+ * @param index Stable positional index of the item; drives the [staggerMs] cascade.
+ * @param count Total item count, used to reverse the stagger on exit.
+ * @param dockingSide Which edge the panel is docked to — the turnstile hinges on that edge.
+ * @param baseRotationZ A pre-existing Z rotation to preserve (e.g. the rail's landscape upright text).
+ */
+@Composable
+internal fun rememberAzKineticModifier(
+    index: Int,
+    count: Int,
+    visible: Boolean,
+    entrance: AzEntrance,
+    exit: AzExit,
+    staggerMs: Int,
+    durationMs: Int,
+    easing: Easing,
+    startAngle: Float,
+    tiltOnPress: Boolean,
+    maxTiltDegrees: Float,
+    dockingSide: AzDockingSide,
+    floating: Boolean = false,
+    baseRotationZ: Float = 0f,
+): Modifier {
+    val density = LocalDensity.current.density
+    val cascadeDist = 20f * density
+
+    // Hidden (pre-entrance) pose. In FAB mode, or for SlideUp, the cascade is a vertical slide.
+    val hiddenRotY = if (!floating && entrance == AzEntrance.Turnstile) startAngle else 0f
+    // Pure Turnstile (docked): rotation only, no fade — the item swings from edge-on to flat.
+    // Fade/SlideUp still fade in; None stays fully opaque.
+    val entranceUsesAlpha = entrance == AzEntrance.Fade || entrance == AzEntrance.SlideUp ||
+        (entrance == AzEntrance.Turnstile && floating)
+    val hiddenAlpha = if (entranceUsesAlpha) 0f else 1f
+    val hiddenTransY =
+        if (entrance != AzEntrance.None && (floating || entrance == AzEntrance.SlideUp)) cascadeDist else 0f
+
+    // Exit pose. None means "do not animate out" (the parent just unmounts).
+    val exitRotY = if (!floating && exit == AzExit.Turnstile) startAngle else 0f
+    val exitUsesAlpha = exit == AzExit.Fade || (exit == AzExit.Turnstile && floating)
+    val exitAlpha = if (exitUsesAlpha) 0f else 1f
+    val exitTransY = if (exit != AzExit.None && floating) -cascadeDist else 0f
+
+    val rotY = remember { Animatable(hiddenRotY) }
+    val alpha = remember { Animatable(hiddenAlpha) }
+    val transY = remember { Animatable(hiddenTransY) }
+
+    LaunchedEffect(visible) {
+        val spec = tween<Float>(durationMillis = durationMs, easing = easing)
+        if (visible) {
+            if (entrance == AzEntrance.None) {
+                launch { rotY.snapTo(0f) }
+                launch { alpha.snapTo(1f) }
+                launch { transY.snapTo(0f) }
+                return@LaunchedEffect
+            }
+            delay(index.toLong() * staggerMs)
+            launch { alpha.animateTo(1f, spec) }
+            launch { rotY.animateTo(0f, spec) }
+            launch { transY.animateTo(0f, spec) }
+        } else {
+            if (exit == AzExit.None) return@LaunchedEffect
+            // Exit cascade is a symmetric mirror of the entrance: on open, item[0] starts at t=0
+            // and the footer arrives at t = count·stagger; on close, the footer folds at t=0 and
+            // item[count-1] starts one stagger tick later, so the eye reads "footer goes first,
+            // then items swing away from the bottom up". The `(count - index)` offset shifts the
+            // whole reverse-cascade by one tick to make room for the footer's fold.
+            delay((count - index).coerceAtLeast(0).toLong() * staggerMs)
+            launch { alpha.animateTo(exitAlpha, spec) }
+            launch { rotY.animateTo(exitRotY, spec) }
+            launch { transY.animateTo(exitTransY, spec) }
+        }
+    }
+
+    // Tilt-on-press state.
+    var tiltX by remember { mutableStateOf(0f) }
+    var tiltY by remember { mutableStateOf(0f) }
+    val tiltRotX = remember { Animatable(0f) }
+    val tiltRotY = remember { Animatable(0f) }
+
+    val hingeX = if (dockingSide == AzDockingSide.LEFT) 0f else 1f
+
+    var modifier = Modifier.graphicsLayer {
+        rotationZ = baseRotationZ
+        rotationY = rotY.value + tiltRotY.value
+        rotationX = tiltRotX.value
+        this.alpha = alpha.value
+        translationY = transY.value
+        transformOrigin = TransformOrigin(hingeX, 0.5f)
+        cameraDistance = 14f * density
+    }
+
+    if (tiltOnPress) {
+        modifier = modifier.pointerInput(tiltOnPress, maxTiltDegrees) {
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                val nx = (down.position.x / size.width) * 2f - 1f
+                val ny = (down.position.y / size.height) * 2f - 1f
+                tiltY = nx * maxTiltDegrees
+                tiltX = -ny * maxTiltDegrees
+                waitForUpOrCancellation()
+                tiltY = 0f
+                tiltX = 0f
+            }
+        }
+        LaunchedEffect(tiltX, tiltY) {
+            launch { tiltRotX.animateTo(tiltX, if (tiltX == 0f) spring() else tween(110)) }
+            launch { tiltRotY.animateTo(tiltY, if (tiltY == 0f) spring() else tween(110)) }
+        }
+    }
+
+    return modifier
+}
+
+/**
+ * Drives the "closing state" for a panel that wants an [AzExit]: returns whether the items should be
+ * **rendered** (kept composed) given the [open] target. When [open] flips false it stays true for the
+ * length of the staggered exit ([durationMs] + [count]·[staggerMs]) so the items can animate out,
+ * then flips false to let the caller tear the panel down. The `count·staggerMs` (rather than
+ * `(count-1)·staggerMs`) matches the exit-cascade shift in [rememberAzKineticModifier]: on close
+ * the footer folds first at t=0 and item[count-1] doesn't start until t=staggerMs, so the last
+ * item finishes at t = count·staggerMs + durationMs. With [exit] == [AzExit.None] it tracks
+ * [open] exactly (immediate teardown, the legacy behavior).
+ */
+@Composable
+internal fun rememberAzClosingState(
+    open: Boolean,
+    exit: AzExit,
+    count: Int,
+    staggerMs: Int,
+    durationMs: Int,
+): Boolean {
+    var rendered by remember { mutableStateOf(open) }
+    LaunchedEffect(open) {
+        if (open) {
+            rendered = true
+        } else if (rendered) {
+            if (exit != AzExit.None) {
+                delay(durationMs.toLong() + count.coerceAtLeast(0).toLong() * staggerMs)
+            }
+            rendered = false
+        }
+    }
+    return rendered
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzLayoutConfig.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzLayoutConfig.kt
@@ -1,0 +1,48 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
+
+/**
+ * Resolves the bottom safe-zone inset for on-screen content.
+ *
+ * In gesture navigation the library imposes **no** bottom margin (content runs edge-to-edge —
+ * there is no button bar to clear). In button navigation it returns the larger of the 10%
+ * content safe-zone and the system navigation-bar inset.
+ *
+ * @param gestureNav Whether the device is in gesture-navigation mode (see [AzNavMode]).
+ * @param contentSafeZone The 10%-of-screen content safe-zone candidate.
+ * @param systemBarInset The system navigation-bar bottom inset candidate.
+ */
+internal fun azResolveSafeBottom(gestureNav: Boolean, contentSafeZone: Dp, systemBarInset: Dp): Dp =
+    if (gestureNav) 0.dp else max(contentSafeZone, systemBarInset)
+
+/**
+ * Screen-percentage constants used to compute safe zones in [com.hereliesaz.aznavrail.AzHostActivityLayout].
+ *
+ * The content area starts below the top safe zone and ends above the bottom safe zone.
+ * The rail itself also enforces inner safe zones to avoid overlapping system bars.
+ */
+object AzLayoutConfig {
+    /** The content area begins this far down from the top of the screen (20 %). */
+    const val ContentSafeTopPercent = 0.2f
+    /** The content area ends this far from the bottom of the screen (10 %). */
+    const val ContentSafeBottomPercent = 0.1f
+    /** The rail surface begins this far from the top (10 %). */
+    const val RailSafeTopPercent = 0.1f
+    /** The rail surface ends this far from the bottom (10 %). */
+    const val RailSafeBottomPercent = 0.1f
+}
+
+/**
+ * Computed safe-zone insets injected via [com.hereliesaz.aznavrail.LocalAzSafeZones] to
+ * prevent content from overlapping system bars or the screen's forbidden top/bottom 10 % strip.
+ *
+ * @param top The top inset in dp (max of 20 % screen height and the system-bar top padding).
+ * @param bottom The bottom inset in dp (max of 10 % screen height and the system-bar bottom padding).
+ */
+data class AzSafeZones(
+    val top: Dp = 0.dp,
+    val bottom: Dp = 0.dp
+)

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzMarkdown.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzMarkdown.kt
@@ -1,0 +1,219 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.AzDivider
+
+/**
+ * A dependency-free Markdown renderer tuned to the AzNavRail aesthetic.
+ *
+ * It is intentionally lightweight (no third-party markdown library): it covers the common subset
+ * found in repo docs — ATX headings, paragraphs, bold/italic, inline code, fenced code blocks,
+ * unordered/ordered lists, block-quotes, horizontal rules, and links — and themes every element
+ * from [MaterialTheme] with [activeColor] used for links and accents, matching the rest of the rail.
+ */
+@Composable
+internal fun AzMarkdown(
+    markdown: String,
+    activeColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    val codeBg = if (activeColor != Color.Unspecified) {
+        activeColor.copy(alpha = 0.08f)
+    } else {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+    }
+    val accent = if (activeColor != Color.Unspecified) activeColor else MaterialTheme.colorScheme.primary
+
+    Column(modifier = modifier) {
+        val lines = markdown.replace("\r\n", "\n").split("\n")
+        var i = 0
+        val paragraph = StringBuilder()
+
+        @Composable
+        fun flushParagraph() {
+            if (paragraph.isNotBlank()) {
+                Text(
+                    text = parseInline(paragraph.toString().trim(), accent),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+            paragraph.setLength(0)
+        }
+
+        while (i < lines.size) {
+            val raw = lines[i]
+            val line = raw.trimEnd()
+            when {
+                // Fenced code block
+                line.trimStart().startsWith("```") -> {
+                    flushParagraph()
+                    val code = StringBuilder()
+                    i++
+                    while (i < lines.size && !lines[i].trimStart().startsWith("```")) {
+                        code.appendLine(lines[i]); i++
+                    }
+                    CodeBlock(code.toString().trimEnd(), codeBg)
+                    Spacer(Modifier.height(8.dp))
+                }
+                // Horizontal rule
+                line.trim().let { it == "---" || it == "***" || it == "___" } -> {
+                    flushParagraph()
+                    AzDivider()
+                    Spacer(Modifier.height(8.dp))
+                }
+                // ATX heading
+                Regex("^#{1,6} ").containsMatchIn(line) -> {
+                    flushParagraph()
+                    val level = line.takeWhile { it == '#' }.length
+                    val text = line.drop(level).trim()
+                    Text(
+                        text = parseInline(text, accent),
+                        style = headingStyleFor(level),
+                        color = if (level <= 2) accent else MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                }
+                // Block quote
+                line.trimStart().startsWith(">") -> {
+                    flushParagraph()
+                    val quote = line.trimStart().removePrefix(">").trim()
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        Box(
+                            Modifier
+                                .width(3.dp)
+                                .height(20.dp)
+                                .background(accent)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = parseInline(quote, accent),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                        )
+                    }
+                    Spacer(Modifier.height(6.dp))
+                }
+                // List item (unordered or ordered)
+                Regex("^\\s*([-*+] |\\d+\\. )").containsMatchIn(raw) -> {
+                    flushParagraph()
+                    val indent = raw.takeWhile { it == ' ' }.length
+                    val ordered = Regex("^\\s*\\d+\\. ").find(raw)
+                    val bullet = ordered?.value?.trim() ?: "•"
+                    val content = raw.trimStart().replaceFirst(Regex("^([-*+] |\\d+\\. )"), "")
+                    Row(modifier = Modifier.padding(start = (8 + indent * 4).dp)) {
+                        Text("$bullet ", style = MaterialTheme.typography.bodyLarge, color = accent)
+                        Text(
+                            text = parseInline(content, accent),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                    Spacer(Modifier.height(2.dp))
+                }
+                line.isBlank() -> flushParagraph()
+                else -> {
+                    if (paragraph.isNotEmpty()) paragraph.append(' ')
+                    paragraph.append(line.trim())
+                }
+            }
+            i++
+        }
+        flushParagraph()
+    }
+}
+
+@Composable
+private fun CodeBlock(code: String, background: Color) {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .background(background, RoundedCornerShape(8.dp))
+            .horizontalScroll(rememberScrollState())
+            .padding(PaddingValues(12.dp))
+    ) {
+        Text(
+            text = code,
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun headingStyleFor(level: Int) = when (level) {
+    1 -> MaterialTheme.typography.headlineMedium
+    2 -> MaterialTheme.typography.headlineSmall
+    3 -> MaterialTheme.typography.titleLarge
+    4 -> MaterialTheme.typography.titleMedium
+    else -> MaterialTheme.typography.titleSmall
+}
+
+private val INLINE = Regex(
+    "`([^`]+)`" +                       // 1: code
+        "|\\*\\*([^*]+)\\*\\*" +        // 2: bold
+        "|__([^_]+)__" +                // 3: bold
+        "|\\*([^*]+)\\*" +              // 4: italic
+        "|_([^_]+)_" +                  // 5: italic
+        "|\\[([^\\]]+)\\]\\(([^)]+)\\)" // 6: link text, 7: url
+)
+
+/** Parses inline markdown (code, bold, italic, links) into a themed [AnnotatedString]. */
+internal fun parseInline(text: String, accent: Color): AnnotatedString = buildAnnotatedString {
+    var last = 0
+    for (m in INLINE.findAll(text)) {
+        if (m.range.first > last) append(text.substring(last, m.range.first))
+        val g = m.groupValues
+        when {
+            g[1].isNotEmpty() -> withStyle(SpanStyle(fontFamily = FontFamily.Monospace, color = accent)) { append(g[1]) }
+            g[2].isNotEmpty() -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(g[2]) }
+            g[3].isNotEmpty() -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(g[3]) }
+            g[4].isNotEmpty() -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(g[4]) }
+            g[5].isNotEmpty() -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(g[5]) }
+            g[6].isNotEmpty() -> withLink(
+                LinkAnnotation.Url(
+                    g[7],
+                    TextLinkStyles(SpanStyle(color = accent, textDecoration = TextDecoration.Underline)),
+                )
+            ) { append(g[6]) }
+        }
+        last = m.range.last + 1
+    }
+    if (last < text.length) append(text.substring(last))
+}
+
+/** [buildAnnotatedString] helper mirroring the stdlib's `withStyle` to keep call sites terse. */
+private inline fun AnnotatedString.Builder.withStyle(style: SpanStyle, block: AnnotatedString.Builder.() -> Unit) {
+    val idx = pushStyle(style)
+    try { block() } finally { pop(idx) }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailDefaults.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailDefaults.kt
@@ -1,0 +1,44 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.ui.unit.dp
+
+/**
+ * Default dimension and sentinel-value constants used throughout the AzNavRail rendering system.
+ *
+ * Ported verbatim from the Android module's `internal/RailState.kt`. Kept in its own file here so it
+ * can live in `commonMain` — the Android original shares a file with `AzNavRailLogger` (which uses
+ * `android.util.Log`), which is a Tier-2 file expect/actual will unblock later. Because the values
+ * are compile-time constants that never diverge across platforms, the small duplication is safe.
+ */
+internal object AzNavRailDefaults {
+    /** Minimum horizontal drag distance (px) before a swipe-to-open gesture is recognised. */
+    const val SWIPE_THRESHOLD_PX = 20f
+    /** FAB-mode: distance from origin (px) within which the rail snaps back to its docked position. */
+    const val SNAP_BACK_RADIUS_PX = 50f
+    /** Padding applied to the header row on all sides. */
+    val HeaderPadding = 8.dp
+
+    /** Strict unified button width shared by all rail items, app icons, and nested-rail items. */
+    val ButtonWidth = 72.dp
+    /** Reduced button width used when a vertical nested rail popup is open. */
+    val ShrunkButtonWidth = 56.dp
+
+    val HeaderTextSpacer = 8.dp
+    val RailContentHorizontalPadding = 4.dp
+    /** Vertical gap between rail buttons when not in packed mode. */
+    val RailContentVerticalArrangement = 8.dp
+    /** Height of the spacer rendered in place of a divider item in the collapsed rail. */
+    val RailContentSpacerHeight = 72.dp
+    val MenuItemHorizontalPadding = 24.dp
+    val MenuItemVerticalPadding = 12.dp
+    val FooterDividerHorizontalPadding = 16.dp
+    val FooterDividerVerticalPadding = 8.dp
+    val FooterSpacerHeight = 12.dp
+    /** Fixed height of the header row (matching the standard button width for alignment). */
+    val HeaderHeightDp = 72.dp
+
+    /** Sentinel value for `AzNavItem.screenTitle` meaning "do not show a title". */
+    const val NO_TITLE = "NO_TITLE_AZ_NAV_RAIL"
+    /** Auto-generated ID used for the implicit help button injected when no explicit help item is present. */
+    const val AUTO_HELP_ID = "AZ_AUTO_HELP_ID_INTERNAL"
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.kt
@@ -1,0 +1,27 @@
+package com.hereliesaz.aznavrail.internal
+
+/**
+ * Logger for AzNavRail internal events.
+ *
+ * The Android sibling uses `android.util.Log`. In the multiplatform module the same object exposes
+ * the same API but routes each call through [platformLogE], which each target implements natively
+ * (Android → `Log.e`, everything else → `println` to stderr with a stack-trace dump).
+ */
+internal object AzNavRailLogger {
+    /** Whether logging is enabled. */
+    var enabled: Boolean = true
+
+    /** Logs an error via the platform's native logger. No-ops when [enabled] is false. */
+    fun e(tag: String, message: String, throwable: Throwable? = null) {
+        if (enabled) {
+            platformLogE(tag, message, throwable)
+        }
+    }
+}
+
+/**
+ * Platform-specific error log implementation. Fanned out via `expect/actual`:
+ *  - Android → `android.util.Log.e(tag, message, throwable)`
+ *  - Desktop/iOS/wasmJs → `println("E/$tag: $message")` + `throwable?.printStackTrace()`.
+ */
+internal expect fun platformLogE(tag: String, message: String, throwable: Throwable?)

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzSheetGestures.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzSheetGestures.kt
@@ -1,0 +1,80 @@
+// FILE: ./aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzSheetGestures.kt
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import com.hereliesaz.aznavrail.bottomsheet.AzSheetController
+
+/**
+ * Vertical drag detector that mirrors LogKitty's accumulated-delta gesture.
+ *
+ * `dragAmount` from [detectVerticalDragGestures] is per-frame; we sum it across the gesture and
+ * step the [controller] exactly once when the cumulative displacement crosses [thresholdDp].
+ * The accumulator and the "fired" latch reset on `onDragStart`, `onDragCancel`, and `onDragEnd`
+ * so the next gesture starts fresh.
+ *
+ * Up-drag (negative accumulator) calls [AzSheetController.stepUp]; down-drag calls
+ * [AzSheetController.stepDown] to descend one detent at a time (mirroring the up-drag),
+ * so dragging down from FULL goes FULL → HALF → PEEK → HIDDEN rather than collapsing in one step.
+ * When [AzSheetController.isEnabled] is `false`, drags are ignored.
+ */
+internal fun Modifier.azSheetVerticalDrag(
+    controller: AzSheetController,
+    density: Density,
+    thresholdDp: Dp,
+): Modifier = this.pointerInput(controller, thresholdDp) {
+    val thresholdPx = with(density) { thresholdDp.toPx() }
+    var accumulated = 0f
+    var fired = false
+    detectVerticalDragGestures(
+        onDragStart = { accumulated = 0f; fired = false },
+        onDragCancel = { accumulated = 0f; fired = false },
+        onDragEnd = { accumulated = 0f; fired = false },
+    ) { change, dragAmount ->
+        if (fired || !controller.isEnabled) return@detectVerticalDragGestures
+        accumulated += dragAmount
+        when {
+            accumulated <= -thresholdPx -> {
+                controller.stepUp()
+                fired = true
+                change.consume()
+            }
+            accumulated >= thresholdPx -> {
+                controller.stepDown()
+                fired = true
+                change.consume()
+            }
+        }
+    }
+}
+
+/**
+ * Horizontal drag detector for tab-style navigation. Fires [onSwipeLeft] or [onSwipeRight]
+ * exactly once per gesture when the cumulative horizontal displacement exceeds [thresholdDp].
+ */
+internal fun Modifier.azSheetHorizontalSwipe(
+    density: Density,
+    thresholdDp: Dp,
+    onSwipeLeft: () -> Unit,
+    onSwipeRight: () -> Unit,
+): Modifier = this.pointerInput(thresholdDp) {
+    val thresholdPx = with(density) { thresholdDp.toPx() }
+    var accumulated = 0f
+    var fired = false
+    detectHorizontalDragGestures(
+        onDragStart = { accumulated = 0f; fired = false },
+        onDragCancel = { accumulated = 0f; fired = false },
+        onDragEnd = { accumulated = 0f; fired = false },
+    ) { change, dragAmount ->
+        if (fired) return@detectHorizontalDragGestures
+        accumulated += dragAmount
+        when {
+            accumulated <= -thresholdPx -> { onSwipeLeft(); fired = true; change.consume() }
+            accumulated >= thresholdPx -> { onSwipeRight(); fired = true; change.consume() }
+        }
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzSheetMetrics.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzSheetMetrics.kt
@@ -1,0 +1,46 @@
+// FILE: ./aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzSheetMetrics.kt
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.ui.unit.Dp
+import com.hereliesaz.aznavrail.model.AzSheetConfig
+import com.hereliesaz.aznavrail.model.AzSheetDetent
+
+/**
+ * Resolves the target [Dp] height for a given [detent] inside a container of [parentHeight].
+ *
+ * The fractions for HALF/FULL come from [AzSheetConfig.halfFraction] / [AzSheetConfig.fullFraction];
+ * PEEK and HIDDEN use absolute values from [AzSheetConfig.peekDp] / [AzSheetConfig.hiddenStripDp].
+ */
+internal fun heightForDetent(
+    detent: AzSheetDetent,
+    parentHeight: Dp,
+    config: AzSheetConfig,
+): Dp = when (detent) {
+    AzSheetDetent.HIDDEN -> config.hiddenStripDp
+    AzSheetDetent.PEEK -> config.peekDp
+    AzSheetDetent.HALF -> parentHeight * config.halfFraction
+    AzSheetDetent.FULL -> parentHeight * config.fullFraction
+}
+
+/**
+ * Pixels by which the system-overlay sheet window should grow *downward*, into the
+ * navigation-bar region, when [AzSheetConfig.drawBehindNavBar] is enabled.
+ *
+ * The window stays anchored `Gravity.BOTTOM` with `y = 0`, so adding this to the window height
+ * extends it behind the bar without moving the top edge of any detent. The growth only applies in
+ * button navigation, where the measured navigation-bar inset is non-zero; in gesture navigation the
+ * inset is ~0, making this a no-op.
+ *
+ * Crucially this is *not* added to the consumer-visible detent height — the exposed (above-bar)
+ * height stays the value the consumer sized its detents to. Only the actual window grows; the extra
+ * band is where content flows behind the nav-bar buttons.
+ *
+ * @param drawBehindNavBar [AzSheetConfig.drawBehindNavBar].
+ * @param buttonNav Whether the device uses button (3-button / 2-button) navigation.
+ * @param navBarInsetPx The measured navigation-bar inset in pixels (0 in gesture navigation).
+ */
+internal fun navBarExtensionPx(
+    drawBehindNavBar: Boolean,
+    buttonNav: Boolean,
+    navBarInsetPx: Int,
+): Int = if (drawBehindNavBar && buttonNav && navBarInsetPx > 0) navBarInsetPx else 0

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/DissolveOverlay.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/DissolveOverlay.kt
@@ -1,0 +1,135 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.zIndex
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/**
+ * State handle for a single tapped-and-dismissing menu item. When the user taps a menu item whose
+ * click causes the drawer to close (`collapseOnClick = true`), the drawer captures the item's
+ * rendered text and window-space bounds, stores them here, and mounts a [DissolveOverlay] that
+ * slides the text toward the middle of the screen while fading it out — while the rest of the
+ * items run their normal bottom-up exit cascade.
+ *
+ * The original item slot is skipped from the exit render so the label doesn't animate in two
+ * places at once.
+ */
+internal data class DissolveState(
+    val itemId: String,
+    val text: String,
+    val bounds: Rect,
+)
+
+/**
+ * A full-screen [Popup] that renders the tapped menu item's label at its captured [DissolveState]
+ * position and animates it: `translationX` from `0` toward the middle of the screen, `alpha` from
+ * `1` to `0`. Runs over [durationMs] with [easing] (default WP7 decelerate). Calls [onFinished]
+ * once the animation completes so the caller can clear its state.
+ *
+ * The popup deliberately uses `clippingEnabled = false` and `focusable = false` so the slide can
+ * cross the rail's docked edge, and taps still fall through to whatever is behind the drawer.
+ */
+@Composable
+internal fun DissolveOverlay(
+    state: DissolveState,
+    textStyle: TextStyle,
+    color: Color,
+    durationMs: Int,
+    easing: Easing,
+    onFinished: () -> Unit,
+) {
+    val density = LocalDensity.current
+    val translateX = remember { Animatable(0f) }
+    val alpha = remember { Animatable(1f) }
+
+    Popup(
+        properties = PopupProperties(clippingEnabled = false, focusable = false),
+        // The popup itself fills the window (its content is `Box(fillMaxSize)`). The actual label
+        // is positioned by an `.offset(x, y)` inside that Box, so we don't need any anchor here.
+        popupPositionProvider = TopLeftPositionProvider,
+    ) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                // Belt-and-braces above the rail. Popup already renders in a separate window layer
+                // above sibling Compose content, but max-z inside the Popup's own container guards
+                // the ordering even if the overlay ever ends up sharing a layer with another node.
+                .zIndex(Float.MAX_VALUE),
+        ) {
+            // Screen center X in px — the label's `translationX` targets this from its captured
+            // left edge, minus half the label's width so its centre lands on the screen centre.
+            val screenWidthPx = androidx.compose.ui.platform.LocalWindowInfo.current.containerSize.width.toFloat()
+            val labelCenterX = state.bounds.left + state.bounds.width / 2f
+            val targetTranslateX = (screenWidthPx / 2f) - labelCenterX
+
+            LaunchedEffect(state.itemId, targetTranslateX) {
+                val spec = tween<Float>(durationMillis = durationMs, easing = easing)
+                launch { translateX.animateTo(targetTranslateX, spec) }
+                launch { alpha.animateTo(0f, spec) }
+                kotlinx.coroutines.delay(durationMs.toLong() + 16L)
+                onFinished()
+            }
+
+            Box(
+                modifier = Modifier
+                    .offset {
+                        IntOffset(
+                            (state.bounds.left + translateX.value).roundToInt(),
+                            state.bounds.top.roundToInt(),
+                        )
+                    }
+                    .size(
+                        width = with(density) { state.bounds.width.toDp() },
+                        height = with(density) { state.bounds.height.toDp() },
+                    )
+                    .graphicsLayer { this.alpha = alpha.value },
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Text(
+                    text = state.text,
+                    style = textStyle,
+                    color = color,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier.padding(horizontal = AzNavRailDefaults.MenuItemHorizontalPadding),
+                )
+            }
+        }
+    }
+}
+
+private object TopLeftPositionProvider : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset = IntOffset(0, 0)
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/RelocItemHandler.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/RelocItemHandler.kt
@@ -1,0 +1,163 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.ui.geometry.Rect
+import com.hereliesaz.aznavrail.model.AzNavItem
+
+/**
+ * Helper object to manage RelocItem interactions.
+ */
+object RelocItemHandler {
+
+    /**
+     * Finds the contiguous cluster of RelocItems surrounding the given item.
+     * Returns the start and end indices (inclusive) in the list.
+     */
+    fun findCluster(items: List<AzNavItem>, itemId: String): IntRange? {
+        val index = items.indexOfFirst { it.id == itemId }
+        if (index == -1) return null
+
+        val item = items[index]
+        if (!item.isRelocItem || item.hostId == null) return null
+
+        var start = index
+        while (start > 0) {
+            val prev = items[start - 1]
+            if (prev.isRelocItem && prev.hostId == item.hostId) {
+                start--
+            } else {
+                break
+            }
+        }
+
+        var end = index
+        while (end < items.lastIndex) {
+            val next = items[end + 1]
+            if (next.isRelocItem && next.hostId == item.hostId) {
+                end++
+            } else {
+                break
+            }
+        }
+
+        return start..end
+    }
+
+    /**
+     * Swaps items in the mutable list to reflect the drag operation.
+     * @param items The mutable list of items.
+     * @param draggedId The ID of the item being dragged.
+     * @param targetIndex The index where the dragged item should be.
+     */
+    fun updateOrder(items: MutableList<AzNavItem>, draggedId: String, targetIndex: Int) {
+        val currentIndex = items.indexOfFirst { it.id == draggedId }
+        if (currentIndex == -1) return
+        if (currentIndex == targetIndex) return
+
+        // Validation: Target must be within the cluster.
+        val cluster = findCluster(items, draggedId) ?: return
+        if (targetIndex !in cluster) return
+
+        val item = items.removeAt(currentIndex)
+        items.add(targetIndex, item)
+    }
+
+    /**
+     * Calculates the target index for a dragged item based on its drag offset and item heights.
+     */
+    fun calculateTargetIndex(
+        items: List<AzNavItem>,
+        draggedItemId: String,
+        currentDragOffset: Float,
+        itemHeights: Map<String, Int>
+    ): Int? {
+        val currentIndex = items.indexOfFirst { it.id == draggedItemId }
+        if (currentIndex == -1) return null
+
+        val cluster = findCluster(items, draggedItemId) ?: return null
+
+        var target = currentIndex
+        var remainingOffset = currentDragOffset
+
+        if (remainingOffset > 0) {
+            while (target < cluster.last) {
+                val nextItem = items[target + 1]
+                val nextHeight = itemHeights[nextItem.id] ?: 0
+                if (nextHeight == 0) break // Safety check
+
+                // User requested 40% overlap threshold
+                // If remaining offset covers > 40% of next item height, swap.
+                if (remainingOffset > nextHeight * 0.4f) {
+                    remainingOffset -= nextHeight
+                    target++
+                } else {
+                    break
+                }
+            }
+        } else {
+            while (target > cluster.first) {
+                val prevItem = items[target - 1]
+                val prevHeight = itemHeights[prevItem.id] ?: 0
+                if (prevHeight == 0) break // Safety check
+
+                // User requested 40% overlap threshold (negative direction)
+                if (remainingOffset < -(prevHeight * 0.4f)) {
+                    remainingOffset += prevHeight
+                    target--
+                } else {
+                    break
+                }
+            }
+        }
+        return target
+    }
+
+    /**
+     * Legacy/Alternative calculation using item bounds directly.
+     */
+    fun calculateTargetIndex(
+        items: List<AzNavItem>,
+        draggedItemId: String,
+        currentDragOffset: Float,
+        itemBounds: Map<String, Rect>,
+        isVertical: Boolean
+    ): Int? {
+        val currentIndex = items.indexOfFirst { it.id == draggedItemId }
+        if (currentIndex == -1) return null
+
+        val cluster = findCluster(items, draggedItemId) ?: return null
+
+        var target = currentIndex
+        var remainingOffset = currentDragOffset
+
+        if (remainingOffset > 0) {
+            while (target < cluster.last) {
+                val nextItem = items[target + 1]
+                val nextRect = itemBounds[nextItem.id] ?: break
+                val nextDim = if (isVertical) nextRect.height else nextRect.width
+                if (nextDim == 0f) break
+
+                if (remainingOffset > nextDim * 0.4f) {
+                    remainingOffset -= nextDim
+                    target++
+                } else {
+                    break
+                }
+            }
+        } else {
+            while (target > cluster.first) {
+                val prevItem = items[target - 1]
+                val prevRect = itemBounds[prevItem.id] ?: break
+                val prevDim = if (isVertical) prevRect.height else prevRect.width
+                if (prevDim == 0f) break
+
+                if (remainingOffset < -(prevDim * 0.4f)) {
+                    remainingOffset += prevDim
+                    target--
+                } else {
+                    break
+                }
+            }
+        }
+        return target
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzAboutModels.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzAboutModels.kt
@@ -1,0 +1,41 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * One entry in the auto-generated About table of contents: a markdown document discovered in the
+ * consuming app's GitHub repository (its root or `docs/` folder).
+ *
+ * @param title Humanized title derived from the filename (e.g. `MIGRATION_GUIDE.md` -> "Migration Guide").
+ * @param path Repository-relative path (e.g. `README.md`, `docs/API.md`). Used as a stable key.
+ * @param downloadUrl Raw download URL returned by the GitHub contents API, fetched lazily on open.
+ */
+data class AzDocEntry(
+    val title: String,
+    val path: String,
+    val downloadUrl: String
+)
+
+/**
+ * A fully-resolved app shown in the "More from Az" carousel. Resolution (name/icon/description and
+ * the Play/website links) is performed in CI and baked into `more-from-az.json`; the rail just reads
+ * these.
+ *
+ * @param name Display name (Play title or GitHub repo name).
+ * @param iconUrl That app's own icon URL (Play `og:image` or the app website's `og:image`), loaded
+ *   with Coil. Never the owner's GitHub avatar; blank falls back to the app's initials.
+ * @param description Short description (Play `og:description` or GitHub repo description).
+ * @param githubUrl Optional GitHub repository link.
+ * @param playStoreUrl Optional Google Play listing link.
+ * @param webUrl Optional website / PWA link.
+ * @param isPwa When true, [webUrl] is a PWA (an "Open" launch button); otherwise it's a "Website".
+ */
+data class AzMoreFromApp(
+    val name: String,
+    val iconUrl: String,
+    val description: String,
+    val githubUrl: String? = null,
+    val playStoreUrl: String? = null,
+    val webUrl: String? = null,
+    val isPwa: Boolean = false,
+    /** Optional banner (docs/banner.* in the app's repo) shown at the top of the app's info panel. */
+    val bannerUrl: String? = null,
+)

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzAdvancedConfig.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzAdvancedConfig.kt
@@ -1,0 +1,54 @@
+package com.hereliesaz.aznavrail.model
+
+import androidx.compose.ui.geometry.Rect
+
+/**
+ * Aggregated advanced settings for the rail, populated by [com.hereliesaz.aznavrail.AzNavRailScope.azAdvanced]
+ * and [com.hereliesaz.aznavrail.AzNavRailScope.azSettings].
+ *
+ * @param isLoading When true, the rail content is replaced by a full-screen [com.hereliesaz.aznavrail.AzLoad] spinner.
+ * @param helpEnabled Whether the interactive help/info overlay is enabled.
+ * @param onDismissHelp Callback invoked when the help overlay is dismissed.
+ * @param overlayService Service class used to launch a system overlay (FAB mode). Automatically
+ *   sets [enableRailDragging] to true when non-null.
+ * @param onUndock Callback invoked when the rail is undocked to FAB mode.
+ * @param enableRailDragging Whether the user can drag the rail to detach it (FAB mode).
+ * @param onRailDrag Callback reporting `(dx, dy)` during in-app drag events.
+ * @param onOverlayDrag Callback reporting `(dx, dy)` during system-overlay drag events.
+ * @param onItemGloballyPositioned Reports the window-space [Rect] of an item by its ID after layout;
+ *   primarily used by the tutorial and help systems.
+ * @param secLoc Developer configuration key that unlocks the Secret Screens debug menu.
+ *   Long-pressing the `@HereLiesAz` footer item prompts for this key.
+ * @param secLocPort TCP port used by the location history sync server. Defaults to 10203.
+ * @param helpList Map of item ID → help text (String or string resource Int) shown in the help overlay.
+ * @param onInteraction Callback invoked whenever any rail item is interacted with (click, toggle,
+ *   cycler advance, nested rail open, reloc drag). Receives the item's `id` and the [AzNavItem] itself.
+ * @param inAppAbout When true (default), the footer "About" item opens the in-app About reader overlay
+ *   (auto-generated from the repo's markdown docs) instead of opening [com.hereliesaz.aznavrail.AzNavRailScopeImpl.appRepositoryUrl]
+ *   in a browser.
+ * @param moreFromAzEnabled When true (default), the About overlay offers a "More from Az" entry that
+ *   opens a carousel of the library author's other apps, fetched from [moreFromAzJsonUrl].
+ * @param moreFromAzJsonUrl Raw URL of the JSON manifest backing the "More from Az" carousel. Its
+ *   `version` integer is CI-managed and used to invalidate the local cache.
+ * @param moreFromAzRailItem When true, a "More" item is pinned at the bottom of the collapsed rail
+ *   that opens the "More from Az" carousel directly (independent of the About screen).
+ */
+data class AzAdvancedConfig(
+    val isLoading: Boolean = false,
+    val helpEnabled: Boolean = false,
+    val onDismissHelp: (() -> Unit)? = null,
+    val overlayService: Class<out android.app.Service>? = null,
+    val onUndock: (() -> Unit)? = null,
+    val enableRailDragging: Boolean = false,
+    val onRailDrag: ((Float, Float) -> Unit)? = null,
+    val onOverlayDrag: ((Float, Float) -> Unit)? = null,
+    val onItemGloballyPositioned: ((String, Rect) -> Unit)? = null,
+    val secLoc: String? = null,
+    val secLocPort: Int = 10203,
+    val helpList: Map<String, Any> = emptyMap(),
+    val onInteraction: ((String, AzNavItem) -> Unit)? = null,
+    val inAppAbout: Boolean = true,
+    val moreFromAzEnabled: Boolean = true,
+    val moreFromAzJsonUrl: String = "https://raw.githubusercontent.com/HereLiesAz/AzNavRail/main/more-from-az.json",
+    val moreFromAzRailItem: Boolean = false
+)

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzButtonShape.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzButtonShape.kt
@@ -1,0 +1,13 @@
+package com.hereliesaz.aznavrail.model
+
+/** Shape options for AzNavRail buttons. */
+enum class AzButtonShape {
+    /** Renders as a circle (square dimensions, circular clip). */
+    CIRCLE,
+    /** Renders as a square with sharp corners. */
+    SQUARE,
+    /** Renders as a fixed-height wide rectangle (typically for text labels). */
+    RECTANGLE,
+    /** No border is drawn; the button is still interactive but visually borderless. */
+    NONE
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzComposableContent.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzComposableContent.kt
@@ -1,0 +1,24 @@
+package com.hereliesaz.aznavrail.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+
+/**
+ * A wrapper to provide custom @Composable content for AzNavRail items.
+ * Pass an instance of this to the `content` parameter of an item.
+ *
+ * Example usage:
+ * ```
+ * azRailItem(
+ *     id = "custom_item",
+ *     text = "Custom",
+ *     content = AzComposableContent { isEnabled ->
+ *         Box(modifier = Modifier.fillMaxSize().alpha(if (isEnabled) 1f else 0.5f)) {
+ *             // Custom layout
+ *         }
+ *     }
+ * )
+ * ```
+ */
+@Immutable
+data class AzComposableContent(val content: @Composable (isEnabled: Boolean) -> Unit)

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzDockingSide.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzDockingSide.kt
@@ -1,0 +1,14 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * The logical docking side of the AzNavRail.
+ *
+ * When [com.hereliesaz.aznavrail.AzNavRailScopeImpl.usePhysicalDocking] is true, the actual
+ * visual side adapts to device rotation; otherwise the rail sticks to the named screen edge.
+ */
+enum class AzDockingSide {
+    /** Rail anchored to the left edge of the screen. */
+    LEFT,
+    /** Rail anchored to the right edge of the screen. */
+    RIGHT
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzDropdownDesign.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzDropdownDesign.kt
@@ -1,0 +1,22 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * The visual design of an [com.hereliesaz.aznavrail.AzDropdownMenu]'s dropped panel.
+ *
+ * The panel is presented as a slice of the AzNavRail itself: pick whether it looks like the
+ * collapsed **rail** or the expanded **menu**. The choice drives both the item rendering and the
+ * panel's width (so it matches the rail/menu it imitates).
+ */
+enum class AzDropdownDesign {
+    /**
+     * The collapsed-rail look: compact rail buttons (icon/auto-sized text), constrained to the
+     * collapsed rail width (matching `azConfig`'s `collapsedWidth`, 100dp by default).
+     */
+    RAIL,
+
+    /**
+     * The expanded-menu look: full-width labeled rows, constrained to the expanded menu width
+     * (matching `azConfig`'s `expandedWidth`, 160dp by default).
+     */
+    MENU
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzHeaderIconShape.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzHeaderIconShape.kt
@@ -1,0 +1,13 @@
+package com.hereliesaz.aznavrail.model
+
+/** Shape of the app icon displayed in the rail header when [com.hereliesaz.aznavrail.AzNavRailScopeImpl.displayAppName] is false. */
+enum class AzHeaderIconShape {
+    /** Clips the icon to a perfect circle. */
+    CIRCLE,
+    /** No clipping — the icon is rendered as-is (typically square). */
+    SQUARE,
+    /** Clips the icon to a rounded rectangle (12 dp corner radius). */
+    ROUNDED,
+    /** Alias for SQUARE; no clip applied. */
+    NONE
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzItemConfig.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzItemConfig.kt
@@ -1,0 +1,48 @@
+package com.hereliesaz.aznavrail.model
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Transient parameter bundle passed from DSL builder methods to the private `addItem`,
+ * `addToggle`, and `addCycler` helpers inside [com.hereliesaz.aznavrail.AzNavRailScopeImpl].
+ *
+ * Not part of the public API; callers interact through [com.hereliesaz.aznavrail.AzNavRailScope].
+ *
+ * @param route Navigation route associated with the item.
+ * @param screenTitle Title displayed on the screen when this item is active.
+ * @param info Help description shown in the Help overlay.
+ * @param isRailItem Whether the item appears on the collapsed rail (vs. menu-only).
+ * @param disabled Whether the item is non-interactive.
+ * @param isHost Whether the item is a parent that can expand sub-items inline.
+ * @param isSubItem Whether the item is a child of a host item.
+ * @param hostId ID of the parent host item; required when [isSubItem] is true.
+ * @param classifiers Strings used for programmatic active-state highlighting.
+ * @param onFocus Callback invoked when the item receives focus (focus map wiring).
+ * @param content Custom visual content for the button (Color, resource Int, image model, or [AzComposableContent]).
+ * @param color Border/icon color override.
+ * @param textColor Text color override.
+ * @param fillColor Translucent fill color override.
+ * @param shape Button shape override; falls back to the scope's [com.hereliesaz.aznavrail.AzNavRailScopeImpl.defaultShape].
+ */
+data class AzItemConfig(
+    val route: String? = null,
+    val screenTitle: String? = null,
+    val info: String? = null,
+    val isRailItem: Boolean = false,
+    val disabled: Boolean = false,
+    val isHost: Boolean = false,
+    val isSubItem: Boolean = false,
+    val hostId: String? = null,
+    val classifiers: Set<String> = emptySet(),
+    val onFocus: (() -> Unit)? = null,
+    val content: Any? = null,
+    val color: Color? = null,
+    val textColor: Color? = null,
+    val fillColor: Color? = null,
+    val shape: AzButtonShape? = null,
+    /**
+     * Host items only: auto-expand the first time the host appears (user can
+     * still collapse).
+     */
+    val initiallyExpanded: Boolean = false
+)

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzKineticTypography.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzKineticTypography.kt
@@ -1,0 +1,32 @@
+package com.hereliesaz.aznavrail.model
+
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.Easing
+
+/**
+ * Windows-Phone-7-style entrance for a drop-down item. Items animate in when the panel opens,
+ * cascaded by their position (see `azConfig(entranceStaggerMs = …)`).
+ *
+ * - [None] — items appear immediately (default; no animation).
+ * - [Fade] — items fade up from transparent.
+ * - [SlideUp] — items rise into place (translation) while fading.
+ * - [Turnstile] — the signature WP7 sweep: each item swings in around its docked edge like a
+ *   turnstile (`rotationY` from `azConfig(entranceStartAngle = …)` back to flat).
+ */
+enum class AzEntrance { None, Fade, SlideUp, Turnstile }
+
+/**
+ * Optional exit for a drop-down item when the panel dismisses.
+ *
+ * Accepted by `azConfig` for API stability, but only [None] is honored today: the drop-down
+ * unmounts its items the instant it closes, so a true exit animation would require holding the
+ * items mounted through a "closing" state. Non-[None] values are reserved for a future release and
+ * currently behave like [None].
+ */
+enum class AzExit { None, Fade, Turnstile }
+
+/** Reusable easings for AzNavRail's kinetic typography. */
+object AzEasing {
+    /** WP7's signature fast-out / gentle-settle curve. Snappy. */
+    val Wp7Decelerate: Easing = CubicBezierEasing(0.1f, 0.9f, 0.2f, 1f)
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzMenuItemAlignment.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzMenuItemAlignment.kt
@@ -1,0 +1,10 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * How the text of a menu-drawer label is aligned inside its row.
+ *
+ * - [CENTER] — legacy behavior: center-aligned regardless of docking side.
+ * - [SIDE]   — aligned to the docked side (`Start` when docked LEFT, `End` when docked RIGHT).
+ *              This is the WP7-style default: labels hug the same edge the rail itself is anchored to.
+ */
+enum class AzMenuItemAlignment { CENTER, SIDE }

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzNavItem.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzNavItem.kt
@@ -1,0 +1,88 @@
+package com.hereliesaz.aznavrail.model
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * The unified, stateless data model for any item in the navigation rail or menu.
+ *
+ * Ported from the Android sibling verbatim EXCEPT that `@Parcelize` / `Parcelable` /
+ * `kotlinx.parcelize.RawValue` are dropped — those exist only on Android. The CMP copy is a plain
+ * data class. All fields keep the same name and defaults.
+ *
+ * See the Android sibling's KDoc for per-param docs — they apply here 1:1.
+ */
+data class AzNavItem(
+    val id: String,
+    val text: String,
+    val menuText: String? = null,
+    val route: String? = null,
+    val screenTitle: String? = null,
+    val isRailItem: Boolean,
+    val color: Color? = null,
+    val textColor: Color? = null,
+    val fillColor: Color? = null,
+    val isToggle: Boolean = false,
+    val isChecked: Boolean? = null,
+    val toggleOnText: String = "",
+    val toggleOffText: String = "",
+    val menuToggleOnText: String? = null,
+    val menuToggleOffText: String? = null,
+    val isCycler: Boolean = false,
+    val options: List<String>? = null,
+    val menuOptions: List<String>? = null,
+    val selectedOption: String? = null,
+    val isDivider: Boolean = false,
+    val collapseOnClick: Boolean = true,
+    val shape: AzButtonShape? = null,
+    val disabled: Boolean = false,
+    val disabledOptions: List<String>? = null,
+    val isHost: Boolean = false,
+    val isSubItem: Boolean = false,
+    val hostId: String? = null,
+    val isExpanded: Boolean = false,
+    /**
+     * When true, the host is auto-expanded the first time it appears (the user
+     * can still collapse it).
+     */
+    val initiallyExpanded: Boolean = false,
+    val info: String? = null,
+    val isRelocItem: Boolean = false,
+    val hiddenMenuItems: List<HiddenMenuItem>? = null,
+    val forceHiddenMenuOpen: Boolean = false,
+    val onHiddenMenuDismiss: (() -> Unit)? = null,
+    val classifiers: Set<String> = emptySet(),
+    val content: Any? = null,
+    val isNestedRail: Boolean = false,
+    val nestedRailAlignment: AzNestedRailAlignment? = null,
+    val nestedRailItems: List<AzNavItem>? = null,
+    val isHelpItem: Boolean = false,
+    val keepNestedRailOpen: Boolean = false,
+) {
+    companion object {
+        /**
+         * Factory method for creating an [AzNavItem] designated as a Help trigger.
+         */
+        fun Help(
+            id: String,
+            text: String = "Help",
+            menuText: String? = null,
+            isRailItem: Boolean = true,
+            content: Any? = null,
+            color: Color? = null,
+            textColor: Color? = null,
+            fillColor: Color? = null,
+            shape: AzButtonShape? = null,
+        ): AzNavItem = AzNavItem(
+            id = id,
+            text = text,
+            menuText = menuText,
+            isRailItem = isRailItem,
+            isHelpItem = true,
+            content = content,
+            color = color,
+            textColor = textColor,
+            fillColor = fillColor,
+            shape = shape,
+        )
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzNestedRailAlignment.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzNestedRailAlignment.kt
@@ -1,0 +1,9 @@
+package com.hereliesaz.aznavrail.model
+
+/** Controls how a nested rail popup lays out its child items. */
+enum class AzNestedRailAlignment {
+    /** Children stacked in a scrollable vertical column, centred beside the parent button. */
+    VERTICAL,
+    /** Children arranged in a scrollable horizontal row, aligned with the parent button vertically. */
+    HORIZONTAL
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzOrientation.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzOrientation.kt
@@ -1,0 +1,14 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * Physical orientation of the rail strip itself.
+ *
+ * Derived automatically from [com.hereliesaz.aznavrail.internal.AzRailLayoutHelper] based on
+ * the docking side and device rotation; not usually set directly by consumers.
+ */
+enum class AzOrientation {
+    /** Rail runs along a vertical (left or right) edge — the default portrait configuration. */
+    Vertical,
+    /** Rail runs along a horizontal (top or bottom) edge — used in landscape physical docking. */
+    Horizontal
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzSheetConfig.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzSheetConfig.kt
@@ -1,0 +1,64 @@
+// FILE: ./aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzSheetConfig.kt
+package com.hereliesaz.aznavrail.model
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Static configuration for [com.hereliesaz.aznavrail.bottomsheet.AzBottomSheet] and
+ * [com.hereliesaz.aznavrail.bottomsheet.AzBottomSheetWindowHost].
+ *
+ * All values have sensible defaults derived from the LogKitty bottom-sheet shell;
+ * override individually for tuning without breaking visual parity.
+ *
+ * @property backgroundColor Sheet background. Defaults to [Color.Unspecified], in which case the
+ *   in-tree shell substitutes `MaterialTheme.colorScheme.surface`.
+ * @property backgroundAlpha Alpha blended over [backgroundColor].
+ * @property scrimColor Color of the dim layer painted between the sheet and content underneath
+ *   when the sheet is at [AzSheetDetent.HALF] or [AzSheetDetent.FULL].
+ * @property scrimAlpha Alpha applied to [scrimColor] in the half/full states.
+ * @property hiddenStripDp Touch-target height of the otherwise-invisible swipe strip when at [AzSheetDetent.HIDDEN].
+ * @property peekDp Height of the [AzSheetDetent.PEEK] state. Mirrors LogKitty's single-line ticker.
+ * @property halfFraction Fraction of total height for [AzSheetDetent.HALF].
+ * @property fullFraction Fraction of total height for [AzSheetDetent.FULL].
+ * @property dragThresholdDp Cumulative vertical drag distance needed to step one detent.
+ *   The drag accumulator is reset between gestures so each gesture moves the sheet exactly one step.
+ * @property collapseOnBack When `true`, the system back press steps the sheet down rather than
+ *   forwarding the event. Honoured by [com.hereliesaz.aznavrail.bottomsheet.AzBottomSheetWindowHost]
+ *   only when its window is focusable.
+ * @property horizontalSwipeEnabled When `true`, horizontal drag on the header invokes the
+ *   `onSwipeLeft` / `onSwipeRight` callbacks (used by LogKitty for tab navigation).
+ * @property animateInTree When `true`, the in-tree shell uses [androidx.compose.animation.core.animateDpAsState]
+ *   to animate between detent heights. The system-overlay flavor always hard-jumps to match LogKitty's look.
+ * @property cornerRadiusDp Top-corner radius of the sheet card.
+ * @property handleVisible When `true`, draws a centered drag-handle pill at the top of the sheet.
+ * @property drawBehindNavBar When `true` **and** the device uses button navigation (3-button /
+ *   2-button), the sheet draws behind the system navigation bar: its exposed height above the bar
+ *   is unchanged, but the navigation-bar background is forced semi-transparent / see-through so
+ *   the sheet content shows through it. Has no effect in gesture navigation (the bar is already a
+ *   thin pill). In-tree this makes the host Activity's navigation bar see-through; in the
+ *   system-overlay flavor it makes the [com.hereliesaz.aznavrail.bottomsheet.AzBottomSheetWindowHost]
+ *   navigation-bar decoration paint semi-transparent. Defaults to `false`.
+ */
+data class AzSheetConfig(
+    val backgroundColor: Color = Color.Unspecified,
+    val backgroundAlpha: Float = 0.92f,
+    val scrimColor: Color = Color.Black,
+    val scrimAlpha: Float = 0.32f,
+    val hiddenStripDp: Dp = 28.dp,
+    // PEEK sits visibly above HIDDEN — the 56dp default was just slightly taller than the 28dp
+    // HIDDEN strip and the two looked nearly identical at runtime. 120dp gives ~92dp of body
+    // content area below the drag handle, so PEEK is unambiguously a step up from HIDDEN
+    // without overlapping HALF (`halfFraction = 0.5`).
+    val peekDp: Dp = 120.dp,
+    val halfFraction: Float = 0.5f,
+    val fullFraction: Float = 0.9f,
+    val dragThresholdDp: Dp = 24.dp,
+    val collapseOnBack: Boolean = true,
+    val horizontalSwipeEnabled: Boolean = false,
+    val animateInTree: Boolean = true,
+    val cornerRadiusDp: Dp = 16.dp,
+    val handleVisible: Boolean = true,
+    val drawBehindNavBar: Boolean = false,
+)

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzSheetDetent.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzSheetDetent.kt
@@ -1,0 +1,25 @@
+// FILE: ./aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzSheetDetent.kt
+package com.hereliesaz.aznavrail.model
+
+/**
+ * Discrete heights an [com.hereliesaz.aznavrail.bottomsheet.AzBottomSheet] can settle at.
+ *
+ * The four-step model mirrors the bottom-sheet shell ported from
+ * [LogKitty](https://github.com/HereLiesAz/LogKitty); consumers can step
+ * up/down with [com.hereliesaz.aznavrail.bottomsheet.AzSheetController.stepUp]
+ * and [com.hereliesaz.aznavrail.bottomsheet.AzSheetController.stepDown], or
+ * jump directly via [com.hereliesaz.aznavrail.bottomsheet.AzSheetController.snapTo].
+ */
+enum class AzSheetDetent {
+    /** A thin, near-invisible strip along the bottom edge that swallows a drag-up gesture but otherwise lets touches pass through. */
+    HIDDEN,
+
+    /** A short ticker-height strip that surfaces a single line of content. */
+    PEEK,
+
+    /** Roughly half the screen height (configurable via [AzSheetConfig.halfFraction]). */
+    HALF,
+
+    /** Nearly full screen height (configurable via [AzSheetConfig.fullFraction]). */
+    FULL,
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/HiddenMenuItem.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/HiddenMenuItem.kt
@@ -1,0 +1,27 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * Represents a single item in the hidden context menu of a relocatable rail item.
+ *
+ * Items are created via `com.hereliesaz.aznavrail.HiddenMenuScope` and stored on
+ * [AzNavItem.hiddenMenuItems].
+ *
+ * @param id Auto-generated unique ID scoped to the parent item.
+ * @param text Display text for list items; empty for input items.
+ * @param route Navigation route to trigger on click, or null for callback-only items.
+ * @param isInput If true, renders a text-input field instead of a label.
+ * @param hint Placeholder text shown in the input field when [isInput] is true.
+ * @param initialValue Pre-filled value for input items.
+ *
+ * Note vs the Android sibling: the Android module tags this class with `@Parcelize` so it can ride
+ * inside a `Bundle`. That plugin isn't available in commonMain, so the CMP copy is a plain data
+ * class. If Compose Multiplatform's `rememberSaveable` ever needs it, provide a custom `Saver`.
+ */
+data class HiddenMenuItem(
+    val id: String,
+    val text: String,
+    val route: String? = null,
+    val isInput: Boolean = false,
+    val hint: String? = null,
+    val initialValue: String = ""
+)

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzCalloutPlacement.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzCalloutPlacement.kt
@@ -1,0 +1,83 @@
+package com.hereliesaz.aznavrail.tutorial
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+
+/**
+ * Pure geometry for placing a guidance callout so it sits **near its target but never on top of it**,
+ * avoids the known [obstacles] (other rail items / targets / already-placed callouts), and stays fully
+ * inside the [safe] area (so text is never clipped and nothing lands in the system-bar zone). All values
+ * are window-space px. Kept pure so it is unit-testable without a renderer; mirrored in the React port.
+ */
+
+/** Area of the intersection of two rects (0 when disjoint). */
+internal fun overlapArea(a: Rect, b: Rect): Float {
+    val w = (minOf(a.right, b.right) - maxOf(a.left, b.left)).coerceAtLeast(0f)
+    val h = (minOf(a.bottom, b.bottom) - maxOf(a.top, b.top)).coerceAtLeast(0f)
+    return w * h
+}
+
+/** Shift a [width]×[height] rect anchored at ([x],[y]) so it lies fully within [safe] (best effort). */
+private fun clampToSafe(x: Float, y: Float, width: Float, height: Float, safe: Rect): Rect {
+    val left = x.coerceIn(safe.left, (safe.right - width).coerceAtLeast(safe.left))
+    val top = y.coerceIn(safe.top, (safe.bottom - height).coerceAtLeast(safe.top))
+    return Rect(left, top, left + width, top + height)
+}
+
+/** Total overlap of [rect] against every obstacle plus the [target] it must not cover. */
+private fun penalty(rect: Rect, obstacles: List<Rect>, target: Rect?): Float {
+    var p = 0f
+    if (target != null) p += overlapArea(rect, target) * 2f // weigh covering the target itself heaviest
+    obstacles.forEach { p += overlapArea(rect, it) }
+    return p
+}
+
+/**
+ * Choose the best window-space rect for a [size] callout. When [target] is non-null the four sides
+ * (below, above, end, start, with [gap]) are tried; otherwise a coarse grid of [safe] is scanned so
+ * untargeted callouts spread out instead of stacking. The lowest-overlap candidate wins (ties resolve in
+ * the listed order — below is preferred), then it is clamped into [safe].
+ */
+internal fun placeCallout(
+    target: Rect?,
+    size: Size,
+    obstacles: List<Rect>,
+    safe: Rect,
+    gap: Float = 8f,
+): Rect {
+    val w = size.width
+    val h = size.height
+    val candidates = ArrayList<Rect>()
+    if (target != null) {
+        // Below, above, end, start — anchored to the target, then clamped into the safe area.
+        candidates += clampToSafe(target.left, target.bottom + gap, w, h, safe)
+        candidates += clampToSafe(target.left, target.top - h - gap, w, h, safe)
+        candidates += clampToSafe(target.right + gap, target.top, w, h, safe)
+        candidates += clampToSafe(target.left - w - gap, target.top, w, h, safe)
+    } else {
+        // No anchor: scan a grid of the safe area (so multiple untargeted callouts don't collide).
+        val stepX = (w * 0.5f).coerceAtLeast(1f)
+        val stepY = (h * 0.5f).coerceAtLeast(1f)
+        var y = safe.top
+        while (y <= (safe.bottom - h).coerceAtLeast(safe.top)) {
+            var x = safe.left
+            while (x <= (safe.right - w).coerceAtLeast(safe.left)) {
+                candidates += clampToSafe(x, y, w, h, safe)
+                x += stepX
+            }
+            y += stepY
+        }
+        if (candidates.isEmpty()) candidates += clampToSafe(safe.left, safe.top, w, h, safe)
+    }
+    // Pick the minimum-penalty candidate; the first listed wins ties (stable preference order).
+    var best = candidates.first()
+    var bestPenalty = penalty(best, obstacles, target)
+    for (i in 1 until candidates.size) {
+        val p = penalty(candidates[i], obstacles, target)
+        if (p < bestPenalty) {
+            best = candidates[i]
+            bestPenalty = p
+        }
+    }
+    return best
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzGuidance.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzGuidance.kt
@@ -1,0 +1,318 @@
+package com.hereliesaz.aznavrail.tutorial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.hereliesaz.aznavrail.model.AzNavItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Runtime for the status-driven guidance framework. The developer activates one or more goals; the
+ * engine (which provides the reactive `activeStatuses`) plus [routeInstructions] decide what to show.
+ *
+ * Port note vs the Android sibling: the CMP variant drops SharedPreferences-backed persistence.
+ * Completed/dismissed goals live only for the current process — restart clears them. A follow-up
+ * PR can re-add persistence via multiplatform-settings without changing this call surface.
+ */
+class AzGuidanceController(
+    initialCompleted: List<String> = emptyList(),
+    initialDismissed: List<String> = emptyList(),
+) {
+    /** Master switch — guidance only renders while enabled. */
+    var enabled by mutableStateOf(false)
+        private set
+
+    private val _activeGoals = mutableStateListOf<String>()
+    /** Goal ids currently guiding (several may guide at once). */
+    val activeGoals: List<String> get() = _activeGoals
+
+    private val _completed = mutableStateListOf<String>().apply { addAll(initialCompleted) }
+    /** Goal ids reached at least once, so onboarding-style goals don't auto-restart within this session. */
+    val completedGoals: List<String> get() = _completed
+
+    private val _dismissed = mutableStateListOf<String>().apply { addAll(initialDismissed) }
+    /** Goal ids the user skipped, so a skipped tutorial is never shown again this session. */
+    val dismissedGoals: List<String> get() = _dismissed
+    fun isDismissed(goalId: String): Boolean = goalId in _dismissed
+
+    // Session-scoped de-dup: statuses that were a shown next-hop's target and have since been reached.
+    // Routing treats them as permanently traversed, so a step shown + acted on never re-appears.
+    private val _consumed = mutableStateListOf<String>()
+    /** Statuses consumed this session (a shown step whose action was taken). Reactive. */
+    val consumedStatuses: Set<String> get() = _consumed.toHashSet()
+    /** Mark [status] consumed (idempotent). Called by the rail when a shown hop's `to` becomes true. */
+    internal fun consume(status: String) { if (status !in _consumed) _consumed.add(status) }
+
+    // --- Paged-edge step cursor (transient; only goal completion persists) ---
+    private val _stepCursor = mutableStateMapOf<String, Int>()
+    /** Current step index for the paged edge identified by [key] (see `AzEdge.stepKey()`). */
+    fun stepIndex(key: String): Int = _stepCursor[key] ?: 0
+    /** Set the step cursor for [key] (used by the overlay to sync reactive auto-advance). */
+    fun setStep(key: String, index: Int) { _stepCursor[key] = index.coerceAtLeast(0) }
+    /** Advance the paged edge [key] to its next step (clamped at render against the step count). */
+    fun advance(key: String) { _stepCursor[key] = stepIndex(key) + 1 }
+    /** Alias for [advance]. */
+    fun next(key: String) = advance(key)
+    /** Step the paged edge [key] back one (never below 0). */
+    fun back(key: String) { _stepCursor[key] = (stepIndex(key) - 1).coerceAtLeast(0) }
+    /** Reset the cursor for [key] (called when its edge is reached so re-entry starts at step 0). */
+    internal fun resetSteps(key: String) { _stepCursor.remove(key) }
+
+    /** Advance the first active paged instruction (host-driven "Next" with no specific edge key). */
+    fun advance() { currentInstructions.firstOrNull { it.stepTotal > 1 && it.stepKey != null }?.stepKey?.let { advance(it) } }
+
+    /**
+     * The guidance callouts being shown right now (one per active goal, plus passive tips), published
+     * each routing pass so a host can mirror them with bespoke rendering and analytics. Empty when
+     * nothing is showing or guidance is disabled.
+     */
+    var currentInstructions by mutableStateOf<List<AzGuidanceSnapshot>>(emptyList())
+        private set
+    /** The primary (first) current instruction, a convenience for single-goal flows. */
+    val current: AzGuidanceSnapshot? get() = currentInstructions.firstOrNull()
+    private val _currentFlow = MutableStateFlow<List<AzGuidanceSnapshot>>(emptyList())
+    /** A [StateFlow] mirror of [currentInstructions] for non-Compose observers. */
+    val currentFlow: StateFlow<List<AzGuidanceSnapshot>> = _currentFlow.asStateFlow()
+    /** Publish the latest routed snapshot list. Called by the rail; not for app use. */
+    internal fun publishCurrent(snapshots: List<AzGuidanceSnapshot>) {
+        currentInstructions = snapshots
+        _currentFlow.value = snapshots
+    }
+
+    fun enable() { enabled = true }
+    fun disable() { enabled = false; _consumed.clear() }
+
+    /**
+     * Begin guiding toward [goalId]. **No-op if the goal was already completed or skipped** — a finished
+     * or dismissed tutorial is never re-shown until the developer calls [resetGuidance].
+     */
+    fun activate(goalId: String) {
+        if (goalId in _completed || goalId in _dismissed) return
+        enabled = true
+        if (goalId !in _activeGoals) _activeGoals.add(goalId)
+    }
+
+    /** Stop guiding toward [goalId] (without recording it as skipped). */
+    fun deactivate(goalId: String) { _activeGoals.remove(goalId) }
+
+    /**
+     * The user **skipped** [goalId]: deactivate and record the dismissal for this session.
+     */
+    fun skip(goalId: String) {
+        _activeGoals.remove(goalId)
+        if (goalId !in _dismissed) _dismissed.add(goalId)
+    }
+
+    /** Cancel tutorial mode entirely: skip every active goal and turn guidance off. */
+    fun skip() {
+        _activeGoals.toList().forEach { skip(it) }
+        enabled = false
+        _consumed.clear()
+    }
+
+    /** Mark a goal reached: deactivate it and record completion for this session. */
+    fun markReached(goalId: String) {
+        _activeGoals.remove(goalId)
+        if (goalId !in _completed) _completed.add(goalId)
+    }
+
+    fun isCompleted(goalId: String): Boolean = goalId in _completed
+
+    /** Clear [goalId]'s completion + dismissal (+ session de-dup) so it can be guided again. */
+    fun resetGuidance(goalId: String) {
+        _completed.remove(goalId)
+        _dismissed.remove(goalId)
+        _consumed.clear()
+    }
+
+    /** Clear all completion + dismissal (+ session de-dup). */
+    fun resetGuidance() {
+        _completed.clear()
+        _dismissed.clear()
+        _consumed.clear()
+    }
+
+    companion object {
+        val Saver: Saver<AzGuidanceController, List<Any?>> = Saver(
+            save = { listOf(ArrayList(it._activeGoals), ArrayList(it._completed), it.enabled, ArrayList(it._dismissed)) },
+            restore = { list ->
+                AzGuidanceController(
+                    initialCompleted = (list[1] as List<*>).filterIsInstance<String>(),
+                    initialDismissed = (list.getOrNull(3) as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+                ).apply {
+                    (list[0] as List<*>).filterIsInstance<String>().forEach { _activeGoals.add(it) }
+                    if (list[2] as Boolean) enabled = true
+                }
+            },
+        )
+    }
+}
+
+@Composable
+fun rememberAzGuidanceController(): AzGuidanceController {
+    return rememberSaveable(saver = AzGuidanceController.Saver) {
+        AzGuidanceController()
+    }
+}
+
+/**
+ * Provides the host-owned [AzGuidanceController] down the composition so the rail can route/render the
+ * same controller the developer receives back from `AzHostActivityLayout`. `null` when the rail is used
+ * standalone (it falls back to its own [rememberAzGuidanceController]).
+ */
+val LocalAzGuidanceController = staticCompositionLocalOf<AzGuidanceController?> { null }
+
+/**
+ * Derives the guidance **auto-edges** for the rail's own affordances, so the developer only hand-authors
+ * edges whose `to` is a custom status. Generated each render from the live [items]:
+ *  - "Open the menu": `az.rail.collapsed → az.rail.expanded`;
+ *  - tap a host item → `az.host.<id>.expanded`;
+ *  - tap a nested-rail item → `az.nestedRail.<id>.open`;
+ *  - tap a routed item → `az.screen.<route>`.
+ */
+internal fun computeAutoEdges(
+    items: List<AzNavItem>,
+    openMenuLabel: String = "Open the menu",
+    tapLabel: (String) -> String = { "Tap $it" },
+): List<AzEdge> {
+    val edges = ArrayList<AzEdge>()
+    edges += AzEdge(
+        from = "az.rail.collapsed",
+        to = "az.rail.expanded",
+        instruction = AzInstruction(openMenuLabel, highlight = AzGuideHighlight.None),
+    )
+    items.forEach { item ->
+        val visibleFrom = if (item.isRailItem) "az.app.ready" else "az.rail.expanded"
+        val highlight = AzGuideHighlight.Item(item.id)
+        val tap = tapLabel(item.text.ifBlank { item.id })
+        when {
+            item.isHost -> edges += AzEdge(visibleFrom, "az.host.${item.id}.expanded", AzInstruction(tap, highlight = highlight))
+            item.isNestedRail -> edges += AzEdge(visibleFrom, "az.nestedRail.${item.id}.open", AzInstruction(tap, highlight = highlight))
+            item.route != null -> edges += AzEdge(visibleFrom, "az.screen.${item.route}", AzInstruction(tap, highlight = highlight))
+        }
+    }
+    return edges
+}
+
+/**
+ * BFS the status flowchart from the currently-true [activeStatuses] to [target]; return the first edge
+ * on a shortest path (its instruction is the next hop), or null if [target] is already true or
+ * unreachable. Only interactive edges (`to != null`) are traversed.
+ */
+internal fun nextHop(edges: List<AzEdge>, activeStatuses: Set<String>, target: String): AzEdge? {
+    if (target in activeStatuses) return null
+    val adjacency = edges.filter { it.to != null }.groupBy { it.from }
+    val visited = HashSet(activeStatuses)
+    val queue = ArrayDeque<Pair<String, AzEdge>>() // (reached status, first edge taken)
+    activeStatuses.forEach { start ->
+        adjacency[start].orEmpty().forEach { e ->
+            val to = e.to!!
+            if (visited.add(to)) queue.add(to to e)
+        }
+    }
+    while (queue.isNotEmpty()) {
+        val (status, firstEdge) = queue.removeFirst()
+        if (status == target) return firstEdge
+        adjacency[status].orEmpty().forEach { e ->
+            val to = e.to!!
+            if (visited.add(to)) queue.add(to to firstEdge)
+        }
+    }
+    return null
+}
+
+/**
+ * One instruction the engine has chosen to show, resolved to its current paged step. Carries the owning
+ * [edge] and [goalId] plus the active step's [stepIndex]/[stepTotal] so the overlay can page it and the
+ * controller can publish an [AzGuidanceSnapshot].
+ */
+internal data class ResolvedInstruction(
+    val instruction: AzInstruction,
+    val edge: AzEdge,
+    val goalId: String?,
+    val stepIndex: Int,
+    val stepTotal: Int,
+)
+
+/** Builds the public [AzGuidanceSnapshot] for this resolved instruction (the [shape] resolved by caller). */
+internal fun ResolvedInstruction.toSnapshot(shape: AzGuideShape?, activeItemId: String?): AzGuidanceSnapshot =
+    AzGuidanceSnapshot(
+        text = instruction.text,
+        title = instruction.title,
+        goalId = goalId,
+        highlight = instruction.highlight,
+        targetId = instruction.highlight.resolveTargetId(activeItemId),
+        resolvedShape = shape,
+        resolvedBounds = shape?.bounds(),
+        stepIndex = stepIndex,
+        stepTotal = stepTotal,
+        stepKey = edge.stepKey(),
+    )
+
+/**
+ * The set of instructions to show right now: the next-hop instruction for each active goal not yet
+ * reached, plus any passive edge whose `from` is currently true. Deduped by (text + highlight).
+ * Returns the goal ids that are already at their target (the caller should `markReached` them).
+ */
+internal data class GuidanceFrame(
+    val resolved: List<ResolvedInstruction>,
+    val reachedGoals: Set<String>,
+) {
+    /** Back-compat view: just the per-step instructions to render. */
+    val instructions: List<AzInstruction> get() = resolved.map { it.instruction }
+}
+
+/**
+ * Resolves an edge to the instruction for its **current step**. A non-paged edge resolves to its single
+ * instruction. A paged edge consults [stepIndexOf] for the manual cursor, then advances past any leading
+ * steps whose `advanceWhen` is already satisfied (reactive advance always wins over the tap cursor).
+ */
+internal fun resolveEdge(
+    edge: AzEdge,
+    goalId: String?,
+    stepIndexOf: (String) -> Int,
+    activeStatuses: Set<String>,
+): ResolvedInstruction {
+    val steps = edge.steps
+    if (steps.isEmpty()) return ResolvedInstruction(edge.instruction, edge, goalId, 0, 1)
+    var idx = stepIndexOf(edge.stepKey()).coerceIn(0, steps.lastIndex)
+    while (idx < steps.lastIndex && steps[idx].advanceWhen?.let { it in activeStatuses } == true) idx++
+    return ResolvedInstruction(steps[idx].toInstruction(edge.instruction.title), edge, goalId, idx, steps.size)
+}
+
+internal fun routeInstructions(
+    edges: List<AzEdge>,
+    goals: Map<String, AzGoal>,
+    activeGoalIds: Collection<String>,
+    activeStatuses: Set<String>,
+    stepIndexOf: (String) -> Int = { 0 },
+    consumedStatuses: Set<String> = emptySet(),
+): GuidanceFrame {
+    // De-dup: a status that was a shown hop's target and has since been reached is treated as
+    // permanently true, so its hop is never routed to (or re-shown) again.
+    val effective = if (consumedStatuses.isEmpty()) activeStatuses else activeStatuses + consumedStatuses
+    val out = LinkedHashMap<Pair<String, AzGuideHighlight>, ResolvedInstruction>()
+    val reached = HashSet<String>()
+    activeGoalIds.forEach { gid ->
+        val goal = goals[gid] ?: return@forEach
+        if (goal.target in effective) { reached.add(gid); return@forEach }
+        nextHop(edges, effective, goal.target)?.let { e ->
+            val r = resolveEdge(e, gid, stepIndexOf, effective)
+            out[r.instruction.text to r.instruction.highlight] = r
+        }
+    }
+    // Passive tips: shown while their `from` status holds.
+    edges.filter { it.to == null && it.from in effective }.forEach { e ->
+        val r = resolveEdge(e, null, stepIndexOf, effective)
+        out[r.instruction.text to r.instruction.highlight] = r
+    }
+    return GuidanceFrame(out.values.toList(), reached)
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzInstructionOverlay.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzInstructionOverlay.kt
@@ -1,0 +1,275 @@
+package com.hereliesaz.aznavrail.tutorial
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.LocalAzSafeZones
+import kotlin.math.abs
+import kotlin.math.hypot
+import kotlin.math.min
+
+/**
+ * Renders guidance as a **non-blocking coach**: a thin accent **outline** around each step's target and
+ * a small **callout** placed *near* (never on) that target, with a **pointer/arrow** connecting them.
+ *
+ * It never dims the screen and never intercepts input outside a callout — the app stays fully usable.
+ * Callouts avoid covering the target, other known UI (rail items / targets), each other, and the
+ * screen/safe-area edges. **Swiping a callout cancels tutorial mode** ([AzGuidanceController.skip]);
+ * tapping an informational step advances it ([AzGuidanceController.advance]). When [renderSlot] is
+ * non-null the host draws the callout body itself.
+ */
+@Composable
+internal fun AzInstructionOverlay(
+    resolved: List<ResolvedInstruction>,
+    itemBoundsCache: Map<String, Rect>,
+    accent: Color,
+    activeItemId: String? = null,
+    targets: Map<String, () -> AzGuideShape?> = emptyMap(),
+    controller: AzGuidanceController? = null,
+    renderSlot: (@Composable (AzGuidanceSnapshot, Rect?) -> Unit)? = null,
+) {
+    if (resolved.isEmpty()) return
+    val density = LocalDensity.current
+    val safeZones = LocalAzSafeZones.current
+    val screenWidthPx = with(density) { LocalConfiguration.current.screenWidthDp.dp.toPx() }
+    val screenHeightPx = with(density) { LocalConfiguration.current.screenHeightDp.dp.toPx() }
+    val marginPx = with(density) { 8.dp.toPx() }
+    val safe = Rect(
+        left = marginPx,
+        top = with(density) { safeZones.top.toPx() } + marginPx,
+        right = screenWidthPx - marginPx,
+        bottom = screenHeightPx - with(density) { safeZones.bottom.toPx() } - marginPx,
+    )
+    val maxCalloutWidthPx = with(density) { 240.dp.toPx() }
+    val defaultCalloutHeightPx = with(density) { 84.dp.toPx() }
+    val gapPx = with(density) { 12.dp.toPx() }
+    val strokePx = with(density) { 2.dp.toPx() }
+    val outlinePadPx = with(density) { 4.dp.toPx() }
+    val arrowPx = with(density) { 12.dp.toPx() }
+    val swipeThresholdPx = with(density) { 48.dp.toPx() }
+
+    // Measured callout sizes (filled after first layout); a second pass re-places with the real size.
+    val sizes = remember { mutableStateMapOf<Int, Size>() }
+
+    // Resolve every step's target shape + bounds (re-runs if a target moves and is Compose-backed).
+    val targetRects: List<Rect?> = resolved.map {
+        it.instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)?.bounds()
+    }
+    val itemRects = itemBoundsCache.values.toList()
+
+    // Greedy placement: each callout near its own target, off obstacles (items + other targets +
+    // already-placed callouts), clamped fully into the safe area.
+    val placed = ArrayList<Rect>(resolved.size)
+    val placements: List<Rect> = resolved.indices.map { i ->
+        val size = sizes[i] ?: Size(maxCalloutWidthPx, defaultCalloutHeightPx)
+        val obstacles = ArrayList<Rect>(itemRects.size + resolved.size)
+        obstacles.addAll(itemRects)
+        targetRects.forEachIndexed { j, r -> if (j != i && r != null) obstacles.add(r) }
+        obstacles.addAll(placed)
+        val rect = placeCallout(targetRects[i], size, obstacles, safe, gapPx)
+        placed.add(rect)
+        rect
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Draw-only layer: outline each target and the connector to its callout. Re-resolved live in the
+        // draw scope so a moving target's outline tracks every frame. NO dim, NO input.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .drawBehind {
+                    resolved.forEachIndexed { i, r ->
+                        val shape = r.instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)
+                        if (shape != null) {
+                            strokeOutline(shape, accent, strokePx, outlinePadPx)
+                            drawConnector(placements[i], shape.bounds(), accent, strokePx, arrowPx)
+                        }
+                    }
+                },
+        )
+
+        resolved.forEachIndexed { i, r ->
+            val rect = placements[i]
+            val measured = sizes.containsKey(i)
+            val stepKey = r.edge.stepKey()
+            val tappable = r.stepTotal > 1 && r.stepIndex < r.stepTotal - 1 &&
+                r.edge.steps.getOrNull(r.stepIndex)?.advanceWhen == null
+
+            Box(
+                modifier = Modifier
+                    .graphicsLayer {
+                        translationX = rect.left
+                        translationY = rect.top
+                        alpha = if (measured) 1f else 0f // hide until measured to avoid a first-frame jump
+                    }
+                    .widthIn(max = 240.dp)
+                    .onSizeChanged { sizes[i] = Size(it.width.toFloat(), it.height.toFloat()) }
+                    // Swipe a callout away → cancel tutorial mode (persisted skip). The callout is the
+                    // only input-consuming element; everything else on screen passes through.
+                    .pointerInput(controller) {
+                        var total = Offset.Zero
+                        var fired = false
+                        detectDragGestures(
+                            onDragStart = { total = Offset.Zero; fired = false },
+                            onDragEnd = { total = Offset.Zero; fired = false },
+                            onDragCancel = { total = Offset.Zero; fired = false },
+                        ) { change, drag ->
+                            change.consume()
+                            total += drag
+                            if (!fired && hypot(total.x, total.y) > swipeThresholdPx) {
+                                fired = true
+                                controller?.skip()
+                            }
+                        }
+                    }
+                    .then(
+                        if (tappable && controller != null) {
+                            Modifier.pointerInput(stepKey) { detectTapGestures { controller.advance(stepKey) } }
+                        } else Modifier,
+                    ),
+            ) {
+                if (renderSlot != null) {
+                    val shape = r.instruction.highlight.resolveShape(itemBoundsCache, activeItemId, targets)
+                    renderSlot(r.toSnapshot(shape, activeItemId), rect)
+                } else {
+                    Callout(r.instruction, accent, r.stepIndex, r.stepTotal, tappable)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Callout(
+    instruction: AzInstruction,
+    accent: Color,
+    stepIndex: Int,
+    stepTotal: Int,
+    tappable: Boolean,
+) {
+    Column(
+        modifier = Modifier
+            .widthIn(max = 240.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(12.dp),
+    ) {
+        instruction.title?.let {
+            Text(it, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold, color = accent)
+        }
+        Text(instruction.text, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface)
+        instruction.media?.let { Box(Modifier.padding(top = 8.dp)) { it() } }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                if (stepTotal > 1) "${stepIndex + 1} / $stepTotal" else "swipe to dismiss",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (tappable) {
+                Text("Tap to continue ▸", style = MaterialTheme.typography.labelSmall, color = accent)
+            }
+        }
+    }
+}
+
+/** Strokes the target's geometry (no fill, no dim) so the control stays visible and usable. */
+private fun DrawScope.strokeOutline(shape: AzGuideShape, color: Color, strokeWidth: Float, pad: Float) {
+    val style = Stroke(width = strokeWidth)
+    when (shape) {
+        is AzGuideShape.Circle -> drawCircle(
+            color = color,
+            radius = shape.radius + shape.padding + pad,
+            center = Offset(shape.cx, shape.cy),
+            style = style,
+        )
+        is AzGuideShape.Rect -> drawRoundRect(
+            color = color,
+            topLeft = Offset(shape.left - shape.padding - pad, shape.top - shape.padding - pad),
+            size = Size(shape.width + 2f * (shape.padding + pad), shape.height + 2f * (shape.padding + pad)),
+            cornerRadius = CornerRadius(if (shape.cornerRadius > 0f) shape.cornerRadius else 12f),
+            style = style,
+        )
+        is AzGuideShape.Path -> drawPath(shape.toComposePath(), color, style = style)
+    }
+}
+
+/** Draws a line from the [callout]'s edge to the [target]'s edge with a small arrowhead at the target. */
+private fun DrawScope.drawConnector(callout: Rect, target: Rect, color: Color, strokeWidth: Float, arrow: Float) {
+    val start = edgePoint(callout, target.center)
+    val end = edgePoint(target, callout.center)
+    val dx = end.x - start.x
+    val dy = end.y - start.y
+    val len = hypot(dx, dy)
+    if (len < 1f) return // callout overlaps the target (shouldn't happen) — skip the connector
+    drawLine(color, start, end, strokeWidth = strokeWidth)
+    val ux = dx / len
+    val uy = dy / len
+    val leftWing = Offset(end.x - arrow * (ux * 0.86f - uy * 0.5f), end.y - arrow * (uy * 0.86f + ux * 0.5f))
+    val rightWing = Offset(end.x - arrow * (ux * 0.86f + uy * 0.5f), end.y - arrow * (uy * 0.86f - ux * 0.5f))
+    drawLine(color, end, leftWing, strokeWidth = strokeWidth)
+    drawLine(color, end, rightWing, strokeWidth = strokeWidth)
+}
+
+/** The point on [rect]'s border along the ray from its centre toward [towards]. */
+private fun edgePoint(rect: Rect, towards: Offset): Offset {
+    val c = rect.center
+    val dx = towards.x - c.x
+    val dy = towards.y - c.y
+    if (dx == 0f && dy == 0f) return c
+    val hw = rect.width / 2f
+    val hh = rect.height / 2f
+    val sx = if (dx != 0f) hw / abs(dx) else Float.MAX_VALUE
+    val sy = if (dy != 0f) hh / abs(dy) else Float.MAX_VALUE
+    val scale = min(sx, sy).coerceIn(0f, 1f)
+    return Offset(c.x + dx * scale, c.y + dy * scale)
+}
+
+/** Converts an [AzGuideShape.Path]'s window-space commands into a Compose [Path]. */
+private fun AzGuideShape.Path.toComposePath(): Path {
+    val path = Path()
+    commands.forEach { cmd ->
+        when (cmd) {
+            is AzPathCmd.MoveTo -> path.moveTo(cmd.x, cmd.y)
+            is AzPathCmd.LineTo -> path.lineTo(cmd.x, cmd.y)
+            is AzPathCmd.QuadTo -> path.quadraticBezierTo(cmd.x1, cmd.y1, cmd.x, cmd.y)
+            is AzPathCmd.CubicTo -> path.cubicTo(cmd.x1, cmd.y1, cmd.x2, cmd.y2, cmd.x, cmd.y)
+            AzPathCmd.Close -> path.close()
+        }
+    }
+    return path
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzStatus.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzStatus.kt
@@ -1,0 +1,296 @@
+package com.hereliesaz.aznavrail.tutorial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Rect
+
+/**
+ * Reactive, status-driven guidance model — the replacement for the scripted scene/card tutorial.
+ *
+ * The app (and AzNavHost automatically) describe the userflow as a flowchart of **statuses** (nodes)
+ * and **edges** (transitions, each carrying the instruction to traverse it). The developer declares
+ * one or more **goals** (target statuses) and activates them; the engine ([AzStatusEngine]) observes
+ * which statuses are currently true and always shows the instruction to reach the next status on the
+ * path toward each active goal, auto-advancing the instant a target status becomes true.
+ *
+ * A "status" is just a `String` id, resolved uniformly by the engine from three sources:
+ *  - a developer predicate registered via `azStatus(id) { … }`,
+ *  - an active classifier name (true while it is in `activeClassifiers`),
+ *  - a built-in `az.*` id published by AzNavHost from the rail/host/route/onscreen/sheet state.
+ */
+
+/**
+ * The dynamic highlight token: when passed anywhere a `highlightItemId` is accepted, the callout
+ * spotlights whatever rail item is currently `*.active` (resolved fresh every frame), rather than a
+ * statically-named id. Degrades to text-only when no item is active. See [AzGuideHighlight.ActiveItem].
+ */
+const val AZ_ITEM_ACTIVE = "az.item.active"
+
+/** What a guidance instruction spotlights. Reused by the highlight renderer. */
+sealed interface AzGuideHighlight {
+    /** No spotlight; the instruction card floats over a plain dim. */
+    data object None : AzGuideHighlight
+    /** Dim the whole screen with no punch-out. */
+    data object FullScreen : AzGuideHighlight
+    /** Spotlight the rail item with this id (looked up in `itemBoundsCache`). */
+    data class Item(val id: String) : AzGuideHighlight
+    /** Spotlight an explicit window-space rectangle. */
+    data class Area(val left: Float, val top: Float, val width: Float, val height: Float) : AzGuideHighlight
+    /**
+     * Spotlight whatever rail item is currently active, resolved at render time against the live
+     * active-item id (the same item that publishes `az.item.<id>.active`). Text-only when none is
+     * active. Authored by passing the [AZ_ITEM_ACTIVE] token as a `highlightItemId`.
+     */
+    data object ActiveItem : AzGuideHighlight
+    /**
+     * Spotlight the item whose id [selector] returns, resolved at render time against the live
+     * item-bounds map every frame — so an edge declared before its target exists (a runtime
+     * `layer.<uuid>` rail item, the just-created item) can still point at it. Returning `null` (or an
+     * id with no measured bounds) degrades to text-only. The [AZ_ITEM_ACTIVE] token is honored here too.
+     */
+    data class Dynamic(val selector: () -> String?) : AzGuideHighlight
+    /**
+     * Spotlight a host-registered, arbitrary on-screen target (not a rail item): a moving circle, rect,
+     * or path drawn over a camera/AR canvas. Resolved at render time against the live target registry
+     * (see `azGuidanceTarget(id) { … }`); the lambda returns the current [AzGuideShape] in window-space
+     * px. Returning `null` (or an unregistered id) degrades to text-only. Authored by passing
+     * `highlightTargetId`.
+     */
+    data class Target(val id: String) : AzGuideHighlight
+}
+
+/**
+ * A spotlight geometry in **window-space px** (the same space as `itemBoundsCache`, so it aligns with
+ * the overlay punch-out at zero offset). Returned by an `azGuidanceTarget` shape lambda and resolved
+ * fresh each frame, so a target can track a moving on-screen object. [padding] inflates the spotlight
+ * uniformly beyond the geometry.
+ */
+sealed interface AzGuideShape {
+    val padding: Float
+    /** A circle centered at ([cx], [cy]) with [radius]. */
+    data class Circle(val cx: Float, val cy: Float, val radius: Float, override val padding: Float = 0f) : AzGuideShape
+    /** An axis-aligned rounded rectangle. */
+    data class Rect(
+        val left: Float, val top: Float, val width: Float, val height: Float,
+        val cornerRadius: Float = 16f, override val padding: Float = 0f,
+    ) : AzGuideShape
+    /** An arbitrary outline described by absolute, window-space [commands] (filled even-odd). */
+    data class Path(val commands: List<AzPathCmd>, override val padding: Float = 0f) : AzGuideShape
+}
+
+/** One command of an [AzGuideShape.Path], in absolute window-space px (SVG-style). */
+sealed interface AzPathCmd {
+    data class MoveTo(val x: Float, val y: Float) : AzPathCmd
+    data class LineTo(val x: Float, val y: Float) : AzPathCmd
+    data class QuadTo(val x1: Float, val y1: Float, val x: Float, val y: Float) : AzPathCmd
+    data class CubicTo(val x1: Float, val y1: Float, val x2: Float, val y2: Float, val x: Float, val y: Float) : AzPathCmd
+    data object Close : AzPathCmd
+}
+
+/**
+ * The axis-aligned window-space bounding box of any [AzGuideShape] (inflated by [AzGuideShape.padding]).
+ * Used for callout placement and for a host's own hit-testing; the true geometry is only used by the
+ * punch-out draw. A path with no points yields [Rect.Zero].
+ */
+fun AzGuideShape.bounds(): Rect = when (this) {
+    is AzGuideShape.Circle -> Rect(cx - radius - padding, cy - radius - padding, cx + radius + padding, cy + radius + padding)
+    is AzGuideShape.Rect -> Rect(left - padding, top - padding, left + width + padding, top + height + padding)
+    is AzGuideShape.Path -> {
+        var minX = Float.POSITIVE_INFINITY; var minY = Float.POSITIVE_INFINITY
+        var maxX = Float.NEGATIVE_INFINITY; var maxY = Float.NEGATIVE_INFINITY
+        fun acc(x: Float, y: Float) { minX = minOf(minX, x); minY = minOf(minY, y); maxX = maxOf(maxX, x); maxY = maxOf(maxY, y) }
+        commands.forEach { cmd ->
+            when (cmd) {
+                is AzPathCmd.MoveTo -> acc(cmd.x, cmd.y)
+                is AzPathCmd.LineTo -> acc(cmd.x, cmd.y)
+                is AzPathCmd.QuadTo -> { acc(cmd.x1, cmd.y1); acc(cmd.x, cmd.y) }
+                is AzPathCmd.CubicTo -> { acc(cmd.x1, cmd.y1); acc(cmd.x2, cmd.y2); acc(cmd.x, cmd.y) }
+                AzPathCmd.Close -> {}
+            }
+        }
+        if (minX > maxX) Rect.Zero else Rect(minX - padding, minY - padding, maxX + padding, maxY + padding)
+    }
+}
+
+/**
+ * One paged sub-step of a multi-step edge (see [azEdge] with `steps`). A single milestone (one status
+ * hop) can carry several of these, revealed one at a time, moving the spotlight as the user reads:
+ * "your design is ready — tap a layer (point at the layer), then open Modes (point at the Modes host)".
+ *
+ * @param text The line shown for this sub-step.
+ * @param title Optional per-step title (overrides the edge title while this step shows).
+ * @param highlightItemId Item to spotlight; the [AZ_ITEM_ACTIVE] token resolves to the active item.
+ * @param highlightTargetId A host-registered [AzGuideShape] target to spotlight (see `azGuidanceTarget`);
+ *   takes precedence over [highlightItemId]/[highlightSelector] when non-null.
+ * @param side Preferred callout placement relative to the spotlight target.
+ * @param highlightSelector Resolved every frame to the id to spotlight; overrides [highlightItemId]
+ *   when non-null, so a step can point at a runtime/dynamically-created item. `null` ⇒ text-only.
+ * @param advanceWhen Optional status id; when it becomes true the overlay auto-advances past this step
+ *   (reactive advance), regardless of the manual tap cursor. `null` ⇒ this is an informational step the
+ *   user advances by tapping.
+ */
+data class AzInstructionStep(
+    val text: String,
+    val title: String? = null,
+    val highlightItemId: String? = null,
+    val highlightTargetId: String? = null,
+    val side: AzCalloutSide = AzCalloutSide.Auto,
+    val highlightSelector: (() -> String?)? = null,
+    val advanceWhen: String? = null,
+)
+
+/** Resolves a step's highlight directive into the renderer's [AzGuideHighlight]. */
+internal fun AzInstructionStep.toHighlight(): AzGuideHighlight =
+    resolveAzHighlight(highlightItemId, highlightSelector, highlightTargetId)
+
+/** This step as a standalone [AzInstruction] (used when the overlay pages a stepped edge). */
+internal fun AzInstructionStep.toInstruction(edgeTitle: String?): AzInstruction =
+    AzInstruction(text = text, title = title ?: edgeTitle, highlight = toHighlight(), side = side)
+
+/**
+ * Resolves a highlight directive into an [AzGuideHighlight] by precedence: a registered [highlightTargetId]
+ * ([AzGuideHighlight.Target]) wins, then a [highlightSelector] ([AzGuideHighlight.Dynamic]), then the
+ * [AZ_ITEM_ACTIVE] token ([AzGuideHighlight.ActiveItem]), then a literal item id ([AzGuideHighlight.Item]),
+ * else [AzGuideHighlight.None].
+ */
+internal fun resolveAzHighlight(
+    highlightItemId: String?,
+    highlightSelector: (() -> String?)?,
+    highlightTargetId: String? = null,
+): AzGuideHighlight = when {
+    highlightTargetId != null -> AzGuideHighlight.Target(highlightTargetId)
+    highlightSelector != null -> AzGuideHighlight.Dynamic(highlightSelector)
+    highlightItemId == AZ_ITEM_ACTIVE -> AzGuideHighlight.ActiveItem
+    highlightItemId != null -> AzGuideHighlight.Item(highlightItemId)
+    else -> AzGuideHighlight.None
+}
+
+/**
+ * Resolves a highlight to the **item id** it currently points at (null ⇒ no item / not item-based),
+ * folding [AzGuideHighlight.ActiveItem] and [AzGuideHighlight.Dynamic] against the live [activeItemId].
+ * Pure, so the resolution is unit-testable without a renderer. [AzGuideHighlight.Area] returns null
+ * here (it carries an explicit rect, resolved separately by the overlay).
+ */
+internal fun AzGuideHighlight.resolveItemId(activeItemId: String?): String? = when (this) {
+    is AzGuideHighlight.Item -> id
+    is AzGuideHighlight.ActiveItem -> activeItemId
+    is AzGuideHighlight.Dynamic -> selector()?.let { if (it == AZ_ITEM_ACTIVE) activeItemId else it }
+    else -> null
+}
+
+/**
+ * Resolves a highlight to the concrete [AzGuideShape] to spotlight, in window-space px: a registered
+ * [AzGuideHighlight.Target] via [targets] (the moving-target lambda), an explicit [AzGuideHighlight.Area]
+ * rect, or a rail item's cached bounds (Item/ActiveItem/Dynamic). `null` ⇒ text-only (no spotlight).
+ * Called both at composition (anchor/float decision) and live in the overlay's draw scope (so a moving
+ * target tracks every frame).
+ */
+internal fun AzGuideHighlight.resolveShape(
+    cache: Map<String, Rect>,
+    activeItemId: String?,
+    targets: Map<String, () -> AzGuideShape?>,
+): AzGuideShape? = when (this) {
+    is AzGuideHighlight.Area -> AzGuideShape.Rect(left, top, width, height)
+    is AzGuideHighlight.Target -> targets[id]?.invoke()
+    else -> resolveItemId(activeItemId)?.let { itemId ->
+        cache[itemId]?.let { AzGuideShape.Rect(it.left, it.top, it.width, it.height) }
+    }
+}
+
+/** The resolved target/item id this highlight points at (for the snapshot/analytics), if any. */
+internal fun AzGuideHighlight.resolveTargetId(activeItemId: String?): String? = when (this) {
+    is AzGuideHighlight.Target -> id
+    else -> resolveItemId(activeItemId)
+}
+
+/**
+ * The instruction shown while the user traverses one edge: the prompt text, an optional title, what to
+ * spotlight, and optional inline media.
+ *
+ * The instruction is rendered as a **callout positioned adjacent to its [highlight] target** — next to
+ * the control the user would use to accomplish that hop — not as a centered card. When several goals
+ * are active, **every** active instruction is shown at once, each placed by its own target, so the
+ * user sees, in place, how to accomplish each goal. [side] biases which edge of the target the callout
+ * prefers (auto-resolved against screen bounds when [AzCalloutSide.Auto]).
+ */
+data class AzInstruction(
+    val text: String,
+    val title: String? = null,
+    val highlight: AzGuideHighlight = AzGuideHighlight.None,
+    val side: AzCalloutSide = AzCalloutSide.Auto,
+    val media: (@Composable () -> Unit)? = null,
+)
+
+/** Preferred placement of a callout relative to its highlight target. */
+enum class AzCalloutSide { Auto, Above, Below, Start, End }
+
+/**
+ * One edge of the flowchart: while status [from] is true, performing the [instruction] is expected to
+ * make status [to] true (an interactive hop). A passive edge ([to] == `null`) just shows info while
+ * [from] holds. Authored via `azEdge(...)`, or auto-generated by AzNavHost for rail affordances.
+ *
+ * When [steps] is non-empty the edge is **paged**: the overlay reveals one [AzInstructionStep] at a
+ * time (advancing on tap, or reactively when a step's `advanceWhen` becomes true), moving the spotlight
+ * per step — several sub-pointers under one milestone. The last step behaves like a single-instruction
+ * edge: the edge is reached when [to] becomes true. Empty [steps] ⇒ the classic single-callout edge.
+ */
+data class AzEdge(
+    val from: String,
+    val to: String?,
+    val instruction: AzInstruction,
+    val steps: List<AzInstructionStep> = emptyList(),
+)
+
+/**
+ * Stable key identifying this edge for the per-edge step cursor (so two goals routing through the same
+ * edge share a cursor, consistent with routing's dedup-by-(text,highlight)). Uses string fields only,
+ * so it is independent of any lambda identity.
+ */
+internal fun AzEdge.stepKey(): String = "$from ${to ?: ""} ${instruction.text}"
+
+/**
+ * A developer-declared guidance target. The engine routes from the current status toward [target]; the
+ * developer activates/deactivates goals on the controller (several may guide at once). When
+ * [autoStartWhen] is non-null the goal self-activates once that status becomes true (onboarding-style).
+ *
+ * When several active goals are guiding at once, **every** goal's next-hop instruction is shown
+ * simultaneously, each as a callout placed adjacent to its own target (deduped where two goals share
+ * the exact same next hop). No goal's instruction ever suppresses another's.
+ */
+data class AzGoal(
+    val id: String,
+    val target: String,
+    val label: String? = null,
+    val autoStartWhen: String? = null,
+)
+
+/**
+ * A read-only snapshot of one guidance callout currently being shown, published live on
+ * [AzGuidanceController.currentInstructions] so a host can mirror it with bespoke rendering (e.g. a
+ * pulsing highlight drawn over its own canvas) and analytics. The framework may show several at once
+ * (one per active goal), so the controller exposes a list.
+ *
+ * @param text The line currently shown (the active step's text for a paged edge).
+ * @param title The title currently shown, if any.
+ * @param goalId The owning goal, or `null` for a passive ambient tip.
+ * @param highlight The spotlight directive.
+ * @param targetId The resolved registered-target / rail-item id this points at, if any.
+ * @param resolvedShape The target geometry resolved at publish time (best-effort; the overlay
+ *   re-resolves live each frame for moving targets), or `null` when text-only.
+ * @param resolvedBounds The axis-aligned bounds of [resolvedShape], a convenience for host hit-testing.
+ * @param stepIndex Zero-based index of the active step within a paged edge (0 for a single-callout edge).
+ * @param stepTotal Total steps in the edge (1 for a single-callout edge).
+ * @param stepKey The owning edge's cursor key (pass to `AzGuidanceController.advance`/`back`).
+ */
+data class AzGuidanceSnapshot(
+    val text: String,
+    val title: String? = null,
+    val goalId: String? = null,
+    val highlight: AzGuideHighlight = AzGuideHighlight.None,
+    val targetId: String? = null,
+    val resolvedShape: AzGuideShape? = null,
+    val resolvedBounds: Rect? = null,
+    val stepIndex: Int = 0,
+    val stepTotal: Int = 1,
+    val stepKey: String? = null,
+)
+

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzStatusEngine.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/tutorial/AzStatusEngine.kt
@@ -1,0 +1,140 @@
+package com.hereliesaz.aznavrail.tutorial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
+
+/** Poll interval for status predicates backed by non-Compose sources (StateFlow.value / a var). */
+private const val STATUS_POLL_MS = 300L
+
+/** True if any registered suppressor predicate is currently true (a throwing predicate counts false). */
+internal fun anySuppressorActive(suppressors: List<Pair<Long, () -> Boolean>>): Boolean =
+    suppressors.any { (_, predicate) -> runCatching { predicate() }.getOrDefault(false) }
+
+/**
+ * Observes the host's guidance [suppressors] (each a `settleMs to predicate` pair, registered via
+ * `azSuppressGuide`) and returns whether the guidance overlay should currently be **hidden**. While any
+ * predicate is true the result is `true` immediately; when all go false a settle delay (the largest
+ * registered `settleMs`) elapses before it flips back to `false`, so a callout never pops over the tail
+ * of an in-progress gesture. Predicates are observed with the same `snapshotFlow` + low-rate poll as
+ * [rememberActiveStatuses], so both Compose-state and plain-`var`/`StateFlow.value` sources resolve.
+ */
+@Composable
+internal fun rememberGuidanceSuppressed(suppressors: List<Pair<Long, () -> Boolean>>): State<Boolean> {
+    // Seed from the live state (the combiner is pure) so the overlay starts hidden when it should —
+    // no one-frame flash of guidance over a gesture that is already in progress at first composition.
+    val suppressed = remember { mutableStateOf(anySuppressorActive(suppressors)) }
+    val current = rememberUpdatedState(suppressors)
+    // Re-launch only when crossing the empty/non-empty boundary; fresh predicates are read via `current`.
+    LaunchedEffect(suppressors.isEmpty()) {
+        if (current.value.isEmpty()) { suppressed.value = false; return@LaunchedEffect }
+        val rawOf = { anySuppressorActive(current.value) }
+        val settleOf = { current.value.maxOfOrNull { it.first }?.coerceAtLeast(0L) ?: 0L }
+        var settleJob: Job? = null
+        merge(
+            snapshotFlow { rawOf() },
+            flow { while (true) { emit(rawOf()); delay(STATUS_POLL_MS) } },
+        ).distinctUntilChanged().collect { on ->
+            if (on) {
+                settleJob?.cancel(); settleJob = null
+                suppressed.value = true
+            } else {
+                // Falling edge: keep hidden for the settle window before re-showing (cancelable so a
+                // new suppression that arrives mid-settle re-hides immediately).
+                settleJob?.cancel()
+                settleJob = launch { delay(settleOf()); suppressed.value = false }
+            }
+        }
+    }
+    return suppressed
+}
+
+/**
+ * Observes the app's full status set reactively and returns the ids currently **true**. Statuses come
+ * from three unified sources:
+ *  - developer predicates (`azStatus(id) { … }`), observed via `snapshotFlow` (instant for Compose
+ *    snapshot state) merged with a low-rate poll (covers `StateFlow.value` / a plain `var`) — the same
+ *    engine that drives `expandWhen`;
+ *  - active classifiers ([activeClassifiers]) — a classifier name is a status while it is active;
+ *  - built-in `az.*` ids computed by [builtins] from AzNavHost's live rail/host/route/onscreen state.
+ *
+ * Keyed on the stable predicate-id set so collectors aren't torn down on unrelated recompositions.
+ */
+@Composable
+internal fun rememberActiveStatuses(
+    statusPredicates: Map<String, () -> Boolean>,
+    activeClassifiers: Set<String>,
+    builtins: () -> Set<String>,
+): State<Set<String>> {
+    val customActive = remember { mutableStateMapOf<String, Boolean>() }
+    // Keyed on the stable id set so collectors aren't torn down on unrelated recompositions. The
+    // predicate lambdas are resolved fresh per evaluation through `currentPredicates`, so a developer
+    // re-passing a new lambda for the same id is honored without restarting the running collectors.
+    val currentPredicates by rememberUpdatedState(statusPredicates)
+    val keysSignature = statusPredicates.keys.sorted().joinToString(",")
+    LaunchedEffect(keysSignature) {
+        customActive.clear()
+        currentPredicates.keys.forEach { id ->
+            launch {
+                val evaluate = { currentPredicates[id]?.invoke() ?: false }
+                merge(
+                    snapshotFlow { evaluate() },
+                    flow { while (true) { emit(evaluate()); delay(STATUS_POLL_MS) } },
+                ).distinctUntilChanged().collect { isOn -> customActive[id] = isOn }
+            }
+        }
+    }
+
+    val classifiers = rememberUpdatedState(activeClassifiers)
+    val builtinsFn = rememberUpdatedState(builtins)
+    return remember {
+        derivedStateOf {
+            val out = HashSet<String>()
+            out.addAll(builtinsFn.value())   // reactive: reads AzNavHost snapshot state inside
+            out.addAll(classifiers.value)
+            customActive.forEach { (id, on) -> if (on) out.add(id) }
+            out
+        }
+    }
+}
+
+/**
+ * Maps AzNavHost's live rail/host/route/onscreen state to the set of true built-in `az.*` statuses.
+ * Pure; call it from inside the `builtins` lambda handed to [rememberActiveStatuses] so the reads stay
+ * reactive. The id scheme is the status vocabulary an app inherits for free.
+ */
+internal fun computeBuiltinStatuses(
+    railExpanded: Boolean,
+    railFloating: Boolean,
+    hostStates: Map<String, Boolean>,
+    currentRoute: String?,
+    activeItemId: String?,
+    nestedRailOpenId: String?,
+    helpOpen: Boolean,
+    onscreenVisibleIds: Set<String> = emptySet(),
+): Set<String> {
+    val out = HashSet<String>()
+    out.add("az.app.ready") // always-true root, so navigation auto-edges have a reachable `from`.
+    if (railExpanded) out.add("az.rail.expanded") else out.add("az.rail.collapsed")
+    if (railFloating) out.add("az.rail.floating")
+    hostStates.forEach { (id, expanded) -> if (expanded) out.add("az.host.$id.expanded") }
+    currentRoute?.let { out.add("az.screen.$it") }
+    activeItemId?.let { out.add("az.item.$it.active") }
+    nestedRailOpenId?.let { out.add("az.nestedRail.$it.open") }
+    if (helpOpen) out.add("az.help.open")
+    onscreenVisibleIds.forEach { out.add("az.onscreen.$it.visible") }
+    return out
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/util/EqualWidthLayout.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/util/EqualWidthLayout.kt
@@ -1,0 +1,46 @@
+package com.hereliesaz.aznavrail.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+/**
+ * A custom layout that forces all children to share the width of the widest child.
+ *
+ * Useful for aligning a column of buttons or labels so they appear uniform even when
+ * their intrinsic widths differ. Children are stacked vertically with [verticalSpacing] between them.
+ *
+ * @param modifier Applied to the layout container.
+ * @param verticalSpacing Gap between adjacent children.
+ * @param content The child composables.
+ */
+@Composable
+fun EqualWidthLayout(
+    modifier: Modifier = Modifier,
+    verticalSpacing: Dp = 0.dp,
+    content: @Composable () -> Unit
+) {
+    Layout(
+        modifier = modifier,
+        content = content
+    ) { measurables, constraints ->
+        val maxWidth = measurables.maxOfOrNull { it.maxIntrinsicWidth(constraints.maxHeight) } ?: 0
+        val newConstraints = constraints.copy(minWidth = maxWidth, maxWidth = maxWidth)
+
+        val placeables = measurables.map { it.measure(newConstraints) }
+
+        val spacingPx = verticalSpacing.toPx()
+        val totalHeight = (placeables.sumOf { it.height } + (spacingPx * (placeables.size - 1))).coerceAtLeast(0f)
+
+        layout(newConstraints.maxWidth, totalHeight.roundToInt()) {
+            var y = 0f
+            placeables.forEach { placeable ->
+                placeable.place(0, y.roundToInt())
+                y += placeable.height + spacingPx
+            }
+        }
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/util/HistoryStore.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/util/HistoryStore.kt
@@ -1,0 +1,76 @@
+package com.hereliesaz.aznavrail.util
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * In-memory autocomplete history for [com.hereliesaz.aznavrail.AzTextBox] (CMP port).
+ *
+ * The Android sibling ([com.hereliesaz.aznavrail.util.HistoryManager]) persists history to per-
+ * context files under `Context.filesDir`. Because commonMain has no `Context` and no cross-platform
+ * file-system API in scope for this phase, the CMP port keeps the same public shape
+ * (`updateSettings` / `addEntry` / `getSuggestions`) but drops persistence — entries live only for
+ * the current process. A follow-up phase can add real persistence via `multiplatform-settings` or
+ * Okio without changing this call surface.
+ */
+internal object HistoryStore {
+
+    private const val DEFAULT_HISTORY_CONTEXT = "default"
+
+    private var maxSuggestions = 5
+    private val histories = mutableMapOf<String, MutableList<String>>()
+    private val mutex = Mutex()
+
+    /**
+     * Sets the maximum suggestion count. Clamped to 0..5 to match the Android sibling.
+     */
+    fun updateSettings(suggestionLimit: Int) {
+        maxSuggestions = suggestionLimit.coerceIn(0, 5)
+    }
+
+    /**
+     * Records a submitted value at the front of the history for [historyContext].
+     * No-ops when [text] is blank or the suggestion limit is 0.
+     */
+    fun addEntry(text: String, historyContext: String?) {
+        val ctx = historyContext ?: DEFAULT_HISTORY_CONTEXT
+        if (text.isBlank() || maxSuggestions == 0) return
+        val list = histories.getOrPut(ctx) { mutableListOf() }
+        list.remove(text)
+        list.add(0, text)
+    }
+
+    /**
+     * Returns a ranked list of autocomplete suggestions from history that match [query].
+     * Prefix matches are returned before substring matches. Results are capped to the configured
+     * suggestion limit.
+     */
+    suspend fun getSuggestions(query: String, historyContext: String?): List<String> {
+        val ctx = historyContext ?: DEFAULT_HISTORY_CONTEXT
+        if (maxSuggestions == 0) return emptyList()
+        return mutex.withLock {
+            val history = histories[ctx] ?: return@withLock emptyList()
+            if (query.isBlank()) {
+                history.take(maxSuggestions)
+            } else {
+                val startsWith = ArrayList<String>(maxSuggestions)
+                val contains = ArrayList<String>(maxSuggestions)
+                for (item in history) {
+                    if (item.equals(query, ignoreCase = true)) continue
+                    if (item.startsWith(query, ignoreCase = true)) {
+                        if (startsWith.size < maxSuggestions) startsWith.add(item)
+                    } else if (contains.size < maxSuggestions &&
+                        item.contains(query, ignoreCase = true)) {
+                        contains.add(item)
+                    }
+                    if (startsWith.size >= maxSuggestions) break
+                }
+                val result = ArrayList<String>(maxSuggestions)
+                result.addAll(startsWith)
+                val needed = maxSuggestions - result.size
+                if (needed > 0) result.addAll(contains.take(needed))
+                result
+            }
+        }
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/util/geometry/density.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/util/geometry/density.kt
@@ -1,0 +1,242 @@
+package com.hereliesaz.aznavrail.util.geometry
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import kotlin.math.roundToInt
+
+// Unit-conversion extension functions for use in non-composable lambdas (e.g., DrawScope, Layout).
+// Composable overloads below delegate to LocalDensity.
+
+// DP
+/** Converts [dp] to [TextUnit] (sp), returning [TextUnit.Unspecified] for unspecified input. */
+fun Density.dpToSp(dp: Dp) = if (dp.isSpecified) dp.toSp() else TextUnit.Unspecified
+/** Converts [dp] to a float-precision pixel value; returns `Float.NaN` for unspecified input. */
+fun Density.dpToFloatPx(dp: Dp) = if (dp.isSpecified) dp.toPx() else Float.NaN
+/** Converts [dp] to truncated integer pixels; returns 0 for unspecified input. */
+fun Density.dpToIntPx(dp: Dp) = if (dp.isSpecified) dp.toPx().toInt() else 0
+/** Converts [dp] to rounded integer pixels; returns 0 for unspecified input. */
+fun Density.dpRoundToPx(dp: Dp) = if (dp.isSpecified) dp.roundToPx() else 0
+
+/** Composable accessor for [Density.dpToSp] using [LocalDensity]. */
+@Composable
+fun Dp.toSp() = LocalDensity.current.dpToSp(this)
+/** Composable accessor for [Density.dpToFloatPx] using [LocalDensity]. */
+@Composable
+fun Dp.toFloatPx() = LocalDensity.current.dpToFloatPx(this)
+/** Composable accessor for [Density.dpToIntPx] using [LocalDensity]. */
+@Composable
+fun Dp.toIntPx() = LocalDensity.current.dpToIntPx(this)
+/** Composable accessor for [Density.dpRoundToPx] using [LocalDensity]. */
+@Composable
+fun Dp.roundToPx() = LocalDensity.current.dpRoundToPx(this)
+
+/** Wraps this [Dp] into a square [DpSize] (width == height == this). Returns [DpSize.Unspecified] when this is unspecified. */
+fun Dp.toRecDpSize() = if (isSpecified) DpSize(this, this) else DpSize.Unspecified
+/** Wraps this [Dp] into a square [DpOffset] (x == y == this). Returns [DpOffset.Unspecified] when this is unspecified. */
+fun Dp.toRecDpOffset() = if (isSpecified) DpOffset(this, this) else DpOffset.Unspecified
+
+
+// TEXT UNIT
+/** Converts [sp] to [Dp]; returns [Dp.Unspecified] for unspecified input. */
+fun Density.spToDp(sp: TextUnit) = if (sp.isSpecified) sp.toDp() else Dp.Unspecified
+/** Converts [sp] to float pixels; returns `Float.NaN` for unspecified input. */
+fun Density.spToFloatPx(sp: TextUnit) = if (sp.isSpecified) sp.toPx() else Float.NaN
+/** Converts [sp] to truncated integer pixels; returns 0 for unspecified input. */
+fun Density.spToIntPx(sp: TextUnit) = if (sp.isSpecified) sp.toPx().toInt() else 0
+/** Converts [sp] to rounded integer pixels; returns 0 for unspecified input. */
+fun Density.spRoundToPx(sp: TextUnit) = if (sp.isSpecified) sp.roundToPx() else 0
+
+/** Composable accessor for [Density.spToDp] using [LocalDensity]. */
+@Composable
+fun TextUnit.toDp() = LocalDensity.current.spToDp(this)
+/** Composable accessor for [Density.spToFloatPx] using [LocalDensity]. */
+@Composable
+fun TextUnit.toFloatPx() = LocalDensity.current.spToFloatPx(this)
+/** Composable accessor for [Density.spToIntPx] using [LocalDensity]. */
+@Composable
+fun TextUnit.toIntPx() = LocalDensity.current.spToIntPx(this)
+/** Composable accessor for [Density.spRoundToPx] using [LocalDensity]. */
+@Composable
+fun TextUnit.roundToPx() = LocalDensity.current.spRoundToPx(this)
+
+
+// FLOAT
+/** Converts pixel float [px] to [Dp]; returns [Dp.Unspecified] when [px] is not finite. */
+fun Density.floatPxToDp(px: Float) = if (px.isFinite()) px.toDp() else Dp.Unspecified
+/** Converts pixel float [px] to [TextUnit]; returns [TextUnit.Unspecified] when [px] is not finite. */
+fun Density.floatPxToSp(px: Float) = if (px.isFinite()) px.toSp() else TextUnit.Unspecified
+
+/** Composable accessor for [Density.floatPxToDp] using [LocalDensity]. */
+@Composable
+fun Float.toDp() = LocalDensity.current.floatPxToDp(this)
+/** Composable accessor for [Density.floatPxToSp] using [LocalDensity]. */
+@Composable
+fun Float.toSp() = LocalDensity.current.floatPxToSp(this)
+
+/** Truncates this finite float to integer pixels; returns 0 when not finite. */
+fun Float.toIntPx() = if (isFinite()) toInt() else 0
+/** Rounds this finite float to integer pixels; returns 0 when not finite. */
+fun Float.roundToPx() = if (isFinite()) roundToInt() else 0
+
+/** Wraps this float as a square [Size] (width == height == this). Returns [Size.Unspecified] when not finite. */
+fun Float.toRecSize() = if (isFinite()) Size(this, this) else Size.Unspecified
+/** Wraps this float as a square [Offset] (x == y == this). Returns [Offset.Unspecified] when not finite. */
+fun Float.toRecOffset() = if (isFinite()) Offset(this, this) else Offset.Unspecified
+
+
+// INT
+/** Converts integer pixels [px] to [Dp]. */
+fun Density.intPxToDp(px: Int) = px.toDp()
+/** Converts integer pixels [px] to [TextUnit] (sp). */
+fun Density.intPxToSp(px: Int) = px.toSp()
+
+/** Composable accessor for [Density.intPxToDp] using [LocalDensity]. */
+@Composable
+fun Int.toDp() = LocalDensity.current.intPxToDp(this)
+/** Composable accessor for [Density.intPxToSp] using [LocalDensity]. */
+@Composable
+fun Int.toSp() = LocalDensity.current.intPxToSp(this)
+
+/** Promotes this integer pixel count to a float. */
+fun Int.toFloatPx() = toFloat()
+
+/** Wraps this int as a square [IntSize] (width == height == this). */
+fun Int.toRecIntSize() = IntSize(this, this)
+/** Wraps this int as a square [IntOffset] (x == y == this). */
+fun Int.toRecIntOffset() = IntOffset(this, this)
+
+
+// DP SIZE
+/** Converts [dpSize] to truncated [IntSize]; returns [IntSize.Zero] when unspecified. */
+fun Density.dpSizeToIntSize(dpSize: DpSize) =
+    if (dpSize.isSpecified) IntSize(dpSize.width.toPx().toInt(), dpSize.height.toPx().toInt())
+    else IntSize.Zero
+
+/** Converts [dpSize] to rounded [IntSize]; returns [IntSize.Zero] when unspecified. */
+fun Density.dpSizeRoundToIntSize(dpSize: DpSize) =
+    if (dpSize.isSpecified) IntSize(dpSize.width.roundToPx(), dpSize.height.roundToPx())
+    else IntSize.Zero
+
+/** Converts [dpSize] to float-pixel [Size]; returns [Size.Unspecified] when unspecified. */
+fun Density.dpSizeToSize(dpSize: DpSize) =
+    if (dpSize.isSpecified) Size(dpSize.width.toPx(), dpSize.height.toPx())
+    else Size.Unspecified
+
+/** Composable accessor for [Density.dpSizeToIntSize] using [LocalDensity]. */
+@Composable
+fun DpSize.toIntSize() = LocalDensity.current.dpSizeToIntSize(this)
+/** Composable accessor for [Density.dpSizeRoundToIntSize] using [LocalDensity]. */
+@Composable
+fun DpSize.roundToIntSize() = LocalDensity.current.dpSizeRoundToIntSize(this)
+/** Composable accessor for [Density.dpSizeToSize] using [LocalDensity]. */
+@Composable
+fun DpSize.toSize() = LocalDensity.current.dpSizeToSize(this)
+
+/** Returns true when this size is specified and both dimensions are strictly positive. */
+fun DpSize.isSpaced() = isSpecified && width > 0.dp && height > 0.dp
+
+
+// SIZE
+/** Converts pixel [size] to [DpSize]; returns [DpSize.Unspecified] when unspecified. */
+fun Density.sizeToDpSize(size: Size) =
+    if (size.isSpecified) DpSize(size.width.toDp(), size.height.toDp())
+    else DpSize.Unspecified
+
+/** Composable accessor for [Density.sizeToDpSize] using [LocalDensity]. */
+@Composable
+fun Size.toDpSize() =
+    if (isSpecified) LocalDensity.current.sizeToDpSize(this)
+    else DpSize.Unspecified
+
+/** Truncates this [Size] to [IntSize]; returns [IntSize.Zero] when unspecified. */
+fun Size.toIntSize() =
+    if (isSpecified) IntSize(width.toInt(), height.toInt())
+    else IntSize.Zero
+
+/** Returns true when this [Size] is specified and both dimensions are strictly positive. */
+fun Size.isSpaced() = isSpecified && width > 0F && height > 0F
+
+
+// INT SIZE
+/** Converts integer [intSize] to [DpSize]. */
+fun Density.intSizeToDpSize(intSize: IntSize) =
+    DpSize(intSize.width.toDp(), intSize.height.toDp())
+
+/** Composable accessor for [Density.intSizeToDpSize] using [LocalDensity]. */
+@Composable
+fun IntSize.toDpSize() = LocalDensity.current.intSizeToDpSize(this)
+
+/** Promotes this [IntSize] to a float [Size]. */
+@Composable
+fun IntSize.toSize() = Size(width.toFloat(), height.toFloat())
+
+/** Returns true when both [IntSize] dimensions are strictly positive. */
+fun IntSize.isSpaced() = width > 0 && height > 0
+
+
+// DP OFFSET
+/** Converts [dpOffset] to truncated [IntOffset]; returns [IntOffset.Zero] when unspecified. */
+fun Density.dpOffsetToIntOffset(dpOffset: DpOffset) =
+    if (dpOffset.isSpecified) IntOffset(dpOffset.x.toPx().toInt(), dpOffset.y.toPx().toInt())
+    else IntOffset.Zero
+
+/** Converts [dpOffset] to rounded [IntOffset]; returns [IntOffset.Zero] when unspecified. */
+fun Density.dpOffsetRoundToIntOffset(dpOffset: DpOffset) =
+    if (dpOffset.isSpecified) IntOffset(dpOffset.x.roundToPx(), dpOffset.y.roundToPx())
+    else IntOffset.Zero
+
+/** Converts [dpOffset] to float-pixel [Offset]; returns [Offset.Unspecified] when unspecified. */
+fun Density.dpOffsetToOffset(dpOffset: DpOffset) =
+    if (dpOffset.isSpecified) Offset(dpOffset.x.toPx(), dpOffset.y.toPx())
+    else Offset.Unspecified
+
+/** Composable accessor for [Density.dpOffsetToIntOffset] using [LocalDensity]. */
+@Composable
+fun DpOffset.toIntOffset() = LocalDensity.current.dpOffsetToIntOffset(this)
+/** Composable accessor for [Density.dpOffsetRoundToIntOffset] using [LocalDensity]. */
+@Composable
+fun DpOffset.roundToIntOffset() = LocalDensity.current.dpOffsetRoundToIntOffset(this)
+/** Composable accessor for [Density.dpOffsetToOffset] using [LocalDensity]. */
+@Composable
+fun DpOffset.toOffset() = LocalDensity.current.dpOffsetToOffset(this)
+
+
+// OFFSET
+/** Converts pixel [offset] to [DpOffset]; returns [DpOffset.Unspecified] when unspecified. */
+fun Density.offsetToDpOffset(offset: Offset) =
+    if (offset.isSpecified) DpOffset(offset.x.toDp(), offset.y.toDp())
+    else DpOffset.Unspecified
+
+/** Composable accessor for [Density.offsetToDpOffset] using [LocalDensity]. */
+@Composable
+fun Offset.toDpOffset() = LocalDensity.current.offsetToDpOffset(this)
+
+/** Truncates this [Offset] to [IntOffset]; returns [IntOffset.Zero] when unspecified. */
+fun Offset.toIntOffset() =
+    if (isSpecified) IntOffset(x.toInt(), y.toInt())
+    else IntOffset.Zero
+
+
+// INT OFFSET
+/** Converts integer [intOffset] to [DpOffset]. */
+fun Density.intOffsetToDpOffset(intOffset: IntOffset) =
+    DpOffset(intOffset.x.toDp(), intOffset.y.toDp())
+
+/** Composable accessor for [Density.intOffsetToDpOffset] using [LocalDensity]. */
+@Composable
+fun IntOffset.toDpOffset() = LocalDensity.current.intOffsetToDpOffset(this)
+
+/** Promotes this [IntOffset] to a float [Offset]. */
+fun IntOffset.toOffset() = Offset(x.toFloat(), y.toFloat())

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/util/text/AutoSizeText.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/util/text/AutoSizeText.kt
@@ -1,0 +1,437 @@
+/*
+MIT License
+
+Copyright (c) 2024 Reda El Madini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package com.hereliesaz.aznavrail.util.text
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxWithConstraintsScope
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.fastAll
+import androidx.compose.ui.util.fastCoerceAtLeast
+import androidx.compose.ui.util.fastCoerceIn
+import androidx.compose.ui.util.fastFilter
+import com.hereliesaz.aznavrail.internal.AzNavRailLogger
+import com.hereliesaz.aznavrail.util.geometry.intPxToSp
+import com.hereliesaz.aznavrail.util.geometry.spRoundToPx
+import com.hereliesaz.aznavrail.util.geometry.spToIntPx
+import com.hereliesaz.aznavrail.util.text.SuggestedFontSizesStatus.Companion.validSuggestedFontSizes
+import kotlin.math.min
+
+private const val TAG = "AutoSizeText"
+
+/**
+ * Composable function that automatically adjusts the text size to fit within given constraints,
+ * considering the ratio of line spacing to text size.
+ *
+ * Features:
+ * 1. Best performance: Utilizes a dichotomous binary search algorithm for swift and optimal text size determination without unnecessary iterations.
+ * 2. Alignment support: Supports six possible alignment values via the Alignment interface.
+ * 3. Material Design 3 support.
+ * 4. Font scaling support: User-initiated font scaling doesn't affect the visual rendering output.
+ * 5. Multiline Support with maxLines Parameter.
+ *
+ * @param text the text to be displayed
+ * @param modifier the [Modifier] to be applied to this layout node
+ * @param color [Color] to apply to the text. If [Color.Unspecified], and [style] has no color set,
+ * this will be [LocalContentColor].
+ * @param suggestedFontSizes The suggested font sizes to choose from (Should be sorted from smallest to largest, not empty and contains only sp text unit).
+ * @param suggestedFontSizesStatus Whether or not suggestedFontSizes is valid: not empty - contains oly sp text unit - sorted.
+ * You can check validity by invoking [List<TextUnit>.suggestedFontSizesStatus].
+ * @param stepGranularityTextSize The step size for adjusting the text size. this parameter is ignored if [suggestedFontSizes] is specified and [suggestedFontSizesStatus] is [SuggestedFontSizesStatus.VALID].
+ * @param minTextSize The minimum text size allowed. this parameter is ignored if [suggestedFontSizes] is specified or [suggestedFontSizesStatus] is [SuggestedFontSizesStatus.VALID].
+ * @param maxTextSize The maximum text size allowed.
+ * @param fontStyle the typeface variant to use when drawing the letters (e.g., italic).
+ * See [TextStyle.fontStyle].
+ * @param fontWeight the typeface thickness to use when painting the text (e.g., [FontWeight.Bold]).
+ * @param fontFamily the font family to be used when rendering the text. See [TextStyle.fontFamily].
+ * @param letterSpacing the amount of space to add between each letter.
+ * See [TextStyle.letterSpacing].
+ * @param textDecoration the decorations to paint on the text (e.g., an underline).
+ * See [TextStyle.textDecoration].
+ * @param alignment The alignment of the text within its container.
+ * @param overflow how visual overflow should be handled.
+ * @param softWrap whether the text should break at soft line breaks. If false, the glyphs in the
+ * text will be positioned as if there was unlimited horizontal space. If [softWrap] is false,
+ * [overflow] and TextAlign may have unexpected effects.
+ * @param maxLines An optional maximum number of lines for the text to span, wrapping if
+ * necessary. If the text exceeds the given number of lines, it will be truncated according to
+ * [overflow] and [softWrap]. It is required that 1 <= [minLines] <= [maxLines].
+ * @param minLines The minimum height in terms of minimum number of visible lines. It is required
+ * that 1 <= [minLines] <= [maxLines].
+ * insert composables into text layout. See [InlineTextContent].
+ * @param onTextLayout callback that is executed when a new text layout is calculated. A
+ * [TextLayoutResult] object that callback provides contains paragraph information, size of the
+ * text, baselines and other details. The callback can be used to add additional decoration or
+ * functionality to the text. For example, to draw selection around the text.
+ * @param style style configuration for the text such as color, font, line height etc.
+ * @param lineSpaceRatio The ratio of line spacing to text size.
+ *
+ * @author Reda El Madini - For support, contact gladiatorkilo@gmail.com
+ */
+@Composable
+fun AutoSizeText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    suggestedFontSizes: List<TextUnit> = emptyList(),
+    suggestedFontSizesStatus: SuggestedFontSizesStatus = SuggestedFontSizesStatus.UNKNOWN,
+    stepGranularityTextSize: TextUnit = TextUnit.Unspecified,
+    minTextSize: TextUnit = TextUnit.Unspecified,
+    maxTextSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    alignment: Alignment = Alignment.TopStart,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current,
+    lineSpaceRatio: Float = style.lineHeight.value / style.fontSize.value,
+) {
+    AutoSizeText(
+        text = AnnotatedString(text),
+        modifier = modifier,
+        color = color,
+        suggestedFontSizes = suggestedFontSizes,
+        suggestedFontSizesStatus = suggestedFontSizesStatus,
+        stepGranularityTextSize = stepGranularityTextSize,
+        minTextSize = minTextSize,
+        maxTextSize = maxTextSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        alignment = alignment,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = style,
+        lineSpacingRatio = lineSpaceRatio,
+    )
+}
+
+/**
+ * Composable function that automatically adjusts the text size to fit within given constraints using AnnotatedString,
+ * considering the ratio of line spacing to text size.
+ *
+ * Features:
+ * Similar to AutoSizeText(String), with support for AnnotatedString.
+ *
+ * @param inlineContent a map storing composables that replaces certain ranges of the text, used to
+ * insert composables into text layout. See [InlineTextContent].
+ * @see AutoSizeText
+ */
+@Composable
+fun AutoSizeText(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    suggestedFontSizes: List<TextUnit> = emptyList(),
+    suggestedFontSizesStatus: SuggestedFontSizesStatus = SuggestedFontSizesStatus.UNKNOWN,
+    stepGranularityTextSize: TextUnit = TextUnit.Unspecified,
+    minTextSize: TextUnit = TextUnit.Unspecified,
+    maxTextSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    alignment: Alignment = Alignment.TopStart,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    inlineContent: Map<String, InlineTextContent> = mapOf(),
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current,
+    lineSpacingRatio: Float = style.lineHeight.value / style.fontSize.value,
+) {
+    // Change font scale to 1F
+    val density = Density(density = LocalDensity.current.density, fontScale = 1F)
+
+    CompositionLocalProvider(LocalDensity provides density) {
+        BoxWithConstraints(
+            modifier = modifier,
+            contentAlignment = alignment,
+        ) {
+            val combinedTextStyle = LocalTextStyle.current + style.copy(
+                color = color.takeIf { it.isSpecified } ?: style.color,
+                fontStyle = fontStyle ?: style.fontStyle,
+                fontWeight = fontWeight ?: style.fontWeight,
+                fontFamily = fontFamily ?: style.fontFamily,
+                letterSpacing = letterSpacing.takeIf { it.isSpecified } ?: style.letterSpacing,
+                textDecoration = textDecoration ?: style.textDecoration,
+                textAlign = if (style.textAlign == TextAlign.Justify) TextAlign.Justify else when (alignment) {
+                    Alignment.TopStart, Alignment.CenterStart, Alignment.BottomStart -> TextAlign.Start
+                    Alignment.TopCenter, Alignment.Center, Alignment.BottomCenter -> TextAlign.Center
+                    Alignment.TopEnd, Alignment.CenterEnd, Alignment.BottomEnd -> TextAlign.End
+                    else -> TextAlign.Unspecified
+                },
+            )
+
+            val layoutDirection = LocalLayoutDirection.current
+            val fontFamilyResolver = LocalFontFamilyResolver.current
+            val textMeasurer = rememberTextMeasurer()
+            val coercedLineSpacingRatio = lineSpacingRatio.takeIf { it.isFinite() && it >= 1 } ?: 1F
+
+            val shouldMoveBackward: (TextUnit) -> Boolean = {
+                shouldShrink(
+                    text = text,
+                    textStyle = combinedTextStyle.copy(
+                        fontSize = it,
+                        lineHeight = it * coercedLineSpacingRatio,
+                    ),
+                    maxLines = maxLines,
+                    layoutDirection = layoutDirection,
+                    softWrap = softWrap,
+                    density = density,
+                    fontFamilyResolver = fontFamilyResolver,
+                    textMeasurer = textMeasurer,
+                )
+            }
+
+            val electedFontSize = remember(
+                key1 = suggestedFontSizes,
+                key2 = suggestedFontSizesStatus,
+            ) {
+                if (suggestedFontSizesStatus == SuggestedFontSizesStatus.VALID)
+                    suggestedFontSizes
+                else suggestedFontSizes.validSuggestedFontSizes
+            }?.let {
+                remember(
+                    key1 = it,
+                    key2 = shouldMoveBackward,
+                ) {
+                    it.findElectedValue(shouldMoveBackward = shouldMoveBackward)
+                }
+            } ?: run {
+                val candidateFontSizesIntProgress = rememberCandidateFontSizesIntProgress(
+                    density = density,
+                    intSize = IntSize(constraints.maxWidth, constraints.maxHeight),
+                    maxTextSize = maxTextSize,
+                    minTextSize = minTextSize,
+                    stepGranularityTextSize = stepGranularityTextSize,
+                )
+                remember(
+                    key1 = candidateFontSizesIntProgress,
+                    key2 = shouldMoveBackward,
+                ) {
+                    candidateFontSizesIntProgress.findElectedValue(
+                        transform = { density.intPxToSp(it) },
+                        shouldMoveBackward = shouldMoveBackward,
+                    )
+                }
+            }
+
+            if (electedFontSize == 0.sp) {
+                AzNavRailLogger.e(
+                    TAG,
+                    """The text cannot be displayed. Please consider the following options:
+| 1. Providing 'suggestedFontSizes' with smaller values that can be utilized.
+| 2. Decreasing the 'stepGranularityTextSize' value.
+| 3. Adjusting the 'minTextSize' parameter to a suitable value and ensuring the overflow parameter is set to "TextOverflow.Ellipsis".
+""".trimMargin(),
+                )
+                return@BoxWithConstraints
+            }
+
+            Text(
+                text = text,
+                overflow = overflow,
+                softWrap = softWrap,
+                maxLines = maxLines,
+                minLines = minLines,
+                inlineContent = inlineContent,
+                onTextLayout = onTextLayout,
+                style = combinedTextStyle.copy(
+                    fontSize = electedFontSize,
+                    lineHeight = electedFontSize * coercedLineSpacingRatio,
+                ),
+            )
+        }
+    }
+}
+
+private fun BoxWithConstraintsScope.shouldShrink(
+    text: AnnotatedString,
+    textStyle: TextStyle,
+    maxLines: Int,
+    layoutDirection: LayoutDirection,
+    softWrap: Boolean,
+    density: Density,
+    fontFamilyResolver: FontFamily.Resolver,
+    textMeasurer: TextMeasurer,
+) = textMeasurer.measure(
+    text = text,
+    style = textStyle,
+    overflow = TextOverflow.Clip,
+    softWrap = softWrap,
+    maxLines = maxLines,
+    constraints = constraints,
+    layoutDirection = layoutDirection,
+    density = density,
+    fontFamilyResolver = fontFamilyResolver,
+).hasVisualOverflow
+
+@Stable
+@Composable
+private fun rememberCandidateFontSizesIntProgress(
+    density: Density,
+    intSize: IntSize,
+    minTextSize: TextUnit = TextUnit.Unspecified,
+    maxTextSize: TextUnit = TextUnit.Unspecified,
+    stepGranularityTextSize: TextUnit = TextUnit.Unspecified,
+): IntProgression {
+    val max = remember(key1 = maxTextSize, key2 = intSize) {
+        min(intSize.width, intSize.height).let { max ->
+            maxTextSize.takeIf { it.isSp }?.let { density.spRoundToPx(it) }?.fastCoerceIn(0, max) ?: max
+        }
+    }
+
+    val min = remember(key1 = minTextSize, key2 = max) {
+        minTextSize.takeIf { it.isSp }?.let { density.spToIntPx(it) }?.fastCoerceIn(0, max) ?: 0
+    }
+
+    val step = remember(
+        key1 = min,
+        key2 = max,
+        key3 = stepGranularityTextSize,
+    ) {
+        stepGranularityTextSize.takeIf { it.isSp }?.let { density.spToIntPx(it) }?.fastCoerceIn(1, max - min) ?: 1
+    }
+
+    return remember(key1 = min, key2 = max, key3 = step) {
+        min..max step step
+    }
+}
+
+internal fun <T> List<T>.findElectedValue(shouldMoveBackward: (T) -> Boolean) = indices.findElectedValue(
+    transform = { this[it] },
+    shouldMoveBackward = shouldMoveBackward,
+)
+
+/**
+ * Performs a binary search on an [IntProgression] to find the largest value that satisfies
+ * a given condition. It's optimized for finding the optimal font size efficiently.
+ *
+ * This function is a variation of binary search. It searches for the "last true" or "first false"
+ * element in a conceptually partitioned range. It determines the highest possible value (e.g., font size)
+ * that does not cause an overflow or meets a certain criteria defined by [shouldMoveBackward].
+ *
+ * The search works on the indices of the progression (`low` and `high` are indices, not the actual values).
+ * - If `shouldMoveBackward(transform(mid * step))` is `true`, it means the current value is too large,
+ *   so the search space is narrowed to the lower half (`high = mid - 1`).
+ * - If it's `false`, the value is acceptable, and we try for a larger one in the upper half (`low = mid + 1`).
+ *
+ * The loop terminates when `low > high`. At this point, `high` points to the index of the largest
+ * value for which `shouldMoveBackward` was `false` (or the one just before the first `true`).
+ * This `high` index is then used to retrieve the elected value.
+ *
+ * @param T The type of the value being evaluated (e.g., [TextUnit] for font size).
+ * @param transform A function to convert an `Int` from the progression into a value of type [T].
+ * @param shouldMoveBackward A predicate that returns `true` if the search should move to smaller values
+ * (i.e., the current value is "too big"), and `false` otherwise.
+ * @return The largest value of type [T] for which [shouldMoveBackward] is `false`. If all values
+ * result in `true`, the smallest value in the progression is returned.
+ */
+private fun <T> IntProgression.findElectedValue(
+    transform: (Int) -> T,
+    shouldMoveBackward: (T) -> Boolean,
+) = kotlin.run {
+    var low = first / step
+    var high = last / step
+    while (low <= high) {
+        val mid = low + (high - low) / 2
+        if (shouldMoveBackward(transform(mid * step))) high = mid - 1
+        else low = mid + 1
+    }
+    transform((high * step).fastCoerceAtLeast(first * step))
+}
+
+/**
+ * Validity tri-state for the `suggestedFontSizes` list passed to [AutoSizeText].
+ *
+ * Mark a list as [VALID] only when it is non-empty, contains only sp values, and is already sorted
+ * ascending — this skips the runtime normalization pass and is the cheaper code path.
+ */
+enum class SuggestedFontSizesStatus {
+    /** Caller guarantees the list is non-empty, all-sp, and sorted ascending; no runtime check. */
+    VALID,
+    /** Caller asserts the list is malformed; AutoSizeText falls back to the candidate-size search. */
+    INVALID,
+    /** Caller does not know — AutoSizeText runs [validSuggestedFontSizes] to normalize. */
+    UNKNOWN;
+
+    companion object {
+        /** Returns [VALID] when the receiver is non-empty, all-sp, and sorted ascending; otherwise [INVALID]. */
+        val List<TextUnit>.suggestedFontSizesStatus: SuggestedFontSizesStatus
+            get() = if (isNotEmpty() && fastAll { it.isSp } && sortedBy { it.value } == this) VALID
+            else INVALID
+
+        /**
+         * Returns a sanitized copy of the receiver — filtered to sp values and sorted ascending —
+         * or `null` if the receiver is empty or contains no sp values.
+         */
+        val List<TextUnit>.validSuggestedFontSizes: List<TextUnit>?
+            get() = takeIf { it.isNotEmpty() } // Optimization: empty check first to immediately return null
+                ?.fastFilter { it.isSp }?.takeIf { it.isNotEmpty() }?.sortedBy { it.value }
+    }
+}

--- a/aznavrail-cmp/src/desktopMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.desktop.kt
+++ b/aznavrail-cmp/src/desktopMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.desktop.kt
@@ -1,0 +1,6 @@
+package com.hereliesaz.aznavrail.internal
+
+internal actual fun platformLogE(tag: String, message: String, throwable: Throwable?) {
+    System.err.println("E/$tag: $message")
+    throwable?.printStackTrace()
+}

--- a/aznavrail-cmp/src/iosMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.ios.kt
+++ b/aznavrail-cmp/src/iosMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.ios.kt
@@ -1,0 +1,6 @@
+package com.hereliesaz.aznavrail.internal
+
+internal actual fun platformLogE(tag: String, message: String, throwable: Throwable?) {
+    println("E/$tag: $message")
+    throwable?.printStackTrace()
+}

--- a/aznavrail-cmp/src/wasmJsMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.wasmJs.kt
+++ b/aznavrail-cmp/src/wasmJsMain/kotlin/com/hereliesaz/aznavrail/internal/AzNavRailLogger.wasmJs.kt
@@ -1,0 +1,6 @@
+package com.hereliesaz.aznavrail.internal
+
+internal actual fun platformLogE(tag: String, message: String, throwable: Throwable?) {
+    println("E/$tag: $message")
+    throwable?.printStackTrace()
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -982,10 +982,22 @@ fun AzDropdownMenu(
                             .then(if (config.design == AzDropdownDesign.RAIL) Modifier.padding(8.dp) else Modifier),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
+                        val entryDensity = androidx.compose.ui.platform.LocalDensity.current
                         entries.forEachIndexed { index, entry ->
-                            // Skip the tapped-to-close entry — the DissolveOverlay is animating
-                            // its label instead. Prevents animating the label in two places.
-                            if (dissolving?.itemId == "azdd:$index") return@forEachIndexed
+                            // If this entry was the one tapped-to-close, render an invisible
+                            // placeholder the same height as the captured entry so the panel
+                            // stays occupied while the dissolve overlay animates its label. A bare
+                            // `Spacer` doesn't draw or hit-test — it just holds the layout so the
+                            // rows below don't snap upward during the dissolve.
+                            val dissolvingHere = dissolving?.takeIf { it.itemId == "azdd:$index" }
+                            if (dissolvingHere != null) {
+                                Spacer(
+                                    Modifier.height(
+                                        with(entryDensity) { dissolvingHere.bounds.height.toDp() }
+                                    )
+                                )
+                                return@forEachIndexed
+                            }
                             AzDropdownEntryItem(
                                 index = index,
                                 count = entries.size,

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -731,13 +731,23 @@ fun AzNavRail(
                                 .fillMaxSize()
                                 .verticalScroll(scrollState)
                         ) {
+                            val density = LocalDensity.current
                             topLevelItems.forEachIndexed { index, item ->
-                                // If this item was the one tapped-to-close, skip its render — the
-                                // dissolve overlay is drawing its label at the captured bounds and
-                                // sliding it away. Skipping avoids animating the label in two
-                                // places at once (once here as it exit-turnstiles, once in the
-                                // overlay).
-                                if (dissolving?.itemId == item.id) return@forEachIndexed
+                                // If this item was the one tapped-to-close, render an invisible
+                                // placeholder the same height as the captured item so the row
+                                // stays occupied while the dissolve overlay animates its label.
+                                // A bare `Spacer` doesn't draw or hit-test, so it holds the layout
+                                // without duplicating the label — the overlay draws the label at
+                                // the item's captured bounds and slides it toward centre.
+                                val dissolvingHere = dissolving?.takeIf { it.itemId == item.id }
+                                if (dissolvingHere != null) {
+                                    Spacer(
+                                        Modifier.height(
+                                            with(density) { dissolvingHere.bounds.height.toDp() }
+                                        )
+                                    )
+                                    return@forEachIndexed
+                                }
                                 MenuItemNode(
                                     item = item,
                                     allItems = displayItems,
@@ -915,23 +925,11 @@ fun AzNavRail(
         }
     }
 
-    // Dissolve overlay for a tapped menu item that collapses the drawer. Renders as a full-screen
-    // `Popup` outside every clipping ancestor, so the label can slide across the docked-edge as it
-    // fades. Cleared once its animation completes.
-    dissolving?.let { snapshot ->
-        val accent = scope.activeColor.takeOrElse { MaterialTheme.colorScheme.primary }
-        val style = MaterialTheme.typography.titleLarge.let { base ->
-            scope.itemTextStyle?.let { base.merge(it) } ?: base
-        }
-        com.hereliesaz.aznavrail.internal.DissolveOverlay(
-            state = snapshot,
-            textStyle = style,
-            color = accent,
-            durationMs = scope.entranceDurationMs,
-            easing = scope.entranceEasing,
-            onFinished = { dissolving = null },
-        )
-    }
+    // Dissolve overlay moved to the end of the composable so it composes AFTER every other
+    // overlay (guidance/instruction callouts). Last-composed wins draw order within the same
+    // Popup layer; combined with `zIndex(Float.MAX_VALUE)` inside DissolveOverlay itself, the
+    // dissolving label is guaranteed to sit above the rail and every other overlay it stacks
+    // against.
 }
 
     // The About reader, Help overlay, and "More from Az" carousel are now rendered by
@@ -1065,6 +1063,25 @@ fun AzNavRail(
     } else {
         // Nothing showing: clear the published snapshot so observers see an empty state.
         LaunchedEffect(guidanceController) { guidanceController.publishCurrent(emptyList()) }
+    }
+
+    // Dissolve overlay for a tapped menu item that collapses the drawer. Rendered as the LAST
+    // child of the composable so its Popup composes after every other overlay (guidance/help/etc.)
+    // in the same overlay layer, and its inner `zIndex(Float.MAX_VALUE)` guarantees ordering even
+    // if it ever ends up sharing a layer. Cleared once its animation completes.
+    dissolving?.let { snapshot ->
+        val accent = scope.activeColor.takeOrElse { MaterialTheme.colorScheme.primary }
+        val style = MaterialTheme.typography.titleLarge.let { base ->
+            scope.itemTextStyle?.let { base.merge(it) } ?: base
+        }
+        com.hereliesaz.aznavrail.internal.DissolveOverlay(
+            state = snapshot,
+            textStyle = style,
+            color = accent,
+            durationMs = scope.entranceDurationMs,
+            easing = scope.entranceEasing,
+            onFinished = { dissolving = null },
+        )
     }
 }
 

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -731,7 +731,6 @@ fun AzNavRail(
                                 .fillMaxSize()
                                 .verticalScroll(scrollState)
                         ) {
-                            val density = LocalDensity.current
                             topLevelItems.forEachIndexed { index, item ->
                                 // If this item was the one tapped-to-close, render an invisible
                                 // placeholder the same height as the captured item so the row

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/DissolveOverlay.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/DissolveOverlay.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.zIndex
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
@@ -75,7 +76,14 @@ internal fun DissolveOverlay(
         // is positioned by an `.offset(x, y)` inside that Box, so we don't need any anchor here.
         popupPositionProvider = TopLeftPositionProvider,
     ) {
-        Box(Modifier.fillMaxSize()) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                // Belt-and-braces above the rail. Popup already renders in a separate window layer
+                // above sibling Compose content, but max-z inside the Popup's own container guards
+                // the ordering even if the overlay ever ends up sharing a layer with another node.
+                .zIndex(Float.MAX_VALUE),
+        ) {
             // Screen center X in px — the label's `translationX` targets this from its captured
             // left edge, minus half the label's width so its centre lands on the screen centre.
             val screenWidthPx = androidx.compose.ui.platform.LocalWindowInfo.current.containerSize.width.toFloat()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,6 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.parcelize) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.compose.multiplatform) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ robolectric = "4.16.1"
 ksp = "2.3.8"
 kotlinpoet = "2.3.0"
 composeMultiplatform = "1.11.1"
+activityComposeCmp = "1.11.0"
 
 [libraries]
 aznavrail = { group = "com.github.HereLiesAz", name = "AzNavRail", version.ref = "aznavrail" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ ui = "1.11.1"
 robolectric = "4.16.1"
 ksp = "2.3.8"
 kotlinpoet = "2.3.0"
+composeMultiplatform = "1.11.1"
 
 [libraries]
 aznavrail = { group = "com.github.HereLiesAz", name = "AzNavRail", version.ref = "aznavrail" }
@@ -60,3 +61,5 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "androidLibrary" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ ksp = "2.3.8"
 kotlinpoet = "2.3.0"
 composeMultiplatform = "1.11.1"
 activityComposeCmp = "1.11.0"
+coil3 = "3.5.0"
 
 [libraries]
 aznavrail = { group = "com.github.HereLiesAz", name = "AzNavRail", version.ref = "aznavrail" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ kotlinpoet = "2.3.0"
 composeMultiplatform = "1.11.1"
 activityComposeCmp = "1.11.0"
 coil3 = "3.5.0"
+navigationComposeCmp = "2.9.2"
 
 [libraries]
 aznavrail = { group = "com.github.HereLiesAz", name = "AzNavRail", version.ref = "aznavrail" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,3 +20,4 @@ dependencyResolutionManagement {
 rootProject.name = "AzNavRail"
 include(":SampleApp")
 include(":aznavrail")
+include(":aznavrail-cmp")


### PR DESCRIPTION
## Part 1 — Dissolve overlay fixes

Two visual bugs in the dissolve overlay shipped by PR #485 called out by feedback:

- **Hold the tapped slot.** The rail's item loop (and dropdown's entries loop) used `return@forEachIndexed` to skip the tapped item's render, which removed its row from the layout entirely — its neighbours snapped up. Replaced the skip with an invisible `Spacer(Modifier.height(dissolvingHere.bounds.height.toDp()))`.
- **Pin z-index above the rail.** Added `Modifier.zIndex(Float.MAX_VALUE)` to the outer Box inside `DissolveOverlay`'s Popup, and moved `AzNavRail`'s `dissolving?.let { ... }` block to the very end of the composable.

Files: `AzNavRail.kt`, `AzDropdownMenu.kt`, `internal/DissolveOverlay.kt`.

## Part 2 — Compose Multiplatform sibling module (`aznavrail-cmp`)

A new sibling module ships alongside the Android library, targeting `androidTarget` + `jvm("desktop")` + `iosX64/iosArm64/iosSimulatorArm64` + `wasmJs { browser() }`. The existing Android `aznavrail/` module is byte-identical to `main`.

### Phase A — scaffold (green on `4378e6b` and earlier)

- `aznavrail-cmp/build.gradle.kts` — KMP + JB Compose + K2 compose-compiler + Android library plugins; targets listed above; `commonMain` deps on `compose.runtime/foundation/material3/ui/components.resources`.
- `settings.gradle.kts` + `gradle/libs.versions.toml` — module include + `composeMultiplatform = "1.11.1"` (matches the existing `ui = 1.11.1`) + plugin aliases.
- `AzCmpPreview.kt` placeholder + minimal `AndroidManifest.xml`.
- Also declared `kotlin-multiplatform` + `compose-multiplatform` at the root `build.gradle.kts` with `apply false` — CI failure `The plugin is already on the classpath with an unknown version` fixed. `androidLibrary { }` reverted to `android { }` because this project pins `android.newDsl=false` in `gradle.properties`.

### Phase B — verbatim ports of Tier-1 files (~26 files, ~2,000 lines)

Copy of every file that only imports Compose UI + kotlinx.coroutines, no `android.*`, no `@Parcelize`, no `LocalContext`. Batches split by dependency graph so each batch compiles cleanly against the previous.

- Batch 1 (21 leaves): all `model/*` except `AzNavItem`/`HiddenMenuItem`, `AzDivider`, `AzLoad`, `util/EqualWidthLayout`, `util/geometry/density`, `internal/AzJustify`, `internal/AzLayoutConfig`, `tutorial/AzCalloutPlacement`, `tutorial/AzStatus`, `tutorial/AzStatusEngine`.
- Batch 2 (5 dep-on-leaves): `bottomsheet/AzSheetController`, `internal/AzSheetMetrics`, `internal/AzKinetics`, `internal/AzSheetGestures`, `internal/AzMarkdown`.

### Phase C — Tier-2 unblocks (~16 files + platform expect/actuals + 3 deps)

- **Logger expect/actual** (`internal/AzNavRailLogger` in commonMain; `expect fun platformLogE`; `actual` in androidMain uses `android.util.Log.e`, desktop/iOS/wasmJs use `println` + `printStackTrace`).
- **`AzNavRailDefaults` + `DissolveOverlay` + `AzBottomSheetShell`** — extracted / ported once their tainted co-tenants were siphoned.
- **Models sans `@Parcelize`** — `AzNavItem` and `HiddenMenuItem` as plain data classes; `@RawValue` dropped. Neither is used with `rememberSaveable` anywhere, so `@Serializable` isn't needed. Unblocks `RelocItemHandler` and `AzAdvancedConfig`.
- **`activity-compose` CMP fork** (`org.jetbrains.androidx.activity:activity-compose:1.11.0`) — provides `BackHandler` in commonMain. Unblocks `bottomsheet/AzBottomSheet`.
- **`HistoryStore` (in-memory)** — replaces the Android `HistoryManager` for the CMP port. `AzTextBox` + `AzForm` + `AzRoller` ported with three-line swap (drop `LocalContext`, `HistoryManager.*` → `HistoryStore.*`). Persistence deferred; consumers who need it can add multiplatform-settings later.
- **Coil3** (`io.coil-kt.coil3:coil-compose:3.5.0`) — replaces Android-only Coil2. `coil.compose.rememberAsyncImagePainter` → `coil3.compose.rememberAsyncImagePainter`. `AutoSizeText` ported (Log.w → `AzNavRailLogger.e`). `AzNavRailButton` ported (drop LocalContext + Int-as-drawable-resource branch — Android-only, `painterResource(Int)` needs `Resources`). `AzButton` ported verbatim.
- **`LocalAzSafeZones` split** into its own file (Android sibling keeps it in `AzNavHost`, which drags in nav + Activity).
- **`AzGuidance` (session-only)** — the guidance controller ported without `SharedPreferences` persistence. `rememberAzGuidanceController()` no longer takes a Context. Unblocks `tutorial/AzInstructionOverlay`.
- Also declined a bespoke `openUri` expect/actual — Compose's built-in `LocalUriHandler` covers it.
- Task "Ktor + kotlinx-serialization for the network layer" deferred: no callers in CMP until AboutOverlay/MoreFromAzOverlay port, so it would be dead weight.

### Phase D — partial (JB nav dep + AzNavRailScope)

- **JB CMP navigation dep** (`org.jetbrains.androidx.navigation:navigation-compose:2.9.2`). Its API is package-compatible with `androidx.navigation`.
- **`AzNavRailScope.kt` (1400 lines)** ported with two mechanical fixes: `Class<out android.app.Service>?` → `Any?` (foreground-service overlays don't exist on non-Android), drop the JVM-only `java.util.Collections.emptySet` import.

**Explicitly not ported in this commit:** `AzNavRail` (1200 lines), `AzNavHost` (726 lines), `AzDropdownMenu` (1100 lines), `Footer`, `MenuItem`, `NestedRail`, `RailContent`, `RailItems`, `HelpOverlay`, `AboutOverlay`, `MoreFromAzOverlay`, `AzRailLayoutHelper`, `RailState`. Each reaches into Android platform APIs at dozens of call sites — `context.startActivity(Intent(ACTION_VIEW, Uri.parse(...)))`, `context.packageManager.getApplicationIcon`, `LocalView.current.display.rotation`, `android.view.Surface.ROTATION_*`, `stringResource(R.string.*)`, `ContextWrapper → Activity` unwrap, `Build.VERSION.SDK_INT`, direct window/statusbar tinting. Each site is a per-file design decision (route URIs via `LocalUriHandler`? drop auto-icon? require caller-provided app metadata in a config?) that mechanical fixup can't answer honestly — landing them here would ship a broken module. They need their own port PRs.

Also explicitly out of scope forever: `service/AzNavRailWindowService`, `AzNavRailOverlayService`, `AzNavRailSimpleOverlayService`, `AzActivity`, `internal/SecretScreens`, `internal/AzNavBarDecorWindow`, `bottomsheet/AzBottomSheetWindowHost`, `internal/AzNavMode` — Android platform-glue with no CMP analogue.

### Result

`aznavrail-cmp` ships **~48 files across `commonMain`** (of ~70 in the Android sibling) plus 4 per-platform actuals for the logger. Every ported file is a straight copy or a call-site-preserving edit; consumers can start using the `commonMain` primitives (buttons, text inputs, forms, kinetic animation engine, justify solver, markdown, bottom sheet shell, tutorial callouts, model classes) on any target the KMP module can build.

## Test plan

Dissolve overlay:
- [ ] Tap a `collapseOnClick = true` item — the row below holds its Y while the label slides toward centre and fades.
- [ ] With the guidance callout visible, tapping still puts the dissolve label on top.

CMP scaffold:
- [ ] `:aznavrail:compileDebugKotlin` still green (existing library unchanged).
- [ ] `:SampleApp:assembleDebug` still green.
- [ ] `:aznavrail-cmp:compileCommonMainKotlinMetadata` green.
- [ ] `:aznavrail-cmp:compileDebugKotlinAndroid` green.
- [ ] `:aznavrail-cmp:desktopMainClasses` green.
- [ ] `:aznavrail-cmp:compileKotlinIosSimulatorArm64` green.
- [ ] `:aznavrail-cmp:compileKotlinWasmJs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc