### PR TITLE
docs: fix Android install coordinate + "No matching variant" troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Add the dependency to your app's `build.gradle.kts`:
 
 ~~~kotlin
 dependencies {
-    implementation("com.github.HereLiesAz:AzNavRail:VERSION") // Replace VERSION with the latest release
+    implementation("com.github.HereLiesAz.AzNavRail:aznavrail:VERSION") // Replace VERSION with the latest release
 }
 ~~~
 
@@ -102,6 +102,39 @@ commonMain.dependencies {
 See the [module README](aznavrail-cmp/README.md) for the CompositionLocal wiring (there's no
 `AzHostActivityLayout` off-Android) and the [`aznavrail-cmp-demo`](aznavrail-cmp-demo) runnable
 desktop + web sample.
+
+### Troubleshooting: `No matching variant … was found`
+
+If your Gradle sync fails with something like:
+
+~~~
+Could not resolve com.github.HereLiesAz.AzNavRail:aznavrail-cmp:VERSION.
+  Required by: project :app
+   > No matching variant of com.github.HereLiesAz.AzNavRail:aznavrail-cmp:VERSION was found.
+~~~
+
+…you're pulling a **Kotlin Multiplatform** artifact into a plain Android/JVM project. The
+multiplatform module (`aznavrail-cmp`) publishes Gradle Module Metadata with a variant per platform,
+and a non-KMP consumer can't select one through JitPack's metadata redirect. **Switch to the Android
+artifact directly:**
+
+- **Android app — use the dedicated Android library (recommended):**
+  ~~~kotlin
+  implementation("com.github.HereLiesAz.AzNavRail:aznavrail:VERSION")
+  ~~~
+  A plain AAR, full-featured — this is the one the setup section above uses, and it includes
+  `AzHostActivityLayout` / `AzNavHost`.
+
+- **Only if you specifically need the multiplatform module inside an Android-only project:**
+  ~~~kotlin
+  implementation("com.github.HereLiesAz.AzNavRail:aznavrail-cmp-android:VERSION")
+  ~~~
+  The Android variant of the CMP module. Note it has **no** `AzHostActivityLayout` / `AzNavHost`, so
+  Golden-Sample code won't compile against it unmodified.
+
+Also make sure you're **not** using the old single-module coordinate
+`com.github.HereLiesAz:AzNavRail:VERSION` — it predates the multi-module split and no longer
+resolves. The module lives under group `com.github.HereLiesAz.AzNavRail`.
 
 ---
 

--- a/aznavrail-cmp/README.md
+++ b/aznavrail-cmp/README.md
@@ -36,7 +36,8 @@ kotlin {
 > **Pure-Android (non-KMP) project?** Don't depend on this multiplatform module — its root artifact
 > is Gradle Module Metadata with per-platform variants, and a plain Android project can't select a
 > variant through JitPack, so you'll get `No matching variant of …:aznavrail-cmp:… was found`. Use
-> the dedicated Android library [`com.github.HereLiesAz.AzNavRail:aznavrail`](../README.md#setup)
+> the dedicated Android library
+> [`com.github.HereLiesAz.AzNavRail:aznavrail`](../README.md#aznavrail-for-android-jetpack-compose)
 > instead (it includes `AzHostActivityLayout` / `AzNavHost`, which this module intentionally omits).
 > If you truly need *this* module in an Android-only build, depend on the Android variant directly:
 > `com.github.HereLiesAz.AzNavRail:aznavrail-cmp-android:VERSION`.

--- a/aznavrail-cmp/README.md
+++ b/aznavrail-cmp/README.md
@@ -33,6 +33,14 @@ kotlin {
 }
 ```
 
+> **Pure-Android (non-KMP) project?** Don't depend on this multiplatform module — its root artifact
+> is Gradle Module Metadata with per-platform variants, and a plain Android project can't select a
+> variant through JitPack, so you'll get `No matching variant of …:aznavrail-cmp:… was found`. Use
+> the dedicated Android library [`com.github.HereLiesAz.AzNavRail:aznavrail`](../README.md#setup)
+> instead (it includes `AzHostActivityLayout` / `AzNavHost`, which this module intentionally omits).
+> If you truly need *this* module in an Android-only build, depend on the Android variant directly:
+> `com.github.HereLiesAz.AzNavRail:aznavrail-cmp-android:VERSION`.
+
 ## Supported targets
 
 | Target | Status |


### PR DESCRIPTION
## Summary

Fixes the dependency-resolution confusion a pure-Android consumer hit (`No matching variant … was found`) after AzNavRail became a multi-module repo with an additive KMP sibling.

**Root cause:** the root README's Android install line was the pre-split coordinate `com.github.HereLiesAz:AzNavRail:VERSION`, which no longer resolves — every module now publishes under group `com.github.HereLiesAz.AzNavRail`. And a pure-Android project that pulls the KMP root `aznavrail-cmp` gets a "No matching variant" error, because that module's Gradle Module Metadata (per-platform variants) can't be selected by a non-KMP consumer through JitPack's redirect.

This was **not intentional** — the KMP work was additive and shouldn't affect Android consumers. The dedicated Android library `aznavrail` was always the right artifact; the docs just pointed at a stale coordinate.

## Changes (docs only)
- **`README.md`** — Android install line → `com.github.HereLiesAz.AzNavRail:aznavrail:VERSION` (the dedicated Android AAR, includes `AzHostActivityLayout`/`AzNavHost`). Added a **Troubleshooting** section that quotes the exact `No matching variant` error and says which coordinate to switch to.
- **`aznavrail-cmp/README.md`** — added a pure-Android caveat: don't pull the multiplatform module into a plain Android project; use `aznavrail` (or `aznavrail-cmp-android` if you specifically need the CMP module on Android — noting it lacks the Activity-host glue).

## On "make the error tell them"
A library can't rewrite the *consumer's* Gradle resolution error text (it's emitted on their side). The effective mechanism is a prominent, greppable README section that quotes the error string verbatim, so it surfaces when a developer searches for it — that's what the Troubleshooting section does.

Docs-only, so CI's `paths-ignore: ['**/*.md']` means no build runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc

---
_Generated by [Claude Code](https://claude.ai/code/session_017sXcbrS4VZiDSv5hu1daFc)_

## Summary by Sourcery

Clarify Android dependency coordinates and troubleshooting guidance for AzNavRail in a multi‑module/KMP setup.

Documentation:
- Update root README Android installation instructions to use the dedicated aznavrail Android artifact under the new group ID.
- Add troubleshooting guidance in the root README for the "No matching variant" Gradle resolution error, including recommended coordinates for Android-only and KMP-related use cases.
- Document in the aznavrail-cmp README that pure-Android projects should depend on the aznavrail or aznavrail-cmp-android artifacts instead of the multiplatform root module.