### PR TITLE
Fix JitPack publish: exclude demo app from the release build

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,4 +21,12 @@ rootProject.name = "AzNavRail"
 include(":SampleApp")
 include(":aznavrail")
 include(":aznavrail-cmp")
-include(":aznavrail-cmp-demo")
+// The demo is a runnable app, not a published artifact. Its wasmJs executable pulls in the Binaryen
+// setup task (and node/yarn tooling) during `assemble`, needlessly building an app during a library
+// release — and that setup registers project-level repositories. JitPack sets JITPACK=true, so skip
+// the demo there entirely; it stays included for CI (which type-checks it) and local dev (where it
+// runs). (repositoriesMode is PREFER_SETTINGS above, so those tool repos are tolerated when the demo
+// IS built off-JitPack.)
+if (System.getenv("JITPACK") == null) {
+    include(":aznavrail-cmp-demo")
+}


### PR DESCRIPTION
## Summary

The JitPack release build regressed after the `:aznavrail-cmp-demo` module landed (#490). JitPack runs the whole-project `./gradlew clean … assemble publishToMavenLocal`, and the demo's `wasmJs { binaries.executable() }` makes `assemble` pull in `kotlinWasmBinaryenSetup` — which registers project-level repositories and (with the original `FAIL_ON_PROJECT_REPOS`) failed the build:

```
Could not determine the dependencies of task ':aznavrail-cmp-demo:kotlinWasmBinaryenSetup'.
> ... repository 'Distributions at https://github.com/WebAssembly/binaryen/releases/download' was added by unknown code
```

`repositoriesMode` was already relaxed to `PREFER_SETTINGS` on `main` (kept as-is here), which tolerates that project repo. But JitPack would still fully **assemble the demo app** (Binaryen + node/yarn/webpack) during a *library* release — pointless work and extra failure surface.

## Change

The demo is a runnable app, not a published artifact. Gate its module inclusion on JitPack's `JITPACK=true` env var in `settings.gradle.kts`:

- **JitPack** (`JITPACK=true`): demo excluded → no demo assembly → `aznavrail` / `aznavrail-cmp` publish cleanly.
- **CI** (`JITPACK` unset): demo still included → the `cmp-compile` job's `desktopMainClasses` / `compileKotlinWasmJs` steps keep type-checking it.
- **Local dev** (`JITPACK` unset): demo still included → `./gradlew :aznavrail-cmp-demo:run` etc. still work.

One-line-of-logic change to `settings.gradle.kts`; `PREFER_SETTINGS` and every other file are untouched.

## Verification
- CI (`build` + `cmp-compile`) must stay green — proving the demo is still included and type-checks for non-JitPack builds.
- JitPack validates on the next tag; the demo no longer participates in that build, so the library publish can't be broken by it. (Can't run JitPack/`assemble` locally — this environment's egress policy blocks the Gradle 9.4.1 wrapper download.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_