### PR TITLE
Fix JitPack publish: gate iOS targets to macOS hosts

### DIFF
--- a/aznavrail-cmp/README.md
+++ b/aznavrail-cmp/README.md
@@ -37,12 +37,18 @@ kotlin {
 
 | Target | Status |
 |---|---|
-| Android | ✅ |
-| Desktop / JVM | ✅ |
-| Web / `wasmJs` | ✅ |
-| iOS (`iosArm64`, `iosSimulatorArm64`) | ✅ (compiled on macOS; CI configures it on Linux) |
+| Android | ✅ published |
+| Desktop / JVM | ✅ published |
+| Web / `wasmJs` | ✅ published |
+| iOS (`iosArm64`, `iosSimulatorArm64`) | ⚠️ source-only (build on macOS) |
 
 `iosX64` (the Intel iOS simulator) is intentionally omitted.
+
+> **iOS note:** the iOS targets are declared only on macOS hosts. Kotlin/Native can't compile
+> Apple targets on Linux, and the release artifacts are built on JitPack (Linux) — so the
+> **published `aznavrail-cmp` does not contain iOS klibs**. To use the rail on iOS, build the module
+> from source on a Mac (where the `iosArm64` / `iosSimulatorArm64` targets are enabled), or publish
+> iOS artifacts yourself from a macOS pipeline. Android / Desktop / Web consumers are unaffected.
 
 ## Minimal usage
 

--- a/aznavrail-cmp/build.gradle.kts
+++ b/aznavrail-cmp/build.gradle.kts
@@ -34,7 +34,7 @@ val multiplatformSettingsVersion = libs.versions.multiplatformSettings.get()
 // publishes Android + Desktop + Web + metadata, and iOS is built when compiling on a Mac. Publishing
 // iOS artifacts to a repository needs a macOS-based pipeline, which is out of scope for the JitPack
 // (Linux) release.
-val hostIsMac = System.getProperty("os.name").startsWith("Mac", ignoreCase = true)
+val hostIsMac = System.getProperty("os.name")?.startsWith("Mac", ignoreCase = true) == true
 
 kotlin {
     jvmToolchain(17)

--- a/aznavrail-cmp/build.gradle.kts
+++ b/aznavrail-cmp/build.gradle.kts
@@ -27,6 +27,15 @@ val ktorVersion = libs.versions.ktor.get()
 val kotlinxSerializationVersion = libs.versions.kotlinxSerialization.get()
 val multiplatformSettingsVersion = libs.versions.multiplatformSettings.get()
 
+// Apple/iOS Kotlin/Native targets can only be COMPILED on a macOS host (they need the Xcode
+// toolchain). Linux CI runners and JitPack (which builds on Linux) therefore can't build or publish
+// them — `publishToMavenLocal` would fail trying to compile the iOS klibs. So the iOS targets (and
+// their `iosMain` source set) are declared only on macOS: off-Mac, the module still builds and
+// publishes Android + Desktop + Web + metadata, and iOS is built when compiling on a Mac. Publishing
+// iOS artifacts to a repository needs a macOS-based pipeline, which is out of scope for the JitPack
+// (Linux) release.
+val hostIsMac = System.getProperty("os.name").startsWith("Mac", ignoreCase = true)
+
 kotlin {
     jvmToolchain(17)
 
@@ -40,9 +49,12 @@ kotlin {
     // iOS: real devices (arm64) + Apple-Silicon simulators (simulatorArm64). iosX64 (the Intel
     // simulator) is omitted — every dependency ships arm64/sim variants and Intel simulators are
     // legacy. The Material icons the UI needs are inlined (see internal/AzIcons.kt) so no
-    // iOS-incompatible `material-icons-extended` dependency is required.
-    iosArm64()
-    iosSimulatorArm64()
+    // iOS-incompatible `material-icons-extended` dependency is required. Declared only on macOS
+    // (see `hostIsMac` above) so the Linux JitPack/CI publish doesn't try to compile Apple klibs.
+    if (hostIsMac) {
+        iosArm64()
+        iosSimulatorArm64()
+    }
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
@@ -105,12 +117,15 @@ kotlin {
             }
         }
         // `iosMain` is the intermediate source set the default hierarchy template creates for the
-        // two iOS targets. It's materialized lazily, so `val iosMain by getting` (which resolves an
-        // already-created source set) fails at configuration time with "KotlinSourceSet with name
-        // 'iosMain' not found". The generated `iosMain` accessor triggers creation, so use it.
-        iosMain.dependencies {
-            // Ktor Darwin engine (NSURLSession) for the iOS targets.
-            implementation("io.ktor:ktor-client-darwin:$ktorVersion")
+        // two iOS targets. It only exists when those targets are declared (macOS only, above), and
+        // it's materialized lazily — so `val iosMain by getting` fails with "KotlinSourceSet with
+        // name 'iosMain' not found". Gate on `hostIsMac` (matching the target declaration) and use
+        // the generated `iosMain` accessor, which triggers creation.
+        if (hostIsMac) {
+            iosMain.dependencies {
+                // Ktor Darwin engine (NSURLSession) for the iOS targets.
+                implementation("io.ktor:ktor-client-darwin:$ktorVersion")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Second (and final) JitPack blocker for the CMP module. After the demo-exclusion fix (#491) got JitPack past the Binaryen error, the next failure is fundamental: **JitPack builds on Linux, where Kotlin/Native cannot compile Apple targets** (they require the Xcode toolchain). With `iosArm64()` / `iosSimulatorArm64()` always declared, JitPack's `assemble publishToMavenLocal` fails trying to build the `aznavrail-cmp-iosarm64` / `aznavrail-cmp-iossimulatorarm64` klibs — so the library never publishes.

## Change

Declare the iOS targets — and gate their `iosMain` Ktor-Darwin dependency — behind a `hostIsMac` check (`System.getProperty("os.name")`) in `aznavrail-cmp/build.gradle.kts`:

- **Linux (JitPack + CI):** iOS absent → the module builds and publishes **Android + Desktop + Web + metadata** cleanly.
- **macOS (local / a future macOS pipeline):** iOS targets enabled → iOS builds normally.

Gating the target *and* the `iosMain.dependencies { }` block together is required — the `iosMain` source set only exists when the targets are declared, so leaving the dependency block ungated would reintroduce an "iosMain not found" error on Linux.

### Tradeoff (chosen deliberately)
The JitPack-published `aznavrail-cmp` **does not contain iOS klibs**. iOS artifacts fundamentally can't be produced from Linux, so shipping them would require a separate macOS-based publishing pipeline (Maven Central / GitHub Packages). iOS consumers build the module from source on a Mac in the meantime. `aznavrail-cmp/README.md` is updated to state this. Android / Desktop / Web consumers are unaffected.

## Verification
- CI (`build` + `cmp-compile`, both on Linux) must stay green — this exercises the exact Linux path JitPack uses, proving the module configures and compiles with iOS gated off.
- JitPack validates on its next build; with iOS out of the Linux build, `publishToMavenLocal` no longer hits the Apple-compile wall.
- Can't run JitPack / a full `assemble` locally (this environment's egress policy blocks the Gradle wrapper download).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_

## Summary by Sourcery

Gate iOS Kotlin/Native targets in the CMP module to macOS hosts so Linux-based JitPack and CI builds can publish non-iOS artifacts successfully.

Build:
- Conditionally declare iOS targets and their iosMain dependencies only when running on macOS to avoid iOS compilation on Linux-based JitPack and CI publishers.

Documentation:
- Update CMP README to clarify that Android, Desktop, and Web artifacts are published, while iOS is source-only and must be built or published from a macOS environment.