### PR TITLE
Finish the CMP module: fix iOS build config + runnable demo + consumer docs

### DIFF
--- a/.github/workflows/android-sample-build.yml
+++ b/.github/workflows/android-sample-build.yml
@@ -60,3 +60,11 @@ jobs:
 
     - name: Compile wasmJs target
       run: ./gradlew :aznavrail-cmp:compileKotlinWasmJs
+
+    # Type-check the runnable demo against the published library API (Desktop + Web). Running the
+    # demo (window / dev server) stays manual — see aznavrail-cmp-demo/README.md.
+    - name: Compile demo (Desktop)
+      run: ./gradlew :aznavrail-cmp-demo:desktopMainClasses
+
+    - name: Compile demo (wasmJs)
+      run: ./gradlew :aznavrail-cmp-demo:compileKotlinWasmJs

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ dependencies {
 }
 ~~~
 
+### Compose Multiplatform
+
+Targeting more than Android? The [`aznavrail-cmp`](aznavrail-cmp/README.md) module is a Compose
+Multiplatform port of the same rail — one `commonMain` source set across **Android, Desktop (JVM),
+Web (wasmJs), and iOS**:
+
+~~~kotlin
+commonMain.dependencies {
+    implementation("com.github.HereLiesAz.AzNavRail:aznavrail-cmp:VERSION")
+}
+~~~
+
+See the [module README](aznavrail-cmp/README.md) for the CompositionLocal wiring (there's no
+`AzHostActivityLayout` off-Android) and the [`aznavrail-cmp-demo`](aznavrail-cmp-demo) runnable
+desktop + web sample.
+
 ---
 
 ## 🛠️ The Golden Sample

--- a/aznavrail-cmp-demo/README.md
+++ b/aznavrail-cmp-demo/README.md
@@ -1,0 +1,36 @@
+# aznavrail-cmp-demo
+
+A minimal, runnable [Compose Multiplatform](https://www.jetbrains.com/compose-multiplatform/) app that
+mounts [`aznavrail-cmp`](../aznavrail-cmp) on **Desktop (JVM)** and **Web (wasmJs)**. It exists to
+prove the library *renders* (not just compiles) and to serve as the smallest possible consumer
+reference — see [`App.kt`](src/commonMain/kotlin/com/hereliesaz/aznavrail/demo/App.kt) for the one
+required piece of wiring (`LocalAzNavHostPresent provides true`).
+
+This module is **not published** and declares no Android target.
+
+## Run it
+
+**Desktop window:**
+
+```bash
+./gradlew :aznavrail-cmp-demo:run
+```
+
+**Web (dev server, opens a browser tab):**
+
+```bash
+./gradlew :aznavrail-cmp-demo:wasmJsBrowserDevelopmentRun
+```
+
+## What it shows
+
+`App()` wraps `AzNavRail` in a `CompositionLocalProvider` supplying:
+
+| Local | Why |
+|---|---|
+| `LocalAzNavHostPresent provides true` | **Required** — otherwise the rail renders a red "Configuration Error" box. |
+| `LocalAzAppMeta provides AzAppMeta(...)` | App name + `packageId` (lets the About screen derive its GitHub repo). |
+| `LocalAzNavHostScope provides rememberAzNavHostScope()` | Enables the built-in About / Help / More-from-Az overlays. |
+
+The rail itself is defined with the same DSL as the Android artifact: `azRailItem { }` /
+`azMenuItem { }`.

--- a/aznavrail-cmp-demo/build.gradle.kts
+++ b/aznavrail-cmp-demo/build.gradle.kts
@@ -1,0 +1,55 @@
+// See the sibling `aznavrail-cmp/build.gradle.kts` for why the `compose.*` accessors are used
+// despite their deprecation warning — they resolve the correct per-artifact CMP versions.
+@file:Suppress("DEPRECATION")
+
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+// Minimal runnable demo for the `aznavrail-cmp` library — proves `AzNavRail` actually renders (not
+// just compiles) on Desktop (JVM) and Web (wasmJs), and doubles as the consumer reference. It is NOT
+// published and declares no Android target (keeping it off the Android build path and Linux-clean).
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.compose.compiler)
+}
+
+kotlin {
+    jvmToolchain(17)
+
+    jvm("desktop")
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+        // `binaries.executable()` (an app, unlike the library) emits the `.js`/`.wasm` bundle and
+        // registers the `wasmJsBrowserDevelopmentRun` task.
+        binaries.executable()
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                // The library under demonstration, consumed as an in-build project.
+                implementation(project(":aznavrail-cmp"))
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material3)
+                implementation(compose.ui)
+            }
+        }
+        val desktopMain by getting {
+            dependencies {
+                // Compose Desktop runtime + Swing/Skiko window host for the current OS.
+                implementation(compose.desktop.currentOs)
+            }
+        }
+    }
+}
+
+// Desktop `application { }` block — provides the `run` task and names the entry point generated from
+// `desktopMain/kotlin/main.kt` (top-level `fun main()` → `…demo.MainKt`).
+compose.desktop {
+    application {
+        mainClass = "com.hereliesaz.aznavrail.demo.MainKt"
+    }
+}

--- a/aznavrail-cmp-demo/src/commonMain/kotlin/com/hereliesaz/aznavrail/demo/App.kt
+++ b/aznavrail-cmp-demo/src/commonMain/kotlin/com/hereliesaz/aznavrail/demo/App.kt
@@ -1,0 +1,43 @@
+package com.hereliesaz.aznavrail.demo
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.hereliesaz.aznavrail.AzAppMeta
+import com.hereliesaz.aznavrail.AzNavRail
+import com.hereliesaz.aznavrail.LocalAzAppMeta
+import com.hereliesaz.aznavrail.LocalAzNavHostPresent
+import com.hereliesaz.aznavrail.LocalAzNavHostScope
+import com.hereliesaz.aznavrail.rememberAzNavHostScope
+
+/**
+ * The shared demo UI, used by every platform entry point.
+ *
+ * `AzNavRail` checks [LocalAzNavHostPresent] and renders a red "Configuration Error" placeholder
+ * when it is `false` (the default) — the Android sibling relies on `AzHostActivityLayout` to set it,
+ * which has no cross-platform analogue, so the CMP consumer provides it themselves. That single local
+ * is the only *required* wiring; the rest have safe defaults but are supplied here to showcase the
+ * full feature set:
+ *  - [LocalAzAppMeta] names the app and (via `packageId`) lets the About screen derive its GitHub repo.
+ *  - [LocalAzNavHostScope] enables the built-in About / Help / More-from-Az overlays.
+ */
+@Composable
+fun App() {
+    MaterialTheme {
+        CompositionLocalProvider(
+            LocalAzNavHostPresent provides true,
+            LocalAzAppMeta provides AzAppMeta(
+                name = "AzNavRail Demo",
+                packageId = "com.hereliesaz.aznavrail",
+            ),
+            LocalAzNavHostScope provides rememberAzNavHostScope(),
+        ) {
+            AzNavRail {
+                azRailItem(id = "home", text = "Home", onClick = {})
+                azRailItem(id = "docs", text = "Docs", onClick = {})
+                azMenuItem(id = "about", text = "About", onClick = {})
+                azMenuItem(id = "settings", text = "Settings", onClick = {})
+            }
+        }
+    }
+}

--- a/aznavrail-cmp-demo/src/desktopMain/kotlin/com/hereliesaz/aznavrail/demo/main.kt
+++ b/aznavrail-cmp-demo/src/desktopMain/kotlin/com/hereliesaz/aznavrail/demo/main.kt
@@ -1,0 +1,11 @@
+package com.hereliesaz.aznavrail.demo
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+
+// Desktop entry point. Run with: ./gradlew :aznavrail-cmp-demo:run
+fun main() = application {
+    Window(onCloseRequest = ::exitApplication, title = "AzNavRail Demo") {
+        App()
+    }
+}

--- a/aznavrail-cmp-demo/src/wasmJsMain/kotlin/com/hereliesaz/aznavrail/demo/main.kt
+++ b/aznavrail-cmp-demo/src/wasmJsMain/kotlin/com/hereliesaz/aznavrail/demo/main.kt
@@ -1,0 +1,13 @@
+package com.hereliesaz.aznavrail.demo
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import kotlinx.browser.document
+
+// Web (wasmJs) entry point. Run with: ./gradlew :aznavrail-cmp-demo:wasmJsBrowserDevelopmentRun
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    ComposeViewport(document.body!!) {
+        App()
+    }
+}

--- a/aznavrail-cmp-demo/src/wasmJsMain/resources/index.html
+++ b/aznavrail-cmp-demo/src/wasmJsMain/resources/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AzNavRail Demo</title>
+    <style>
+        html, body { margin: 0; padding: 0; height: 100%; background: #101014; }
+    </style>
+</head>
+<body>
+    <!-- Compose renders into <body> via ComposeViewport(document.body!!). The bundle name matches
+         the module: aznavrail-cmp-demo. -->
+    <script src="aznavrail-cmp-demo.js"></script>
+</body>
+</html>

--- a/aznavrail-cmp/README.md
+++ b/aznavrail-cmp/README.md
@@ -1,0 +1,113 @@
+# AzNavRail — Compose Multiplatform
+
+`aznavrail-cmp` is the [Compose Multiplatform](https://www.jetbrains.com/compose-multiplatform/)
+port of [AzNavRail](../README.md) — the opinionated, DSL-driven navigation rail. It shares the
+Android library's API and look, but runs from a single `commonMain` source set across **Android,
+Desktop (JVM), Web (wasmJs), and iOS**.
+
+> The Android-only `aznavrail` artifact remains the right choice for pure-Android apps. Use
+> `aznavrail-cmp` when you target multiple platforms from shared Compose code.
+
+## Install
+
+JitPack builds every tagged release. Add the repo (settings.gradle.kts):
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+Then depend on the module from your `commonMain`:
+
+```kotlin
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation("com.github.HereLiesAz.AzNavRail:aznavrail-cmp:VERSION") // latest release tag
+        }
+    }
+}
+```
+
+## Supported targets
+
+| Target | Status |
+|---|---|
+| Android | ✅ |
+| Desktop / JVM | ✅ |
+| Web / `wasmJs` | ✅ |
+| iOS (`iosArm64`, `iosSimulatorArm64`) | ✅ (compiled on macOS; CI configures it on Linux) |
+
+`iosX64` (the Intel iOS simulator) is intentionally omitted.
+
+## Minimal usage
+
+Unlike the Android artifact, there is **no `AzHostActivityLayout`** in the CMP module (it's built on
+`Activity`/`Window`, which don't exist off-Android). Instead you provide a couple of
+CompositionLocals yourself. Only **`LocalAzNavHostPresent provides true`** is strictly required —
+without it the rail renders a red "Configuration Error" placeholder. Everything else has safe
+defaults.
+
+```kotlin
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import com.hereliesaz.aznavrail.AzNavRail
+import com.hereliesaz.aznavrail.LocalAzNavHostPresent
+import com.hereliesaz.aznavrail.LocalAzAppMeta
+import com.hereliesaz.aznavrail.AzAppMeta
+import com.hereliesaz.aznavrail.LocalAzNavHostScope
+import com.hereliesaz.aznavrail.rememberAzNavHostScope
+
+@Composable
+fun App() = MaterialTheme {
+    CompositionLocalProvider(
+        LocalAzNavHostPresent provides true,                                   // required
+        LocalAzAppMeta provides AzAppMeta(                                      // optional: name/icon/repo
+            name = "My App",
+            packageId = "com.example.myapp",                                   // enables About repo derivation
+        ),
+        LocalAzNavHostScope provides rememberAzNavHostScope(),                 // optional: enables About/Help/More overlays
+    ) {
+        AzNavRail {
+            azRailItem(id = "home", text = "Home", onClick = { /* … */ })
+            azMenuItem(id = "about", text = "About", onClick = { /* … */ })
+        }
+    }
+}
+```
+
+### CompositionLocals
+
+| Local | Required? | Purpose / default |
+|---|---|---|
+| `LocalAzNavHostPresent` | **Yes** — set `true` | The rail refuses to render (red error box) when `false` (default). |
+| `LocalAzAppMeta` | Optional | App name / icon / package id. Default is a placeholder `"App"`. `packageId` lets the About screen auto-derive the GitHub repo. |
+| `LocalAzNavHostScope` | Optional | Provide `rememberAzNavHostScope()` to make the About / Help / More-from-Az overlays function. Default `null` = overlays disabled. |
+| `LocalAzSafeZones` | Optional | Safe-area insets. Has a working default. |
+| `LocalAzGuideStrings` | Optional | Localized guidance strings (English defaults). |
+
+## Differences from the Android artifact
+
+- **No `AzNavHost` / `AzHostActivityLayout` / window-overlay Services** — Android platform glue with
+  no cross-platform analogue. You mount `AzNavRail` under your own root composable and provide the
+  CompositionLocals above.
+- **Material icons are inlined** (see `internal/AzIcons.kt`) so the module needs no
+  `material-icons-extended` dependency (which has no iOS variant). The glyphs are identical.
+- **Networking** (About docs + More-from-Az carousel) uses [Ktor](https://ktor.io/) with a two-tier
+  cache: an in-memory hot tier plus a best-effort persistent tier
+  ([multiplatform-settings](https://github.com/russhwolf/multiplatform-settings)). Bodies over ~6 KB
+  aren't persisted (storage-backend limits); everything still works within a session.
+- **Guidance/tutorial completion is session-only** unless you persist it yourself (the Android
+  sibling uses `SharedPreferences`).
+- On **wasmJs (browser)** some cross-origin HEAD probes (repo icon/banner resolution) may be blocked
+  by CORS; the code degrades gracefully (OpenGraph fallback / blank banner).
+
+## Runnable demo
+
+See [`aznavrail-cmp-demo`](../aznavrail-cmp-demo) for a minimal desktop + wasmJs app that mounts the
+rail. Run the desktop demo with `./gradlew :aznavrail-cmp-demo:run` and the web demo with
+`./gradlew :aznavrail-cmp-demo:wasmJsBrowserDevelopmentRun`.

--- a/aznavrail-cmp/build.gradle.kts
+++ b/aznavrail-cmp/build.gradle.kts
@@ -104,12 +104,13 @@ kotlin {
                 implementation("io.ktor:ktor-client-js:$ktorVersion")
             }
         }
-        // `iosMain` is created by the default hierarchy template (2+ iOS targets share it).
-        val iosMain by getting {
-            dependencies {
-                // Ktor Darwin engine (NSURLSession) for the iOS targets.
-                implementation("io.ktor:ktor-client-darwin:$ktorVersion")
-            }
+        // `iosMain` is the intermediate source set the default hierarchy template creates for the
+        // two iOS targets. It's materialized lazily, so `val iosMain by getting` (which resolves an
+        // already-created source set) fails at configuration time with "KotlinSourceSet with name
+        // 'iosMain' not found". The generated `iosMain` accessor triggers creation, so use it.
+        iosMain.dependencies {
+            // Ktor Darwin engine (NSURLSession) for the iOS targets.
+            implementation("io.ktor:ktor-client-darwin:$ktorVersion")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ rootProject.name = "AzNavRail"
 include(":SampleApp")
 include(":aznavrail")
 include(":aznavrail-cmp")
+include(":aznavrail-cmp-demo")


### PR DESCRIPTION
## Summary

Follow-up to #489 (merged). That PR landed the CMP network layer, publishing, persistent cache, and iOS support — but its final commit merged with **red CI**, leaving `main`'s `build` and `cmp-compile` jobs broken. This PR fixes that and finishes the remaining two follow-ups (runnable demo + consumer docs).

Because #489 is already merged, this is a fresh branch off `main` and a **new** PR (not a reopen).

### 1. Fix the `iosMain` source-set config error (unbreaks `main`)
`#489`'s `d45307c` wired the iOS Ktor engine with `val iosMain by getting { … }`. `iosMain` is an **intermediate** source set the default hierarchy template creates *lazily*, so `by getting` (which resolves an already-materialized source set) fails configuration with `KotlinSourceSet with name 'iosMain' not found`. Since Gradle configures every included module before running any task, this broke **both** CI jobs — including the `build` job's `:SampleApp:assembleDebug`, which never touches the CMP module.

Fix: use the generated `iosMain.dependencies { … }` accessor, which materializes the source set on access. The leaf source sets (`commonMain`/`androidMain`/`desktopMain`/`wasmJsMain`, created directly by their targets) keep their `by getting` blocks.

### 2. Runnable demo module (`:aznavrail-cmp-demo`, Desktop + wasmJs)
A minimal Compose Multiplatform app that mounts `AzNavRail` from the shared library — proving it *renders*, not just compiles, and serving as the smallest consumer reference. `App()` supplies the one required local (`LocalAzNavHostPresent = true`) plus `LocalAzAppMeta` / `LocalAzNavHostScope` to exercise the About/Help/More overlays. No Android target; not published.

- Desktop: `./gradlew :aznavrail-cmp-demo:run`
- Web: `./gradlew :aznavrail-cmp-demo:wasmJsBrowserDevelopmentRun`

CI: the `cmp-compile` job now also type-checks the demo against the library API on Desktop (`desktopMainClasses`) and wasmJs (`compileKotlinWasmJs`).

### 3. Consumer docs
`aznavrail-cmp/README.md` (install coordinate, supported targets, minimal-usage snippet, differences from the Android artifact) + a "Compose Multiplatform" pointer in the root `README.md`.

## Verification
- **`build` + `cmp-compile` both green** is the proof `main` is unbroken (step 1).
- `cmp-compile` now includes the demo's Desktop + wasmJs compile — the demo type-checks against the real library API.
- iOS still *configures* on the Linux runners but is not compiled there (Kotlin/Native Apple targets need macOS — unchanged from #489); a macOS matrix leg remains a documented follow-up.
- Running the demo (window / dev server) is manual — see `aznavrail-cmp-demo/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_