### PR TITLE
feat(AzNavRail): dropdown triggers in the title row, unattached hosts, popups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,55 @@ configurable (mirroring the rail's `azTheme`). Only the dropped list is an overl
   exactly like `MenuItem.kt`. RN/web use an `onNavigate(route)` prop + `route?` on `AzDropdownItem`.
 - Controlled `expanded`/`onExpandedChange` remain. Tapping outside, back, or an item folds it up.
 
+Drop-down trigger: `AzDropdownMenu`'s trigger is chosen with `azConfig(trigger = …)` from the sanctioned
+`AzDropdownTrigger` set — `MoreVert` (three vertical dots, **the default**), `Hamburger`, `AppIcon` (the
+launcher icon, the pre-trigger default), `Text("…")`, or `Icon(model)` (ImageVector/Painter/URL/any Coil
+model). Size and clip shape still come from `headerIconSize`/`headerIconShape`. `azConfig(triggerPlacement = …)`
+takes `AzDropdownTriggerPlacement { AUTO, TITLE, INLINE }`: `AUTO` (default) lifts the trigger out of its call
+site and places it **next to the big screen title**, above the onscreen area, whenever the drop-down is declared
+inside an `AzHostActivityLayout`; a standalone drop-down stays inline. Several title-hosted drop-downs line their
+triggers up beside each other in registration (= declaration) order, on the side opposite the rail. The dropped
+panel stays composed at the call site and anchors to the real trigger via window-space bounds the trigger reports
+back (`AzTitleTriggerSlot` in `internal/AzTitleTriggers.kt`; the slot publishes a comparable
+`AzDropdownTriggerSpec` as snapshot state and keeps its tap/bounds callbacks as plain fields, which is what stops
+the host's composition from looping).
+
+Unattached host rail items (`azUnattachedHostItem`): a rail host that does **not** live in the rail strip. It is
+drawn on its own at an `AzUnattachedAnchor` — `OPPOSITE` (side opposite the rail, level with the rail's items),
+`BOTTOM` (bottom of the screen, opposite side), or `FLOATING` (draggable, position persisted) — and tapping it
+unfolds its sub-items inline beneath it, exactly as they would have unfolded in the rail. Sub-items attach by
+`hostId` as usual and sub-hosts nest to any depth. The host and its **whole subtree** are filtered out of both the
+rail strip and the drawer (`azUnattachedSubtreeIds`). Several hosts sharing an anchor stack into a column with the
+rail's own spacing/packing. The `FLOATING` stack drags as one unit, is clamped to the 10%–90% vertical safe zone
+FAB mode uses, and persists its position **as a fraction of the window** (`AzUnattachedStore` —
+multiplatform-settings on CMP, SharedPreferences on Android) so it survives rotation and different screen sizes.
+Rendered by `internal/AzUnattachedRail.kt`, which owns its own `hostStates` (the rail's map does not cover it) and
+re-implements the same rising-edge `initiallyExpanded` / `expandWhen` contract.
+
+Per-item badges + loading: every item builder accepts `badge` / `persistentBadge` / `isLoading`, and **any**
+already-declared item can be decorated by id with `azItemState(id, badge, persistentBadge, isLoading, alert)` —
+applied after the whole DSL runs (alongside `applyRelocReorders`), so declaration order is irrelevant and null
+fields leave the item's existing value alone. Loading is **per item**: the button hides its content and spins an
+`AzLoad` scaled to the button and tinted to the item's colour (`AzLoad` now takes `size`/`color`/`showLabel`); a
+menu row keeps its label and spins a small ring beside it. Badges now render in nested rails too — previously
+`NestedRail.kt` silently dropped them.
+
+Popups (`AzPopup`): a window **bound to a rail item**, registered with `azPopup(controller)` on the host DSL and
+driven by an `AzPopupController` from `rememberAzPopupController()`. `show(itemId = …)` names the source item;
+`show()` with no id binds to the **last touched** rail item (`AzNavRailScopeImpl.lastTouchedItemId`). The body runs
+in an `AzPopupScope` exposing `kind`/`title`/`message`/`payload`, `dismiss()`, and `item` — an
+`AzPopupItemHandle` that can read the live `AzNavItem` and write back to it (`setBadge`, `setLoading`, `setAlert`,
+`clear`). Those writes land in `AzNavRailScopeImpl.itemOverrides`, which deliberately survives `reset()` (the DSL
+re-runs every recomposition and would otherwise wipe them next frame) and wins over `azItemState`. A
+`AzPopupKind.NOTICE` / `WARNING` popup redraws its bound item as a **yellow, rounded-corner triangle outline**
+(`AzButtonShape.TRIANGLE` + `AzRoundedTriangleShape`, corners cut back and bridged with a quadratic through the
+vertex) for exactly as long as the popup is up — raised and dropped by the popup's own `DisposableEffect`, never
+left behind. In the drawer, where a row is type rather than a button, the flagged item takes the same yellow.
+
+INVARIANT — every `AzButtonShape` -> Compose `Shape` conversion goes through the single
+`AzButtonShape.toComposeShape()` in `internal/AzShapes.kt`, so adding a member can never be silently missed by one
+call site.
+
 In-app About reader + "More from Az": the footer "About" item opens a built-in, themed markdown reader
 instead of opening the repo URL in a browser. On the rail (Android/web) About + More-from-Az flow
 through the host's `onscreen()` layout path (rail stays docked beside them); the standalone

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -79,6 +80,11 @@ import com.hereliesaz.aznavrail.service.GithubDocsRepository
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzDockingSide
 import com.hereliesaz.aznavrail.model.AzDropdownDesign
+import com.hereliesaz.aznavrail.model.AzDropdownTrigger
+import com.hereliesaz.aznavrail.model.AzDropdownTriggerPlacement
+import com.hereliesaz.aznavrail.internal.AzDropdownTriggerButton
+import com.hereliesaz.aznavrail.internal.AzDropdownTriggerSpec
+import com.hereliesaz.aznavrail.internal.AzTitleTriggerSlot
 import com.hereliesaz.aznavrail.model.AzEasing
 import com.hereliesaz.aznavrail.model.AzEntrance
 import com.hereliesaz.aznavrail.model.AzExit
@@ -135,6 +141,17 @@ interface AzDropdownMenuScope {
      * @param maxTiltDegrees Maximum tilt angle for [tiltOnPress].
      * @param itemExit Exit played as the panel dismisses (see [AzExit]); defaults to [AzExit.Turnstile].
      *   Items are held mounted through the close so they can animate out.
+     * @param trigger What the user taps to open the menu. Defaults to [AzDropdownTrigger.MoreVert] —
+     *   the three vertical dots. Pass [AzDropdownTrigger.Text] for a word, [AzDropdownTrigger.Icon]
+     *   for your own glyph/image, [AzDropdownTrigger.Hamburger] for the bars, or
+     *   [AzDropdownTrigger.AppIcon] for the launcher icon (the pre-trigger default). The trigger's
+     *   size and clip shape come from [headerIconSize] / [headerIconShape].
+     * @param triggerPlacement Where that trigger is drawn. [AzDropdownTriggerPlacement.AUTO] (the
+     *   default) lifts it up next to the big screen title, above the onscreen content area, whenever
+     *   the drop-down is declared inside an `AzHostActivityLayout`; standalone drop-downs stay
+     *   inline. Several title-hosted drop-downs line their triggers up beside each other in
+     *   declaration order. Force either behaviour with [AzDropdownTriggerPlacement.TITLE] /
+     *   [AzDropdownTriggerPlacement.INLINE].
      */
     fun azConfig(
         design: AzDropdownDesign = AzDropdownDesign.MENU,
@@ -161,6 +178,8 @@ interface AzDropdownMenuScope {
         menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment =
             com.hereliesaz.aznavrail.model.AzMenuItemAlignment.SIDE,
         justifyMenuItems: Boolean = true,
+        trigger: AzDropdownTrigger = AzDropdownTrigger.MoreVert,
+        triggerPlacement: AzDropdownTriggerPlacement = AzDropdownTriggerPlacement.AUTO,
     )
 
     /**
@@ -238,6 +257,8 @@ internal data class AzDropdownConfig(
     val menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment =
         com.hereliesaz.aznavrail.model.AzMenuItemAlignment.SIDE,
     val justifyMenuItems: Boolean = true,
+    val trigger: AzDropdownTrigger = AzDropdownTrigger.MoreVert,
+    val triggerPlacement: AzDropdownTriggerPlacement = AzDropdownTriggerPlacement.AUTO,
 )
 
 /** One declared entry, collected by the builder and rendered by the composable. */
@@ -322,12 +343,14 @@ private class AzDropdownMenuScopeImpl : AzDropdownMenuScope {
         dimBehindMenuAlpha: Float,
         menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment,
         justifyMenuItems: Boolean,
+        trigger: AzDropdownTrigger,
+        triggerPlacement: AzDropdownTriggerPlacement,
     ) {
         config = AzDropdownConfig(
             design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape, headerIconSize,
             showFooter, inAppAbout, appRepositoryUrl, itemTextStyle, itemEntrance, entranceStaggerMs,
             entranceDurationMs, entranceEasing, entranceStartAngle, tiltOnPress, maxTiltDegrees, itemExit,
-            dimBehindMenu, dimBehindMenuAlpha, menuItemAlignment, justifyMenuItems,
+            dimBehindMenu, dimBehindMenuAlpha, menuItemAlignment, justifyMenuItems, trigger, triggerPlacement,
         )
     }
 
@@ -757,9 +780,15 @@ private fun entryLabel(entry: AzDropdownEntry): String = when (entry) {
  * Pins the dropped panel to the [dockingSide] **screen edge** and **drops it from the trigger**: it
  * opens downward from the trigger's bottom when there is room, otherwise upward from its top. Like
  * the rail, the side is physical ([AzDockingSide.LEFT] → left edge, [AzDockingSide.RIGHT] → right).
+ *
+ * [anchorOverride] supplies the trigger's real window-space bounds when the trigger has been lifted
+ * out to the screen-title row: the `Popup` is still composed at the drop-down's own call site, so
+ * the `anchorBounds` Compose hands us there would describe the empty placeholder, not the button
+ * the user actually tapped. It returns null for an inline trigger, where `anchorBounds` is correct.
  */
 private class AzDropdownEdgePositionProvider(
-    private val dockingSide: AzDockingSide
+    private val dockingSide: AzDockingSide,
+    private val anchorOverride: () -> IntRect? = { null },
 ) : PopupPositionProvider {
     override fun calculatePosition(
         anchorBounds: IntRect,
@@ -767,12 +796,13 @@ private class AzDropdownEdgePositionProvider(
         layoutDirection: LayoutDirection,
         popupContentSize: IntSize
     ): IntOffset {
+        val anchor = anchorOverride() ?: anchorBounds
         val x = if (dockingSide == AzDockingSide.LEFT) 0 else windowSize.width - popupContentSize.width
-        val fitsBelow = anchorBounds.bottom + popupContentSize.height <= windowSize.height
+        val fitsBelow = anchor.bottom + popupContentSize.height <= windowSize.height
         val y = if (fitsBelow) {
-            anchorBounds.bottom
+            anchor.bottom
         } else {
-            (anchorBounds.top - popupContentSize.height).coerceAtLeast(0)
+            (anchor.top - popupContentSize.height).coerceAtLeast(0)
         }
         return IntOffset(x, y)
     }
@@ -781,9 +811,17 @@ private class AzDropdownEdgePositionProvider(
 /**
  * A standalone, hamburger-style drop-down menu, declared with the same opinionated DSL as the rail.
  *
- * The trigger is the **app icon** (auto-drawn exactly like the rail's header; its shape/size are set
- * via [AzDropdownMenuScope.azConfig], mirroring the rail's `azTheme`), dropped inline like any
- * widget. Tapping it unfolds a [Popup] panel of the items you declare in
+ * The trigger defaults to the **three vertical dots** and, when the drop-down is declared inside an
+ * `AzHostActivityLayout` (the usual case — inside an `onscreen { … }` block), it is placed
+ * automatically **next to the big screen title**, above the onscreen content area, rather than where
+ * the composable happens to sit. Declare several drop-downs and their triggers line up beside each
+ * other there, in declaration order. Choose a word or your own glyph with
+ * `azConfig(trigger = AzDropdownTrigger.Text("Filter"))` / `AzDropdownTrigger.Icon(myVector)`, and
+ * opt back out of the title row with `azConfig(triggerPlacement = AzDropdownTriggerPlacement.INLINE)`.
+ * The trigger's size and clip shape come from `azConfig`'s `headerIconSize` / `headerIconShape`,
+ * mirroring the rail's `azTheme`.
+ *
+ * Tapping it unfolds a [Popup] panel of the items you declare in
  * [content]; the panel is presented as a slice of the rail ([AzDropdownDesign.RAIL]) or menu
  * ([AzDropdownDesign.MENU]), width-constrained to match, pinned to the [AzDockingSide] screen edge,
  * and dropping from the trigger. Tapping outside or pressing back folds it up.
@@ -802,7 +840,8 @@ private class AzDropdownEdgePositionProvider(
  * Items may declare a `route`; when set, tapping navigates the [navController] (so the drop-down can
  * drive an `AzNavHost`, just like the rail), then runs the item's callback.
  *
- * @param modifier Modifier applied to the trigger's box — place/position it like any widget.
+ * @param modifier Modifier applied to the trigger's box. Only meaningful for an inline trigger; a
+ *   title-hosted trigger is positioned by the host.
  * @param navController Controller used to navigate item `route`s. Defaults to the enclosing
  *   `AzNavHost`'s controller when present.
  * @param expanded Optional controlled open-state. When null the menu manages its own state.
@@ -853,47 +892,58 @@ fun AzDropdownMenu(
     val maxPanelHeight = with(density) { (LocalWindowInfo.current.containerSize.height * 0.8f).toDp() }
     val panelWidth = if (config.design == AzDropdownDesign.RAIL) config.collapsedWidth else config.expandedWidth
 
-    val positionProvider = remember(config.dockingSide) {
-        AzDropdownEdgePositionProvider(config.dockingSide)
+    // Where the trigger ends up. AUTO lifts it into the screen-title row whenever there is a host to
+    // put it in; a standalone drop-down (no AzHostActivityLayout) has no title row, so it stays inline.
+    val titleHost = LocalAzNavHostScope.current as? AzNavHostScopeImpl
+    val hostsTrigger = titleHost != null && when (config.triggerPlacement) {
+        AzDropdownTriggerPlacement.INLINE -> false
+        AzDropdownTriggerPlacement.TITLE, AzDropdownTriggerPlacement.AUTO -> true
     }
 
-    // The trigger is the app's launcher icon, provided via LocalAzAppMeta. Android's
-    // AzHostActivityLayout populates this from `packageManager.getApplicationIcon`; other targets
-    // pass a caller-supplied Coil3 model (URL string, ByteArray, or Painter).
+    // The trigger's real window-space bounds, reported by whichever button ends up drawing it, so
+    // the panel drops from the button the user tapped even when that button lives in the title row.
+    var triggerBounds by remember { mutableStateOf<IntRect?>(null) }
+
+    val positionProvider = remember(config.dockingSide) {
+        AzDropdownEdgePositionProvider(config.dockingSide) { triggerBounds }
+    }
+
+    // The launcher icon, provided via LocalAzAppMeta. Android's AzHostActivityLayout populates it
+    // from `packageManager.getApplicationIcon`; other targets pass a caller-supplied Coil3 model
+    // (URL string, ByteArray, or Painter). Only AzDropdownTrigger.AppIcon uses it.
     val appIcon = appMeta.icon
 
-    Box(modifier = modifier) {
-        // The inline app-icon trigger — the app icon, clipped to the configured shape/size. The icon
-        // itself is decorative; the box carries the "Menu" accessibility label.
-        val iconClipShape: Shape? = when (config.headerIconShape) {
-            AzHeaderIconShape.CIRCLE -> CircleShape
-            AzHeaderIconShape.ROUNDED -> RoundedCornerShape(12.dp)
-            else -> null
+    // One slot per drop-down. It carries the trigger's (comparable) look as snapshot state and its
+    // behaviour as plain fields, so the title row can render a trigger that always calls back into
+    // this composition without this composition having to re-publish a fresh lambda every frame.
+    val slot = remember { AzTitleTriggerSlot() }
+    slot.onTap = {
+        setOpen(!isOpen)
+        if (config.vibrate) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+    }
+    slot.onBounds = { bounds -> triggerBounds = bounds }
+    slot.publish(
+        AzDropdownTriggerSpec(
+            trigger = config.trigger,
+            size = config.headerIconSize,
+            iconShape = config.headerIconShape,
+            appIcon = appIcon,
+            textStyle = config.itemTextStyle,
+        )
+    )
+
+    if (hostsTrigger) {
+        DisposableEffect(titleHost, slot) {
+            titleHost?.registerTitleTrigger(slot)
+            onDispose { titleHost?.unregisterTitleTrigger(slot) }
         }
-        val clipModifier = if (iconClipShape != null) Modifier.clip(iconClipShape) else Modifier
-        Box(
-            modifier = Modifier
-                // Automatic breathing room around the app-icon trigger so it never sits flush against
-                // neighbouring widgets (mirrors the rail header's spacing).
-                .padding(AzNavRailDefaults.HeaderPadding)
-                .size(config.headerIconSize)
-                .then(clipModifier)
-                .clickable {
-                    setOpen(!isOpen)
-                    if (config.vibrate) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                }
-                .semantics(mergeDescendants = true) { contentDescription = "Menu" },
-            contentAlignment = Alignment.Center
-        ) {
-            if (appIcon != null) {
-                Image(
-                    painter = rememberAsyncImagePainter(appIcon),
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxSize().then(clipModifier)
-                )
-            } else {
-                Icon(imageVector = AzIcons.Menu, contentDescription = null)
-            }
+    }
+
+    Box(modifier = modifier) {
+        // The trigger itself, unless the host has taken it up to the title row — in which case
+        // nothing is drawn here and only the dropped panel below still belongs to this call site.
+        if (!hostsTrigger) {
+            AzDropdownTriggerButton(slot)
         }
 
         // Keep the panel composed through the staggered exit so items can animate out before teardown.

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzLoad.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzLoad.kt
@@ -11,22 +11,33 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 /**
- * A standard loading spinner component for AzNavRail.
+ * The standard AzNavRail loading spinner: a circular border rotating about its Y axis, with
+ * "loading..." in the middle.
  *
- * It renders a rotating circular border with "loading..." text in the center.
- * This component is used by [AzNavRail] when `isLoading` is set to true in `azAdvanced`,
- * and by [AzButton] when its `isLoading` state is true.
+ * Used full-size by the About/More-from-Az readers, and shrunk down **inside individual buttons** —
+ * every rail item is its own loading animation, so a single item can spin while the rest of the rail
+ * stays live. The label is dropped automatically at button scale, where there is no room for it.
  *
- * It uses a simple Y-axis rotation animation.
+ * @param size The spinner's diameter. Defaults to the full-screen reader size.
+ * @param color Ring and label colour. [Color.Unspecified] (the default) uses the theme primary.
+ * @param showLabel Whether "loading..." is drawn. Defaults to true only when [size] is large enough
+ *   to fit it.
  */
 @Composable
-fun AzLoad() {
+fun AzLoad(
+    size: Dp = 120.dp,
+    color: Color = Color.Unspecified,
+    showLabel: Boolean = size >= 96.dp,
+) {
     val infiniteTransition = rememberInfiniteTransition()
     val rotationY by infiniteTransition.animateFloat(
         initialValue = 0f,
@@ -37,25 +48,29 @@ fun AzLoad() {
         )
     )
 
+    val ringColor = color.takeOrElse { MaterialTheme.colorScheme.primary }
+
     Box(
         modifier = Modifier
-            .size(120.dp)
+            .size(size)
             .graphicsLayer {
                 this.rotationY = rotationY
             }
             .border(
                 width = 2.dp,
-                color = MaterialTheme.colorScheme.primary,
+                color = ringColor,
                 shape = CircleShape
             ),
         contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = "loading...",
-            style = TextStyle(
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 16.sp
+        if (showLabel) {
+            Text(
+                text = "loading...",
+                style = TextStyle(
+                    color = ringColor,
+                    fontSize = 16.sp
+                )
             )
-        )
+        }
     }
 }

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavHost.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavHost.kt
@@ -7,9 +7,11 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -46,7 +49,10 @@ import com.hereliesaz.aznavrail.bottomsheet.AzBottomSheet
 import com.hereliesaz.aznavrail.bottomsheet.AzSheetController
 import com.hereliesaz.aznavrail.internal.AboutOverlay
 import com.hereliesaz.aznavrail.internal.AzBottomSheetItem
+import com.hereliesaz.aznavrail.internal.AzDropdownTriggerButton
 import com.hereliesaz.aznavrail.internal.AzLayoutConfig
+import com.hereliesaz.aznavrail.internal.AzTitleTriggerSlot
+import com.hereliesaz.aznavrail.internal.AzUnattachedRail
 import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
 import com.hereliesaz.aznavrail.internal.AzRailLayoutHelper
 import com.hereliesaz.aznavrail.internal.AzSafeZones
@@ -98,6 +104,31 @@ interface AzNavHostScope : AzNavRailScope {
     fun onscreen(alignment: Alignment = Alignment.TopStart, page: Float = 0f, content: @Composable () -> Unit)
 
     /**
+     * Registers a popup window driven by [controller], drawn over everything else in the host.
+     *
+     * A popup is **bound to a rail item**: `controller.show(itemId = "sync")` names one explicitly,
+     * and `controller.show()` binds to whichever rail item the user touched last. The body receives
+     * that item as an [AzPopupItemHandle] through its [AzPopupScope], so the two share state in both
+     * directions — the popup can read the item and write back to it (badge, its own loading
+     * animation, an alert flag), and those writes outlive the DSL re-running until the popup clears
+     * them.
+     *
+     * A [AzPopupKind.NOTICE] or [AzPopupKind.WARNING] popup additionally redraws its bound item as a
+     * **yellow, rounded-corner triangle outline** for as long as it is up, and restores the item
+     * when it closes.
+     *
+     * @param controller Created with [rememberAzPopupController] outside the DSL so its state
+     *   survives recomposition.
+     * @param dismissOnOutsideTap Whether tapping the scrim closes the popup.
+     * @param content The popup's body. Defaults to the built-in title/message/OK panel.
+     */
+    fun azPopup(
+        controller: AzPopupController,
+        dismissOnOutsideTap: Boolean = true,
+        content: @Composable AzPopupScope.() -> Unit = { AzPopupBody() },
+    )
+
+    /**
      * Registers a bottom sheet that draws above the rail/menu/onscreen area and spans to the bottom
      * edge (so the HIDDEN detent is reachable from the nav-bar edge). Use
      * [com.hereliesaz.aznavrail.bottomsheet.rememberAzSheetController] to create [controller] outside
@@ -138,6 +169,24 @@ class AzNavHostScopeImpl(
     val backgrounds = mutableListOf<AzBackgroundItem>()
     val onscreenItems = mutableListOf<AzOnscreenItem>()
     internal val bottomSheets = mutableListOf<AzBottomSheetItem>()
+    internal val popups = mutableListOf<AzPopupItem>()
+
+    /**
+     * Drop-down triggers lifted out of their call sites and hosted next to the screen title, in
+     * registration order (which is declaration order, since `onscreen` blocks compose in order).
+     *
+     * Registered from `AzDropdownMenu`'s `DisposableEffect`, so — unlike [onscreenItems] — this is
+     * NOT cleared by [resetHost]: it is keyed to composition lifetime, not to the DSL pass.
+     */
+    internal val titleTriggers = mutableStateListOf<AzTitleTriggerSlot>()
+
+    internal fun registerTitleTrigger(slot: AzTitleTriggerSlot) {
+        if (!titleTriggers.contains(slot)) titleTriggers.add(slot)
+    }
+
+    internal fun unregisterTitleTrigger(slot: AzTitleTriggerSlot) {
+        titleTriggers.remove(slot)
+    }
 
     // Built-in overlay visibility. The rail flips these on user action; the host renders the overlays.
     // Deliberately NOT cleared by resetHost() so visibility survives the DSL re-applying each recomposition.
@@ -181,6 +230,14 @@ class AzNavHostScopeImpl(
         bottomSheets.add(AzBottomSheetItem(controller, config, onSwipeLeft, onSwipeRight, content))
     }
 
+    override fun azPopup(
+        controller: AzPopupController,
+        dismissOnOutsideTap: Boolean,
+        content: @Composable AzPopupScope.() -> Unit,
+    ) {
+        popups.add(AzPopupItem(controller, dismissOnOutsideTap, content))
+    }
+
     fun getRailScopeImpl() = railScope
 
     fun resetHost() {
@@ -188,6 +245,7 @@ class AzNavHostScopeImpl(
         backgrounds.clear()
         onscreenItems.clear()
         bottomSheets.clear()
+        popups.clear()
     }
 }
 
@@ -230,8 +288,10 @@ fun AzHostActivityLayout(
     scope.resetHost()
     scope.setController(navController)
     scope.apply(content)
-    // Re-apply persisted reloc-item reorders so drag-and-drop sticks across recomposition.
+    // Re-apply persisted reloc-item reorders so drag-and-drop sticks across recomposition, then
+    // stamp on the per-item badge/loading/alert state the DSL and any live popup declared.
     scope.getRailScopeImpl().applyRelocReorders()
+    scope.getRailScopeImpl().applyItemStates()
 
     // Status-driven guidance controller: provided to the rail (which routes/renders it) and returned.
     val guidanceController = rememberAzGuidanceController()
@@ -315,7 +375,10 @@ fun AzHostActivityLayout(
         val titlePaddingSide =
             if (visualDockingSideProxy == AzDockingSide.LEFT) Modifier.padding(end = 32.dp) else Modifier.padding(start = 32.dp)
 
-        if (currentTitle != null && currentTitle != AzNavRailDefaults.NO_TITLE && currentTitle.isNotBlank()) {
+        val hasTitle = currentTitle != null && currentTitle != AzNavRailDefaults.NO_TITLE && currentTitle.isNotBlank()
+        // The title row is also where hosted drop-down triggers live, so it is drawn whenever there
+        // is a title OR at least one trigger to place.
+        if (hasTitle || scope.titleTriggers.isNotEmpty()) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -324,30 +387,47 @@ fun AzHostActivityLayout(
                     .then(titlePaddingSide),
                 contentAlignment = titleAlignment,
             ) {
-                // Keying on the title restarts the kinetic entrance every time the active screen changes.
-                key(currentTitle) {
-                    val titleKinetic = rememberAzKineticModifier(
-                        index = 0,
-                        count = 1,
-                        visible = true,
-                        entrance = railScopeImpl.titleEntrance,
-                        exit = AzExit.None,
-                        staggerMs = 0,
-                        durationMs = 420,
-                        easing = AzEasing.Wp7Decelerate,
-                        startAngle = 70f,
-                        tiltOnPress = false,
-                        maxTiltDegrees = 0f,
-                        dockingSide = visualDockingSideProxy,
-                    )
-                    Text(
-                        text = currentTitle,
-                        modifier = titleKinetic,
-                        style = MaterialTheme.typography.displayMedium
-                            .copy(fontWeight = FontWeight.Bold)
-                            .merge(railScopeImpl.titleTextStyle),
-                        color = MaterialTheme.colorScheme.onBackground,
-                    )
+                // Title and triggers read like an app bar mirrored onto the rail's docking side: the
+                // triggers sit hard against the edge the title hugs, with the title just inboard of
+                // them. Several triggers line up beside each other in registration order.
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(0.dp),
+                ) {
+                    if (visualDockingSideProxy != AzDockingSide.LEFT) {
+                        scope.titleTriggers.forEach { slot -> AzDropdownTriggerButton(slot) }
+                    }
+                    if (hasTitle) {
+                        // Keying on the title restarts the kinetic entrance every time the active
+                        // screen changes.
+                        key(currentTitle) {
+                            val titleKinetic = rememberAzKineticModifier(
+                                index = 0,
+                                count = 1,
+                                visible = true,
+                                entrance = railScopeImpl.titleEntrance,
+                                exit = AzExit.None,
+                                staggerMs = 0,
+                                durationMs = 420,
+                                easing = AzEasing.Wp7Decelerate,
+                                startAngle = 70f,
+                                tiltOnPress = false,
+                                maxTiltDegrees = 0f,
+                                dockingSide = visualDockingSideProxy,
+                            )
+                            Text(
+                                text = currentTitle!!,
+                                modifier = titleKinetic,
+                                style = MaterialTheme.typography.displayMedium
+                                    .copy(fontWeight = FontWeight.Bold)
+                                    .merge(railScopeImpl.titleTextStyle),
+                                color = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
+                    }
+                    if (visualDockingSideProxy == AzDockingSide.LEFT) {
+                        scope.titleTriggers.forEach { slot -> AzDropdownTriggerButton(slot) }
+                    }
                 }
             }
         }
@@ -386,6 +466,21 @@ fun AzHostActivityLayout(
                 railAlignment = railAlignment,
                 reverseLayout = reverseLayout,
                 content = {},
+            )
+        }
+
+        // Unattached host items — rail hosts that live outside the rail strip. Drawn after the rail
+        // so a floating stack can be dragged over it, and before the built-in overlays so About /
+        // Help / More-from-Az still cover everything.
+        CompositionLocalProvider(
+            LocalAzNavHostScope provides scope,
+            LocalAzSafeZones provides AzSafeZones(safeTop, safeBottom),
+        ) {
+            AzUnattachedRail(
+                scope = railScope,
+                navController = navController,
+                currentDestination = effectiveCurrentDestination,
+                visualDockingSide = visualDockingSideProxy,
             )
         }
 
@@ -451,6 +546,16 @@ fun AzHostActivityLayout(
                 onSwipeLeft = item.onSwipeLeft,
                 onSwipeRight = item.onSwipeRight,
                 content = item.content,
+            )
+        }
+
+        // Popups sit above the sheets: they are the layer that interrupts, and a warning raised
+        // while a sheet is open still has to be the thing the user answers.
+        scope.popups.forEach { popup ->
+            AzPopupHost(
+                popup = popup,
+                railScope = railScope,
+                modifier = Modifier.zIndex(3f),
             )
         }
     }

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -79,6 +79,7 @@ import com.hereliesaz.aznavrail.internal.MenuItem
 import com.hereliesaz.aznavrail.internal.rememberAzKineticModifier
 import com.hereliesaz.aznavrail.internal.rememberAzClosingState
 import com.hereliesaz.aznavrail.internal.RailItems
+import com.hereliesaz.aznavrail.internal.toComposeShape
 import com.hereliesaz.aznavrail.model.AzExit
 import com.hereliesaz.aznavrail.internal.SecretScreens
 import com.hereliesaz.aznavrail.service.GithubDocsRepository
@@ -239,6 +240,7 @@ fun AzNavRail(
         scope.reset()
         scope.apply(content)
         scope.applyRelocReorders()
+        scope.applyItemStates()
     }
     // When providedScope is non-null, AzHostActivityLayout already applied the DSL + reorders.
 
@@ -254,6 +256,13 @@ fun AzNavRail(
         scope.appRepositoryUrl.ifBlank {
             packageName?.let { GithubDocsRepository.repoUrlFromPackage(it) } ?: scope.appRepositoryUrl
         }
+    }
+
+    // Ids of the unattached hosts and their whole subtrees. They are declared on this scope like any
+    // other item, but they render at their own anchor (see `AzUnattachedRail`), so the rail strip
+    // and the drawer both have to skip them.
+    val unattachedIds = remember(scope.navItems.toList()) {
+        com.hereliesaz.aznavrail.internal.azUnattachedSubtreeIds(scope.navItems)
     }
 
     var isExpanded by remember { mutableStateOf(if (scope.noMenu) false else initiallyExpanded) }
@@ -705,7 +714,8 @@ fun AzNavRail(
                     }
                 }
                 val isRailOpen = !(isFloating && !showFloatingButtons) && !(scope.noMenu && scope.isFoldedUp)
-                val railItemsCount = scope.navItems.filter { it.isRailItem && !it.isSubItem }.size
+                val railItemsCount =
+                    scope.navItems.filter { it.isRailItem && !it.isSubItem && it.id !in unattachedIds }.size
                 val railItemsRendered = rememberAzClosingState(
                     open = isRailOpen,
                     exit = AzExit.Turnstile,
@@ -718,13 +728,18 @@ fun AzNavRail(
                     // MAIN CONTENT and MENU separation
                     BoxWithConstraints(modifier = Modifier.weight(1f)) {
                         val hasExplicitHelpItem = scope.navItems.any { it.isHelpItem || it.id == AzNavRailDefaults.AUTO_HELP_ID }
+                        // Unattached hosts and everything hanging off them have left the rail: they
+                        // draw themselves at their own anchor, so neither the strip nor the drawer
+                        // may render them.
+                        val attachedItems = if (unattachedIds.isEmpty()) scope.navItems
+                        else scope.navItems.filterNot { it.id in unattachedIds }
                         val displayItems = if (scope.advancedConfig.helpEnabled && !hasExplicitHelpItem) {
-                            scope.navItems + AzNavItem.Help(
+                            attachedItems + AzNavItem.Help(
                                 id = AzNavRailDefaults.AUTO_HELP_ID,
                                 isRailItem = false
                             )
                         } else {
-                            scope.navItems
+                            attachedItems
                         }
                         val topLevelItems = displayItems.filter { !it.isSubItem }
                         // Keep the menu composed through the staggered exit so items can turnstile out as the
@@ -793,7 +808,7 @@ fun AzNavRail(
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
                                 RailItems(
-                                    items = scope.navItems,
+                                    items = attachedItems,
                                     scope = scope,
                                     navController = effectiveNavController,
                                     currentDestination = actualCurrentDestination,
@@ -822,6 +837,9 @@ fun AzNavRail(
                                         }
                                     },
                                     onItemSelected = { item ->
+                                        // Remember who was touched last: a notice/warning popup
+                                        // raised without an explicit source claims this item.
+                                        scope.lastTouchedItemId = item.id
                                         if (item.isHelpItem) {
                                             toggleHelpOverlay(item.id)
                                         }
@@ -871,7 +889,9 @@ fun AzNavRail(
                                 .padding(8.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            val buttonShape = scope.defaultShape
+                            // `defaultShape` is an AzButtonShape; border/background need the real
+                            // Compose Shape it maps to.
+                            val buttonShape = scope.defaultShape.toComposeShape()
                             val transparentShapeModifier = Modifier
                                 .size(activeButtonSize)
                                 .border(
@@ -1142,6 +1162,7 @@ private fun MenuItemNode(
         isSelected = (item.route != null && item.route == currentDestination) ||
                 item.classifiers.any { scope.activeClassifiers.contains(it) },
         onClick = {
+            scope.lastTouchedItemId = item.id
             if (item.isHelpItem) {
                 onToggleHelp(item.id)
             } else {

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.rememberAsyncImagePainter
 import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
+import com.hereliesaz.aznavrail.internal.toComposeShape
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzComposableContent
 import com.hereliesaz.aznavrail.util.text.AutoSizeText
@@ -106,18 +107,15 @@ internal fun AzNavRailButton(
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
 
-    val buttonShape: Shape = when (shape) {
-        AzButtonShape.CIRCLE -> CircleShape
-        AzButtonShape.SQUARE -> RectangleShape
-        AzButtonShape.RECTANGLE -> RectangleShape
-        AzButtonShape.NONE -> RectangleShape
-    }
+    val buttonShape: Shape = shape.toComposeShape()
 
     val isRotated = rotationDegrees != 0f && (rotationDegrees % 180 != 0f)
 
     // STRICT WIDTH COMPLIANCE for all shapes. Swapped in landscape to maintain "physical" size.
     val buttonModifier = when (shape) {
-        AzButtonShape.CIRCLE, AzButtonShape.SQUARE -> modifier
+        // The triangle occupies the same square footprint as a circle, so an item that flips to the
+        // warning glyph doesn't reflow the rail around it.
+        AzButtonShape.CIRCLE, AzButtonShape.SQUARE, AzButtonShape.TRIANGLE -> modifier
             .size(size)
             .aspectRatio(1f)
         AzButtonShape.RECTANGLE, AzButtonShape.NONE -> {
@@ -179,7 +177,12 @@ internal fun AzNavRailButton(
     ) {
         Box(
             // If itemContent is present (Color/Img), we force 0 padding to Fill/Crop. Otherwise, apply text padding.
-            modifier = if (itemContent != null) Modifier else Modifier.padding(contentPadding),
+            // A triangle's usable area is its lower half, so its content is nudged down off the apex.
+            modifier = when {
+                itemContent != null -> Modifier
+                shape == AzButtonShape.TRIANGLE -> Modifier.padding(contentPadding).padding(top = size * 0.25f)
+                else -> Modifier.padding(contentPadding)
+            },
             contentAlignment = Alignment.Center
         ) {
             Box(
@@ -203,7 +206,15 @@ internal fun AzNavRailButton(
                     )
                 }
             }
-            if (isLoading) AzLoad()
+            // Each button spins its own spinner, scaled to the button rather than the full-screen
+            // default, and tinted to the item's own colour so a loading item still reads as itself.
+            if (isLoading) {
+                val spinnerSize = when (shape) {
+                    AzButtonShape.RECTANGLE, AzButtonShape.NONE -> 28.dp
+                    else -> size * 0.6f
+                }
+                AzLoad(size = spinnerSize, color = finalColor, showLabel = false)
+            }
         }
     }
 }

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -20,7 +20,10 @@ import com.hereliesaz.aznavrail.model.AzEasing
 import com.hereliesaz.aznavrail.model.AzEntrance
 import com.hereliesaz.aznavrail.model.AzExit
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
+import com.hereliesaz.aznavrail.model.AzItemAlert
 import com.hereliesaz.aznavrail.model.AzItemConfig
+import com.hereliesaz.aznavrail.model.AzItemState
+import com.hereliesaz.aznavrail.model.AzUnattachedAnchor
 import com.hereliesaz.aznavrail.model.AzMenuItemAlignment
 import com.hereliesaz.aznavrail.model.AzNavItem
 import com.hereliesaz.aznavrail.model.AzNestedRailAlignment
@@ -298,7 +301,7 @@ interface AzNavRailScope {
      * @param info Description text for the Help/Info screen.
      * @param onClick Callback invoked when the item is clicked.
      */
-    fun azMenuItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azMenuItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds an explicit Help trigger item to the rail.
@@ -310,7 +313,7 @@ interface AzNavRailScope {
      * @param color Custom color.
      * @param shape Custom shape.
      */
-    fun azHelpRailItem(id: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null)
+    fun azHelpRailItem(id: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false)
 
     /**
      * Adds an explicit Help trigger item as a SubItem to a Host Item.
@@ -323,7 +326,7 @@ interface AzNavRailScope {
      * @param color Custom color.
      * @param shape Custom shape.
      */
-    fun azHelpSubItem(id: String, hostId: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null)
+    fun azHelpSubItem(id: String, hostId: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false)
 
     /**
      * Adds an item to the always-visible rail.
@@ -341,7 +344,7 @@ interface AzNavRailScope {
      * @param onFocus Callback invoked when the item receives focus.
      * @param onClick Callback invoked when the item is clicked.
      */
-    fun azRailItem(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
+    fun azRailItem(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Nested Rail item. This item opens a secondary popup rail when clicked.
@@ -361,7 +364,7 @@ interface AzNavRailScope {
      * @param keepNestedRailOpen If true, the nested rail remains open until the parent item is tapped again.
      * @param nestedContent DSL block to define the items within the nested rail.
      */
-    fun azNestedRail(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, alignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onFocus: (() -> Unit)? = null, keepNestedRailOpen: Boolean = false, nestedContent: AzNavRailScope.() -> Unit)
+    fun azNestedRail(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, alignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onFocus: (() -> Unit)? = null, keepNestedRailOpen: Boolean = false, nestedContent: AzNavRailScope.() -> Unit)
 
     /**
      * Adds a toggle switch item to the menu.
@@ -370,7 +373,7 @@ interface AzNavRailScope {
      * @param toggleOnText Text to display when checked.
      * @param toggleOffText Text to display when unchecked.
      */
-    fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a toggle switch item to the rail.
@@ -387,7 +390,7 @@ interface AzNavRailScope {
      * @param info Help info string.
      * @param onClick Click callback.
      */
-    fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a cycler item (multi-state button) to the menu.
@@ -396,7 +399,7 @@ interface AzNavRailScope {
      * @param selectedOption The currently selected option.
      * @param disabledOptions List of options that cannot be selected.
      */
-    fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a cycler item to the always-visible rail.
@@ -420,7 +423,7 @@ interface AzNavRailScope {
      * @param fillColor Translucent fill color override.
      * @param onClick Callback fired on commit.
      */
-    fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a visual divider line to the menu list. Has no effect on the collapsed rail.
@@ -441,7 +444,7 @@ interface AzNavRailScope {
      * @param info Help info string.
      * @param onClick Click callback.
      */
-    fun azMenuHostItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
+    fun azMenuHostItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Host Item to the rail. Sub-items targeting [id] via their
@@ -466,6 +469,7 @@ interface AzNavRailScope {
         fillColor: Color? = null,
         badge: String? = null,
         persistentBadge: Boolean = false,
+        isLoading: Boolean = false,
         initiallyExpanded: Boolean = false,
         expandWhen: (() -> Boolean)? = null,
         onExpandedChange: ((Boolean) -> Unit)? = null,
@@ -473,11 +477,83 @@ interface AzNavRailScope {
     )
 
     /**
+     * Adds an **unattached** Host Item — a rail host that does not live in the rail strip.
+     *
+     * It is drawn on its own at [anchor], and tapping it unfolds its sub-items inline beneath it,
+     * exactly as they would have unfolded inside the rail. Sub-items attach the usual way, by
+     * pointing their `hostId` at this item's [id] (`azRailSubItem`, `azRailSubToggle`,
+     * `azRailSubCycler`, `azRailSubHostItem` — sub-hosts nest to any depth). Declare several
+     * unattached hosts sharing an [anchor] and they stack into a column, spaced exactly as they
+     * would have been in the rail.
+     *
+     * The host and its whole subtree are removed from the rail strip and the drawer menu; this item
+     * exists only at its anchor.
+     *
+     * @param anchor Where it parks: [AzUnattachedAnchor.BOTTOM] (bottom of the screen, opposite the
+     *   rail), [AzUnattachedAnchor.OPPOSITE] (opposite side, level with the rail's items), or
+     *   [AzUnattachedAnchor.FLOATING] (draggable, with its position persisted across launches).
+     *   Other parameters mirror [azRailHostItem]; see that method's docs.
+     */
+    fun azUnattachedHostItem(
+        id: String,
+        text: String,
+        anchor: AzUnattachedAnchor = AzUnattachedAnchor.OPPOSITE,
+        route: String? = null,
+        content: Any? = null,
+        color: Color? = null,
+        shape: AzButtonShape? = null,
+        disabled: Boolean = false,
+        screenTitle: String? = null,
+        info: String? = null,
+        classifiers: Set<String> = emptySet(),
+        menuText: String? = null,
+        textColor: Color? = null,
+        fillColor: Color? = null,
+        badge: String? = null,
+        persistentBadge: Boolean = false,
+        isLoading: Boolean = false,
+        initiallyExpanded: Boolean = false,
+        expandWhen: (() -> Boolean)? = null,
+        onExpandedChange: ((Boolean) -> Unit)? = null,
+        onClick: (() -> Unit)? = null
+    )
+
+    /**
+     * Decorates an **already-declared** item — of any kind, anywhere: a rail item, a menu item, a
+     * sub-item, a host, a nested-rail child, an unattached host — with the per-item state the rail
+     * can render on top of it.
+     *
+     * This is the uniform way to give *every* item a badge and its own loading animation without
+     * every builder growing the same three parameters. Call it anywhere in the DSL block; it is
+     * applied after all items are declared, so the order does not matter. Values left null are left
+     * alone, so decorating only the badge does not clear the item's loading state.
+     *
+     * ```
+     * azRailItem(id = "sync", text = "Sync") { sync() }
+     * azItemState(id = "sync", isLoading = syncing, badge = pendingCount.takeIf { it > 0 }?.toString())
+     * ```
+     *
+     * @param id The id of the item to decorate. Unknown ids are ignored.
+     * @param badge Short badge text drawn in a small circle on the button's corner; blank/null hides it.
+     * @param persistentBadge Whether the badge stays visible (true) or dissolves after a second (false).
+     * @param isLoading Whether this item's button spins its own loading animation in place of its content.
+     * @param alert Alert styling — a notice/warning redraws the item as a yellow, rounded-corner
+     *   triangle outline. Usually set for you by an [com.hereliesaz.aznavrail.AzPopupController].
+     */
+    fun azItemState(
+        id: String,
+        badge: String? = null,
+        persistentBadge: Boolean? = null,
+        isLoading: Boolean? = null,
+        alert: AzItemAlert? = null
+    )
+
+    /**
      * Adds a Sub Item to a Host Item in the menu.
      *
      * @param hostId The ID of the parent Host Item.
      */
-    fun azMenuSubItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azMenuSubItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Item to a Host Item in the rail. Parameters mirror [azMenuSubItem]; on the rail
@@ -485,7 +561,7 @@ interface AzNavRailScope {
      *
      * @param onFocus Called when the sub-item gains focus.
      */
-    fun azRailSubItem(id: String, hostId: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
+    fun azRailSubItem(id: String, hostId: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Item that is itself a Host Item in the menu. It is a child of [hostId] (so it only
@@ -494,7 +570,7 @@ interface AzNavRailScope {
      *
      * @param hostId The ID of the parent Host Item this sub-host belongs to.
      */
-    fun azMenuSubHostItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
+    fun azMenuSubHostItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Item that is itself a Host Item to the rail. It is a child of
@@ -519,6 +595,9 @@ interface AzNavRailScope {
         menuText: String? = null,
         textColor: Color? = null,
         fillColor: Color? = null,
+        badge: String? = null,
+        persistentBadge: Boolean = false,
+        isLoading: Boolean = false,
         initiallyExpanded: Boolean = false,
         expandWhen: (() -> Boolean)? = null,
         onExpandedChange: ((Boolean) -> Unit)? = null,
@@ -536,13 +615,13 @@ interface AzNavRailScope {
      * @param toggleOffText Label shown when unchecked.
      * @param onClick Fired on toggle.
      */
-    fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+    fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Toggle to a Host Item in the rail. Parameters mirror [azMenuSubToggle]; only
      * visible while the parent host is expanded on the rail.
      */
-    fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+    fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Cycler to a Host Item in the menu.
@@ -554,13 +633,13 @@ interface AzNavRailScope {
      * @param disabledOptions Options that should be skipped during cycling.
      * @param onClick Fired on commit.
      */
-    fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+    fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Cycler to a Host Item in the rail. Parameters mirror [azMenuSubCycler]; the
      * cycler only renders while the parent host is expanded on the rail.
      */
-    fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+    fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Relocatable Item to a Host Item in the rail.
@@ -587,7 +666,7 @@ interface AzNavRailScope {
      * @param forceHiddenMenuOpen Programmatic control to explicitly show or hide the hidden menu.
      * @param onHiddenMenuDismiss Callback invoked when the hidden menu dismisses itself.
      */
-    fun azRailRelocItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null, onRelocate: ((Int, Int, List<String>) -> Unit)? = null, nestedRailAlignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, keepNestedRailOpen: Boolean = false, nestedContent: (AzNavRailScope.() -> Unit)? = null, forceHiddenMenuOpen: Boolean = false, onHiddenMenuDismiss: (() -> Unit)? = null, hiddenMenu: HiddenMenuScope.() -> Unit = {})
+    fun azRailRelocItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null, onRelocate: ((Int, Int, List<String>) -> Unit)? = null, nestedRailAlignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, keepNestedRailOpen: Boolean = false, nestedContent: (AzNavRailScope.() -> Unit)? = null, forceHiddenMenuOpen: Boolean = false, onHiddenMenuDismiss: (() -> Unit)? = null, hiddenMenu: HiddenMenuScope.() -> Unit = {})
 }
 
 /**
@@ -713,6 +792,27 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
      * drag end and re-applied via [applyRelocReorders] after the DSL block runs.
      */
     val savedRelocOrders: androidx.compose.runtime.snapshots.SnapshotStateMap<String, List<String>> = mutableStateMapOf()
+    /**
+     * Per-item state declared through [azItemState], keyed by item id. Cleared on each [reset] and
+     * re-declared by the DSL, like the items themselves.
+     */
+    val declaredItemStates = mutableMapOf<String, AzItemState>()
+
+    /**
+     * Per-item state pushed **imperatively** from an [com.hereliesaz.aznavrail.AzPopupController]'s
+     * item handle. Survives [reset] (the DSL re-runs constantly and would otherwise wipe it on the
+     * next frame) and wins over [declaredItemStates], because it represents something that happened
+     * after the developer's declaration — a popup taking ownership of the item that raised it.
+     */
+    val itemOverrides: androidx.compose.runtime.snapshots.SnapshotStateMap<String, AzItemState> = mutableStateMapOf()
+
+    /**
+     * The last rail/menu item the user touched. A notice/warning popup raised with no explicit
+     * source item claims this one, which is what "the last touched rail item turns into a warning
+     * triangle" resolves to.
+     */
+    var lastTouchedItemId: String? by mutableStateOf(null)
+
     /** Cache of window-space bounds for each item, populated as items are laid out. */
     val itemBoundsCache = mutableStateMapOf<String, Rect>()
     /** Transient selected options for cyclers during the debounce window. */
@@ -732,6 +832,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         onRelocateMap.clear()
         expandWhenMap.clear()
         onExpandedChangeMap.clear()
+        declaredItemStates.clear()
         statusPredicates.clear()
         guidanceEdges.clear()
         guidanceGoals.clear()
@@ -785,6 +886,43 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
             }
         }
         staleHosts.forEach { savedRelocOrders.remove(it) }
+    }
+
+    /**
+     * Stamps [declaredItemStates] and [itemOverrides] onto the freshly-declared [navItems] (and onto
+     * nested-rail children, which live in their parent's `nestedRailItems`).
+     *
+     * Called right after the DSL block runs, alongside [applyRelocReorders], for the same reason:
+     * the DSL rebuilds every item from scratch on each recomposition, so anything layered on top of
+     * an item has to be re-applied afterwards or it lasts exactly one frame.
+     */
+    fun applyItemStates() {
+        if (declaredItemStates.isEmpty() && itemOverrides.isEmpty()) return
+        fun decorate(item: AzNavItem): AzNavItem {
+            val declared = declaredItemStates[item.id]
+            val override = itemOverrides[item.id]
+            // Nested-rail children are decorated too, so `azItemState` reaches items declared inside
+            // a `nestedContent { … }` block — hence the recursion happens even when the parent
+            // itself carries no state of its own.
+            if (declared == null && override == null) {
+                val children = item.nestedRailItems ?: return item
+                return item.copy(nestedRailItems = children.map { decorate(it) })
+            }
+            val badge = override?.badge ?: declared?.badge ?: item.badge
+            val persistent = override?.persistentBadge ?: declared?.persistentBadge ?: item.persistentBadge
+            val loading = override?.isLoading ?: declared?.isLoading ?: item.isLoading
+            val alert = override?.alert ?: declared?.alert ?: item.alert
+            return item.copy(
+                badge = badge,
+                persistentBadge = persistent,
+                isLoading = loading,
+                alert = alert,
+                nestedRailItems = item.nestedRailItems?.map { decorate(it) },
+            )
+        }
+        for (i in navItems.indices) {
+            navItems[i] = decorate(navItems[i])
+        }
     }
 
     // Config
@@ -1079,14 +1217,14 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         }
     }
 
-    override fun azMenuItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azMenuItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azHelpRailItem(id: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?) {
+    override fun azHelpRailItem(id: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean) {
         checkId(id)
         navItems.add(
-            AzNavItem.Help(
+            AzNavItem.Help(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 id = id,
                 text = text,
                 menuText = menuText,
@@ -1100,13 +1238,13 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         )
     }
 
-    override fun azHelpSubItem(id: String, hostId: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?) {
+    override fun azHelpSubItem(id: String, hostId: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean) {
         checkId(id)
         if (navItems.none { it.id == hostId }) {
             throw IllegalArgumentException("`azHelpSubItem(id = \"$id\", hostId = \"$hostId\", ...)` references a host that has not been declared yet. Sub-items attach to a previously-registered host so the rail can resolve `hostId` -> host item when rendering. Fix: declare a parent `azMenuHostItem` / `azRailHostItem` / `azHelpRailItem` (or any item) with `id = \"$hostId\"` BEFORE this `azHelpSubItem` call in the `azRailContent { ... }` block; or change the `hostId` argument here to match an id that already exists.")
         }
         navItems.add(
-            AzNavItem(
+            AzNavItem(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 id = id,
                 text = text,
                 menuText = menuText,
@@ -1123,11 +1261,11 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         )
     }
 
-    override fun azRailItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azRailItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azNestedRail(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, alignment: AzNestedRailAlignment, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onFocus: (() -> Unit)?, keepNestedRailOpen: Boolean, nestedContent: AzNavRailScope.() -> Unit) {
+    override fun azNestedRail(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, alignment: AzNestedRailAlignment, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onFocus: (() -> Unit)?, keepNestedRailOpen: Boolean, nestedContent: AzNavRailScope.() -> Unit) {
         checkId(id)
         val nestedScope = AzNavRailScopeImpl(this.globalIdSet)
         nestedScope.azConfig(dockingSide = this.dockingSide, packButtons = this.packButtons, noMenu = this.noMenu, vibrate = this.vibrate, displayAppName = this.displayAppName, activeClassifiers = this.activeClassifiers, expandedWidth = this.expandedWidth, collapsedWidth = this.collapsedWidth, showFooter = this.showFooter, appRepositoryUrl = this.appRepositoryUrl)
@@ -1146,7 +1284,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         if (onFocus != null) onFocusMap[id] = onFocus
 
         navItems.add(
-            AzNavItem(
+            AzNavItem(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 id = id, text = text, menuText = menuText, route = route, isRailItem = true, isNestedRail = true,
                 nestedRailAlignment = alignment, nestedRailItems = nestedScope.navItems.toList(),
                 disabled = disabled, screenTitle = screenTitle ?: text,
@@ -1156,30 +1294,30 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         )
     }
 
-    override fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
     override fun azDivider() {
         navItems.add(AzNavItem(id = "divider_${navItems.size}", text = "", isRailItem = false, isDivider = true))
     }
 
-    override fun azMenuHostItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, expandWhen: (() -> Boolean)?, onExpandedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {
+    override fun azMenuHostItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, expandWhen: (() -> Boolean)?, onExpandedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {
         if (expandWhen != null) expandWhenMap[id] = expandWhen
         if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
 
@@ -1199,6 +1337,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         fillColor: Color?,
         badge: String?,
         persistentBadge: Boolean,
+        isLoading: Boolean,
         initiallyExpanded: Boolean,
         expandWhen: (() -> Boolean)?,
         onExpandedChange: ((Boolean) -> Unit)?,
@@ -1210,7 +1349,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
             id = id,
             text = text,
             menuText = menuText,
-            config = AzItemConfig(
+            config = AzItemConfig(isLoading = isLoading, 
                 classifiers = classifiers,
                 route = route,
                 screenTitle = screenTitle,
@@ -1229,19 +1368,89 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
             onClick = onClick ?: {})
     }
 
-    override fun azMenuSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azUnattachedHostItem(
+        id: String,
+        text: String,
+        anchor: AzUnattachedAnchor,
+        route: String?,
+        content: Any?,
+        color: Color?,
+        shape: AzButtonShape?,
+        disabled: Boolean,
+        screenTitle: String?,
+        info: String?,
+        classifiers: Set<String>,
+        menuText: String?,
+        textColor: Color?,
+        fillColor: Color?,
+        badge: String?,
+        persistentBadge: Boolean,
+        isLoading: Boolean,
+        initiallyExpanded: Boolean,
+        expandWhen: (() -> Boolean)?,
+        onExpandedChange: ((Boolean) -> Unit)?,
+        onClick: (() -> Unit)?
+    ) {
+        if (expandWhen != null) expandWhenMap[id] = expandWhen
+        if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
+        addItem(
+            id = id,
+            text = text,
+            menuText = menuText,
+            config = AzItemConfig(
+                classifiers = classifiers,
+                route = route,
+                screenTitle = screenTitle,
+                info = info,
+                // Unattached hosts are rail-flavoured (they render rail buttons and unfold rail
+                // sub-items); `isUnattached` is what keeps them out of the rail strip itself.
+                isRailItem = true,
+                disabled = disabled,
+                isHost = true,
+                content = content,
+                color = color,
+                textColor = textColor,
+                fillColor = fillColor,
+                shape = shape,
+                badge = badge,
+                persistentBadge = persistentBadge,
+                isLoading = isLoading,
+                initiallyExpanded = initiallyExpanded,
+                isUnattached = true,
+                unattachedAnchor = anchor
+            ),
+            onClick = onClick ?: {})
     }
 
-    override fun azRailSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, isSubItem = true, hostId = hostId, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azItemState(
+        id: String,
+        badge: String?,
+        persistentBadge: Boolean?,
+        isLoading: Boolean?,
+        alert: AzItemAlert?
+    ) {
+        val existing = declaredItemStates[id]
+        declaredItemStates[id] = AzItemState(
+            badge = badge ?: existing?.badge,
+            persistentBadge = persistentBadge ?: existing?.persistentBadge,
+            isLoading = isLoading ?: existing?.isLoading,
+            alert = alert ?: existing?.alert,
+        )
     }
 
-    override fun azMenuSubHostItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, expandWhen: (() -> Boolean)?, onExpandedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {
+    override fun azMenuSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    }
+
+    override fun azRailSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, isSubItem = true, hostId = hostId, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    }
+
+    override fun azMenuSubHostItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, expandWhen: (() -> Boolean)?, onExpandedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {
         checkSubHost(id, hostId, "azMenuSubHostItem")
         if (expandWhen != null) expandWhenMap[id] = expandWhen
         if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
     override fun azRailSubHostItem(
@@ -1259,6 +1468,9 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         menuText: String?,
         textColor: Color?,
         fillColor: Color?,
+        badge: String?,
+        persistentBadge: Boolean,
+        isLoading: Boolean,
         initiallyExpanded: Boolean,
         expandWhen: (() -> Boolean)?,
         onExpandedChange: ((Boolean) -> Unit)?,
@@ -1271,7 +1483,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
             id = id,
             text = text,
             menuText = menuText,
-            config = AzItemConfig(
+            config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 classifiers = classifiers,
                 route = route,
                 screenTitle = screenTitle,
@@ -1304,23 +1516,23 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         }
     }
 
-    override fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
-        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    override fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
-    override fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
-        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    override fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
-    override fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
-        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    override fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
-    override fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
-        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    override fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
-    override fun azRailRelocItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onFocus: (() -> Unit)?, onClick: (() -> Unit)?, onRelocate: ((Int, Int, List<String>) -> Unit)?, nestedRailAlignment: AzNestedRailAlignment, keepNestedRailOpen: Boolean, nestedContent: (AzNavRailScope.() -> Unit)?, forceHiddenMenuOpen: Boolean, onHiddenMenuDismiss: (() -> Unit)?, hiddenMenu: HiddenMenuScope.() -> Unit) {
+    override fun azRailRelocItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?, onRelocate: ((Int, Int, List<String>) -> Unit)?, nestedRailAlignment: AzNestedRailAlignment, keepNestedRailOpen: Boolean, nestedContent: (AzNavRailScope.() -> Unit)?, forceHiddenMenuOpen: Boolean, onHiddenMenuDismiss: (() -> Unit)?, hiddenMenu: HiddenMenuScope.() -> Unit) {
         checkId(id)
         val hiddenMenuScope = HiddenMenuScopeImpl(id, hiddenMenuOnClickMap, hiddenMenuOnValueChangeMap)
         hiddenMenuScope.hiddenMenu()
@@ -1350,7 +1562,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         } else null
 
         navItems.add(
-            AzNavItem(
+            AzNavItem(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 id = id, text = text, menuText = menuText, route = route, isRailItem = true, isSubItem = true, hostId = hostId,
                 isRelocItem = true, disabled = disabled, screenTitle = finalScreenTitle, info = info,
                 hiddenMenuItems = hiddenMenuScope.items, forceHiddenMenuOpen = forceHiddenMenuOpen, onHiddenMenuDismiss = onHiddenMenuDismiss, classifiers = classifiers, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape,
@@ -1376,7 +1588,8 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
                 classifiers = config.classifiers, isCycler = true, options = options, menuOptions = menuOptions, selectedOption = selectedOption,
                 disabled = config.disabled, disabledOptions = disabledOptions, isSubItem = config.isSubItem,
                 hostId = config.hostId, info = config.info, color = config.color, textColor = config.textColor,
-                fillColor = config.fillColor, shape = config.shape, badge = config.badge, persistentBadge = config.persistentBadge
+                fillColor = config.fillColor, shape = config.shape, badge = config.badge,
+                persistentBadge = config.persistentBadge, isLoading = config.isLoading
             )
         )
     }
@@ -1396,7 +1609,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
                 menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, disabled = config.disabled,
                 isSubItem = config.isSubItem, hostId = config.hostId, info = config.info, color = config.color,
                 textColor = config.textColor, fillColor = config.fillColor, shape = config.shape, badge = config.badge,
-                persistentBadge = config.persistentBadge
+                persistentBadge = config.persistentBadge, isLoading = config.isLoading
             )
         )
     }
@@ -1420,7 +1633,10 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
                 shape = config.shape,
                 initiallyExpanded = config.initiallyExpanded,
                 badge = config.badge,
-                persistentBadge = config.persistentBadge
+                persistentBadge = config.persistentBadge,
+                isLoading = config.isLoading,
+                isUnattached = config.isUnattached,
+                unattachedAnchor = config.unattachedAnchor
             )
         )
     }

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzPopup.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/AzPopup.kt
@@ -1,0 +1,311 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.internal.color
+import com.hereliesaz.aznavrail.model.AzItemAlert
+import com.hereliesaz.aznavrail.model.AzItemState
+import com.hereliesaz.aznavrail.model.AzNavItem
+
+/** How loud an [AzPopup] is, and what it does to the rail item that raised it. */
+enum class AzPopupKind {
+    /** Ordinary information. The source item is left looking like itself. */
+    INFO,
+
+    /** A notice. The source item becomes a yellow rounded-corner triangle outline while it is up. */
+    NOTICE,
+
+    /** A warning. Same triangle, in a louder yellow. */
+    WARNING,
+}
+
+/** One live show request, describing what the popup is about and which item raised it. */
+data class AzPopupRequest(
+    /**
+     * The id of the rail item that raised it. Null asks the rail for the **last touched** item,
+     * which is what a warning raised from a background job — with no tap to name a source — binds to.
+     */
+    val itemId: String? = null,
+    val kind: AzPopupKind = AzPopupKind.INFO,
+    val title: String? = null,
+    val message: String? = null,
+    /** Anything else the popup body needs. Passed straight through, untouched. */
+    val payload: Any? = null,
+)
+
+/**
+ * The handle an [AzPopup] gets on the rail item that raised it — the shared channel between the two.
+ *
+ * The popup can read the item as the rail currently has it, and write back to it: a long-running
+ * action started from a rail item can spin that item's own loading animation, drop a badge on it
+ * when it finishes, or flag it. Writes are held on the rail scope and survive the DSL re-running, so
+ * they last until the popup clears them (which it does automatically on dismiss).
+ */
+@Stable
+interface AzPopupItemHandle {
+    /** The bound item's id. */
+    val id: String
+
+    /** The bound item as the rail currently renders it, or null if it is no longer declared. */
+    val item: AzNavItem?
+
+    /** Sets (or, with a null/blank [text], clears) the item's badge. */
+    fun setBadge(text: String?, persistent: Boolean = false)
+
+    /** Starts or stops the item's own loading animation. */
+    fun setLoading(loading: Boolean)
+
+    /** Flags the item, or clears the flag with null. A flagged item draws as the warning triangle. */
+    fun setAlert(alert: AzItemAlert?)
+
+    /** Drops everything this popup pushed onto the item, restoring what the DSL declared. */
+    fun clear()
+}
+
+/** What an [AzPopup]'s body is given: the request that opened it, its item, and a way out. */
+@Stable
+interface AzPopupScope {
+    val kind: AzPopupKind
+    val title: String?
+    val message: String?
+    val payload: Any?
+
+    /** The rail item that raised this popup, or null when it was raised without one. */
+    val item: AzPopupItemHandle?
+
+    /** Closes the popup (and reverts anything it did to [item] that it did not make permanent). */
+    fun dismiss()
+}
+
+/**
+ * Opens and closes an [AzPopup], and names the rail item it belongs to.
+ *
+ * Create one with [rememberAzPopupController], register a popup for it with `azPopup(controller)`
+ * in the host DSL, and raise it from anywhere — an item's `onClick`, a coroutine, a callback:
+ *
+ * ```
+ * val alerts = rememberAzPopupController()
+ * AzHostActivityLayout(navController = navController) {
+ *     azRailItem(id = "sync", text = "Sync") { alerts.show(itemId = "sync", title = "Syncing…") }
+ *     azPopup(alerts) {
+ *         Text(message ?: "")
+ *         AzButton(onClick = { item?.setLoading(false); dismiss() }, text = "Stop")
+ *     }
+ * }
+ * ```
+ */
+@Stable
+class AzPopupController {
+    /** The live request, or null when nothing is showing. */
+    var request: AzPopupRequest? by mutableStateOf(null)
+        private set
+
+    val isVisible: Boolean get() = request != null
+
+    /**
+     * Raises the popup.
+     *
+     * @param itemId The rail item this popup belongs to. Leave null to bind to the **last touched**
+     *   rail item, which is what makes an unattributed warning land on whatever the user just did.
+     */
+    fun show(
+        itemId: String? = null,
+        kind: AzPopupKind = AzPopupKind.INFO,
+        title: String? = null,
+        message: String? = null,
+        payload: Any? = null,
+    ) {
+        request = AzPopupRequest(itemId, kind, title, message, payload)
+    }
+
+    /** Closes the popup. */
+    fun dismiss() {
+        request = null
+    }
+}
+
+/** Creates the [AzPopupController] for one popup, surviving recomposition. */
+@Composable
+fun rememberAzPopupController(): AzPopupController = remember { AzPopupController() }
+
+/** Holds a popup registered via `AzNavHostScope.azPopup`. */
+internal data class AzPopupItem(
+    val controller: AzPopupController,
+    val dismissOnOutsideTap: Boolean,
+    val content: @Composable AzPopupScope.() -> Unit,
+)
+
+/** Writes an [AzPopup]'s changes into the rail scope's override map, keyed by item id. */
+internal class AzPopupItemHandleImpl(
+    override val id: String,
+    private val scope: AzNavRailScopeImpl,
+) : AzPopupItemHandle {
+
+    override val item: AzNavItem? get() = scope.navItems.firstOrNull { it.id == id }
+
+    private fun update(transform: (AzItemState) -> AzItemState) {
+        val current = scope.itemOverrides[id] ?: AzItemState()
+        scope.itemOverrides[id] = transform(current)
+    }
+
+    override fun setBadge(text: String?, persistent: Boolean) =
+        update { it.copy(badge = text, persistentBadge = persistent) }
+
+    override fun setLoading(loading: Boolean) = update { it.copy(isLoading = loading) }
+
+    override fun setAlert(alert: AzItemAlert?) = update { it.copy(alert = alert) }
+
+    override fun clear() {
+        scope.itemOverrides.remove(id)
+    }
+}
+
+/** The [AzPopupScope] handed to a popup's body. */
+internal class AzPopupScopeImpl(
+    private val request: AzPopupRequest,
+    override val item: AzPopupItemHandle?,
+    private val onDismiss: () -> Unit,
+) : AzPopupScope {
+    override val kind: AzPopupKind get() = request.kind
+    override val title: String? get() = request.title
+    override val message: String? get() = request.message
+    override val payload: Any? get() = request.payload
+    override fun dismiss() = onDismiss()
+}
+
+/**
+ * The built-in popup body: the request's title and message in the rail's own type, with a single
+ * "OK" that closes it. It is what `azPopup(controller)` renders when you don't supply a body.
+ */
+@Composable
+fun AzPopupScope.AzPopupBody() {
+    val accent = when (kind) {
+        AzPopupKind.INFO -> MaterialTheme.colorScheme.primary
+        AzPopupKind.NOTICE -> AzItemAlert.NOTICE.color()
+        AzPopupKind.WARNING -> AzItemAlert.WARNING.color()
+    }
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        title?.takeIf { it.isNotBlank() }?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                color = accent,
+                textAlign = TextAlign.Center,
+            )
+        }
+        message?.takeIf { it.isNotBlank() }?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+        }
+        AzButton(onClick = { dismiss() }, text = "OK", color = accent)
+    }
+}
+
+/**
+ * Renders one registered popup as a centred panel over a scrim.
+ *
+ * While a [AzPopupKind.NOTICE] / [AzPopupKind.WARNING] popup is up, the bound rail item is flagged
+ * — it redraws as a yellow rounded-corner triangle outline — and the flag is lifted again when the
+ * popup closes, so the item never keeps a warning it no longer owns.
+ */
+@Composable
+internal fun AzPopupHost(
+    popup: AzPopupItem,
+    railScope: AzNavRailScopeImpl,
+    modifier: Modifier = Modifier,
+) {
+    val request = popup.controller.request ?: return
+
+    // Resolve the bound item once per request: the explicit id if there is one, else whatever the
+    // user last touched.
+    val boundId = request.itemId ?: railScope.lastTouchedItemId
+    val handle = remember(boundId, railScope) {
+        boundId?.let { AzPopupItemHandleImpl(it, railScope) }
+    }
+
+    // The flag is owned by the popup's lifetime, not by the developer: raised with the request and
+    // dropped on dismissal (or when the popup leaves composition mid-flight).
+    DisposableEffect(request, handle) {
+        val alert = when (request.kind) {
+            AzPopupKind.INFO -> null
+            AzPopupKind.NOTICE -> AzItemAlert.NOTICE
+            AzPopupKind.WARNING -> AzItemAlert.WARNING
+        }
+        if (alert != null) handle?.setAlert(alert)
+        onDispose { if (alert != null) handle?.setAlert(null) }
+    }
+
+    val dismiss = { popup.controller.dismiss() }
+    val scope = remember(request, handle) { AzPopupScopeImpl(request, handle, dismiss) }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.45f))
+            .pointerInput(popup.dismissOnOutsideTap) {
+                detectTapGestures {
+                    if (popup.dismissOnOutsideTap) dismiss()
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            modifier = Modifier
+                .padding(24.dp)
+                .widthIn(max = 420.dp)
+                // Swallow taps on the panel itself so they don't reach the dismissing scrim.
+                .pointerInput(Unit) { detectTapGestures { } },
+            color = MaterialTheme.colorScheme.surface,
+            shape = RoundedCornerShape(12.dp),
+            tonalElevation = 2.dp,
+            shadowElevation = 8.dp,
+            border = BorderStroke(
+                width = 2.dp,
+                color = when (request.kind) {
+                    AzPopupKind.INFO -> railScope.activeColor.takeOrElse { MaterialTheme.colorScheme.primary }
+                    AzPopupKind.NOTICE -> AzItemAlert.NOTICE.color()
+                    AzPopupKind.WARNING -> AzItemAlert.WARNING.color()
+                },
+            ),
+        ) {
+            Box(modifier = Modifier.padding(24.dp)) {
+                popup.content(scope)
+            }
+        }
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzIcons.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzIcons.kt
@@ -36,6 +36,14 @@ internal object AzIcons {
         "M3,18h18v-2H3v2zM3,13h18v-2H3v2zM3,6v2h18V6H3z",
     )
 
+    /** Three vertical dots — the default [com.hereliesaz.aznavrail.AzDropdownMenu] trigger. */
+    val MoreVert: ImageVector = icon(
+        "MoreVert",
+        "M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9," +
+            "2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9," +
+            "-2 -2,-2z",
+    )
+
     /** The "X" glyph. `Icons.Filled.Close` and `Icons.Filled.Clear` are the same glyph. */
     val Close: ImageVector = icon(
         "Close",

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzShapes.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzShapes.kt
@@ -1,0 +1,104 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzItemAlert
+import kotlin.math.min
+import kotlin.math.sqrt
+
+/**
+ * An upward-pointing triangle with rounded corners, inscribed in the button's box — the glyph a rail
+ * item turns into while it owns a notice or warning popup.
+ *
+ * Each corner is cut back along both of its edges by [cornerRadius] and bridged with a quadratic
+ * curve through the original vertex, which is the cheap, well-behaved way to round an arbitrary
+ * polygon: no arc-centre trigonometry, and the curve stays inside the untouched triangle.
+ */
+internal data class AzRoundedTriangleShape(val cornerRadius: Dp = 6.dp) : Shape {
+
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ): Outline {
+        val radiusPx = with(density) { cornerRadius.toPx() }
+        return Outline.Generic(roundedTrianglePath(size, radiusPx))
+    }
+}
+
+/** The rounded-triangle [Path] for a box of [size], corners cut back by [radiusPx]. */
+internal fun roundedTrianglePath(size: Size, radiusPx: Float): Path {
+    val apex = Offset(size.width / 2f, 0f)
+    val bottomRight = Offset(size.width, size.height)
+    val bottomLeft = Offset(0f, size.height)
+    val vertices = listOf(apex, bottomRight, bottomLeft)
+
+    val path = Path()
+    if (size.width <= 0f || size.height <= 0f) return path
+
+    // Never cut back more than half an edge, or adjacent corners would overrun each other on a
+    // button small enough that the radius rivals the triangle's own edges.
+    fun distance(a: Offset, b: Offset): Float {
+        val dx = b.x - a.x
+        val dy = b.y - a.y
+        return sqrt(dx * dx + dy * dy)
+    }
+
+    fun towards(from: Offset, to: Offset, by: Float): Offset {
+        val length = distance(from, to)
+        if (length == 0f) return from
+        val t = (by / length).coerceIn(0f, 0.5f)
+        return Offset(from.x + (to.x - from.x) * t, from.y + (to.y - from.y) * t)
+    }
+
+    val shortestEdge = minOf(
+        distance(vertices[0], vertices[1]),
+        distance(vertices[1], vertices[2]),
+        distance(vertices[2], vertices[0]),
+    )
+    val cut = min(radiusPx, shortestEdge / 2f)
+
+    vertices.forEachIndexed { index, vertex ->
+        val previous = vertices[(index + vertices.size - 1) % vertices.size]
+        val next = vertices[(index + 1) % vertices.size]
+        val entry = towards(vertex, previous, cut)
+        val exit = towards(vertex, next, cut)
+        if (index == 0) path.moveTo(entry.x, entry.y) else path.lineTo(entry.x, entry.y)
+        path.quadraticTo(vertex.x, vertex.y, exit.x, exit.y)
+    }
+    path.close()
+    return path
+}
+
+/**
+ * The Compose [Shape] an [AzButtonShape] draws as — the single mapping every call site shares, so a
+ * new member (like [AzButtonShape.TRIANGLE]) can never be silently missed by one of them.
+ */
+internal fun AzButtonShape.toComposeShape(): Shape = when (this) {
+    AzButtonShape.CIRCLE -> CircleShape
+    AzButtonShape.SQUARE -> RectangleShape
+    AzButtonShape.RECTANGLE -> RectangleShape
+    AzButtonShape.TRIANGLE -> AzRoundedTriangleShape()
+    AzButtonShape.NONE -> RectangleShape
+}
+
+/**
+ * The stroke colour for an alerted item. Both levels are yellow — a notice sits back in amber, a
+ * warning comes forward in a saturated hazard yellow — so either reads instantly as "look at me"
+ * against the rail's normal accent.
+ */
+internal fun AzItemAlert.color(): Color = when (this) {
+    AzItemAlert.NOTICE -> Color(0xFFFFC107)
+    AzItemAlert.WARNING -> Color(0xFFFFD400)
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzTitleTriggers.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzTitleTriggers.kt
@@ -1,0 +1,195 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import coil3.compose.rememberAsyncImagePainter
+import com.hereliesaz.aznavrail.model.AzDropdownTrigger
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
+import kotlin.math.roundToInt
+
+/**
+ * The stable, comparable description of a drop-down's trigger.
+ *
+ * Every field is an immutable value, so a slot's spec can be re-published on each recomposition and
+ * compared away when nothing changed — which is what keeps the title-hosted trigger from looping the
+ * host's composition. Behaviour (the tap handler, the bounds reporter) deliberately lives on
+ * [AzTitleTriggerSlot] as plain fields instead, because those are only read from event callbacks.
+ */
+internal data class AzDropdownTriggerSpec(
+    val trigger: AzDropdownTrigger = AzDropdownTrigger.MoreVert,
+    val size: Dp = 40.dp,
+    val iconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
+    /** Resolved launcher icon model, used only by [AzDropdownTrigger.AppIcon]. */
+    val appIcon: Any? = null,
+    /** Accent applied to the glyph / label. [Color.Unspecified] falls back to the theme primary. */
+    val color: Color = Color.Unspecified,
+    /** Optional style merged over an [AzDropdownTrigger.Text] trigger's default. */
+    val textStyle: TextStyle? = null,
+    val contentDescription: String = "Menu",
+)
+
+/**
+ * One drop-down's claim on a slot in the screen-title row.
+ *
+ * The drop-down composable owns its own open-state and renders its own panel where it is declared;
+ * only the trigger is relocated. It publishes [spec] (snapshot state, so the title row redraws when
+ * the trigger's look changes) and keeps [onTap] / [onBounds] refreshed as plain fields, so the title
+ * row's button always calls back into the drop-down's current composition.
+ */
+internal class AzTitleTriggerSlot {
+    var spec: AzDropdownTriggerSpec by mutableStateOf(AzDropdownTriggerSpec())
+
+    /** Opens/closes the owning drop-down. Read only from the click handler, never during composition. */
+    var onTap: () -> Unit = {}
+
+    /** Reports the trigger's window-space bounds so the owning drop-down can anchor its panel there. */
+    var onBounds: (IntRect) -> Unit = {}
+
+    /** Publishes [next] only when it actually differs, so equal re-publishes cost no recomposition. */
+    fun publish(next: AzDropdownTriggerSpec) {
+        if (spec != next) spec = next
+    }
+}
+
+/**
+ * Draws one trigger and wires its tap + bounds reporting.
+ *
+ * Used for both placements: the screen-title row renders one of these per registered slot, and an
+ * `INLINE` drop-down renders one at its own call site. Either way the drop-down learns where its
+ * trigger ended up, so the dropped panel is positioned against the real thing.
+ */
+@Composable
+internal fun AzDropdownTriggerButton(
+    slot: AzTitleTriggerSlot,
+    modifier: Modifier = Modifier,
+) {
+    val spec = slot.spec
+    val accent = spec.color.takeOrElse { MaterialTheme.colorScheme.primary }
+    val clipShape: Shape? = when (spec.iconShape) {
+        AzHeaderIconShape.CIRCLE -> CircleShape
+        AzHeaderIconShape.ROUNDED -> RoundedCornerShape(12.dp)
+        else -> null
+    }
+    val clipModifier = if (clipShape != null) Modifier.clip(clipShape) else Modifier
+
+    val boundsModifier = Modifier.onGloballyPositioned { coordinates ->
+        val pos = coordinates.positionInWindow()
+        val size = coordinates.size
+        slot.onBounds(
+            IntRect(
+                left = pos.x.roundToInt(),
+                top = pos.y.roundToInt(),
+                right = pos.x.roundToInt() + size.width,
+                bottom = pos.y.roundToInt() + size.height,
+            )
+        )
+    }
+
+    // A text trigger sizes to its own label; every icon trigger is a square of `spec.size`.
+    val sizeModifier =
+        if (spec.trigger is AzDropdownTrigger.Text) Modifier else Modifier.size(spec.size)
+
+    Box(
+        modifier = modifier
+            // Automatic breathing room so neighbouring triggers (and the title) never sit flush.
+            .padding(AzNavRailDefaults.HeaderPadding)
+            .then(sizeModifier)
+            .then(clipModifier)
+            .then(boundsModifier)
+            .clickable { slot.onTap() }
+            .semantics(mergeDescendants = true) { contentDescription = spec.contentDescription },
+        contentAlignment = Alignment.Center,
+    ) {
+        when (val trigger = spec.trigger) {
+            is AzDropdownTrigger.Text -> Text(
+                text = trigger.text,
+                style = MaterialTheme.typography.titleLarge.merge(spec.textStyle),
+                color = accent,
+                maxLines = 1,
+                softWrap = false,
+            )
+
+            is AzDropdownTrigger.Icon -> when (val model = trigger.model) {
+                is ImageVector -> Icon(
+                    imageVector = model,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.fillMaxSize(),
+                )
+
+                is Painter -> Image(
+                    painter = model,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize().then(clipModifier),
+                )
+
+                else -> Image(
+                    painter = rememberAsyncImagePainter(model),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize().then(clipModifier),
+                )
+            }
+
+            AzDropdownTrigger.AppIcon -> {
+                val appIcon = spec.appIcon
+                if (appIcon != null) {
+                    Image(
+                        painter = rememberAsyncImagePainter(appIcon),
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize().then(clipModifier),
+                    )
+                } else {
+                    Icon(
+                        imageVector = AzIcons.Menu,
+                        contentDescription = null,
+                        tint = accent,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+
+            AzDropdownTrigger.Hamburger -> Icon(
+                imageVector = AzIcons.Menu,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.fillMaxSize(),
+            )
+
+            AzDropdownTrigger.MoreVert -> Icon(
+                imageVector = AzIcons.MoreVert,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzUnattachedRail.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzUnattachedRail.kt
@@ -1,0 +1,359 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import androidx.navigation.NavController
+import com.hereliesaz.aznavrail.AzNavRailScopeImpl
+import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzNavItem
+import com.hereliesaz.aznavrail.model.AzUnattachedAnchor
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/**
+ * Every id in the unattached hosts' subtrees — the hosts themselves plus their sub-items to any
+ * depth. The rail strip and the drawer filter these out, because an unattached host has left the
+ * rail: it draws itself (and unfolds its children) wherever its anchor puts it.
+ */
+internal fun azUnattachedSubtreeIds(items: List<AzNavItem>): Set<String> {
+    val roots = items.filter { it.isUnattached }.map { it.id }
+    if (roots.isEmpty()) return emptySet()
+    val ids = roots.toMutableSet()
+    // Sub-items reference their host by id, so one sweep per level resolves the whole tree. Bounded
+    // by the item count, which also stops a malformed cycle from spinning forever.
+    repeat(items.size) {
+        val grew = items.any { it.isSubItem && it.hostId in ids && ids.add(it.id) }
+        if (!grew) return ids
+    }
+    return ids
+}
+
+/**
+ * Draws the [AzUnattachedAnchor] stacks — the rail host items declared with `azUnattachedHostItem`,
+ * which live outside the rail strip.
+ *
+ * Hosts sharing an anchor stack into a column in declaration order, spaced exactly like rail items
+ * (and packed when the rail is packed). Tapping one unfolds its sub-items inline beneath it, and
+ * sub-hosts nest to any depth, matching the rail's accordion behaviour.
+ *
+ * @param scope The rail scope supplying items, callbacks and theme tokens.
+ * @param visualDockingSide The side the rail is currently drawn on; the [AzUnattachedAnchor.BOTTOM]
+ *   and [AzUnattachedAnchor.OPPOSITE] stacks park on the other one.
+ */
+@Composable
+internal fun AzUnattachedRail(
+    scope: AzNavRailScopeImpl,
+    navController: NavController?,
+    currentDestination: String?,
+    visualDockingSide: AzDockingSide,
+    modifier: Modifier = Modifier,
+) {
+    val unattached = scope.navItems.filter { it.isUnattached }
+    if (unattached.isEmpty()) return
+
+    val density = LocalDensity.current
+    val containerSize = LocalWindowInfo.current.containerSize
+    val screenWidthPx = containerSize.width.toFloat()
+    val screenHeightPx = containerSize.height.toFloat()
+    val coroutineScope = rememberCoroutineScope()
+
+    // Expansion state is owned here, not by the rail: an unattached host is not in the rail's
+    // hostStates map and must keep unfolding even while the rail's own menu is closed.
+    val hostStates = remember { mutableStateMapOf<String, Boolean>() }
+    val initiallyExpandedSeen = remember { mutableMapOf<String, Boolean>() }
+    val expandWhenSeen = remember { mutableMapOf<String, Boolean>() }
+    val cyclerJobs = remember { mutableStateMapOf<String, Job>() }
+
+    val subtreeIds = remember(scope.navItems.toList()) { azUnattachedSubtreeIds(scope.navItems) }
+
+    // Rising-edge auto-expand, mirroring the rail: expand when `initiallyExpanded` flips true, then
+    // leave the user alone.
+    LaunchedEffect(scope.navItems) {
+        scope.navItems.forEach { item ->
+            if (item.isHost && item.id in subtreeIds) {
+                if (item.initiallyExpanded && initiallyExpandedSeen[item.id] != true) {
+                    hostStates[item.id] = true
+                }
+                initiallyExpandedSeen[item.id] = item.initiallyExpanded
+            }
+        }
+    }
+
+    // Reactive expansion for unattached hosts — same edge-triggered contract as the rail's, and the
+    // same snapshot-plus-poll observation so plain (non-snapshot) sources still drive it.
+    val expandWhenKeys = scope.expandWhenMap.keys.filter { it in subtreeIds }.sorted().joinToString(",")
+    LaunchedEffect(expandWhenKeys) {
+        scope.expandWhenMap.toMap().forEach { (id, cond) ->
+            if (id !in subtreeIds) return@forEach
+            launch {
+                merge(
+                    snapshotFlow { cond() },
+                    flow { while (true) { emit(cond()); delay(300) } },
+                ).distinctUntilChanged().collect { conditionNow ->
+                    val before = expandWhenSeen[id]
+                    when {
+                        before == null -> if (conditionNow) hostStates[id] = true
+                        before != conditionNow -> hostStates[id] = conditionNow
+                    }
+                    expandWhenSeen[id] = conditionNow
+                }
+            }
+        }
+    }
+
+    val buttonSize = if (scope.railItemWidth.isSpecified) scope.railItemWidth else AzNavRailDefaults.ButtonWidth
+    val spacing = if (scope.packButtons) 0.dp else AzNavRailDefaults.RailContentVerticalArrangement
+    val railOnLeft = visualDockingSide == AzDockingSide.LEFT
+    val safeInset = with(density) { (screenHeightPx * 0.1f).toDp() }
+
+    val onCyclerClick: (AzNavItem) -> Unit = { item ->
+        if (!item.disabled) {
+            cyclerJobs[item.id]?.cancel()
+            val options = item.options ?: emptyList()
+            val enabled = options.filterNot { it in (item.disabledOptions ?: emptyList()) }
+            if (enabled.isNotEmpty()) {
+                val current = scope.transientCyclerOptions[item.id] ?: item.selectedOption
+                val next = enabled[(enabled.indexOf(current) + 1).mod(enabled.size)]
+                scope.transientCyclerOptions[item.id] = next
+                // Commit after the same 1s "stop" window the rail's cyclers use.
+                cyclerJobs[item.id] = coroutineScope.launch {
+                    delay(1000L)
+                    scope.onClickMap[item.id]?.invoke()
+                    cyclerJobs.remove(item.id)
+                }
+            }
+            scope.advancedConfig.onInteraction?.invoke(item.id, item)
+        }
+    }
+
+    val byAnchor = unattached.groupBy { it.unattachedAnchor ?: AzUnattachedAnchor.OPPOSITE }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        byAnchor[AzUnattachedAnchor.OPPOSITE]?.let { hosts ->
+            UnattachedStack(
+                hosts = hosts,
+                modifier = Modifier
+                    .align(if (railOnLeft) Alignment.TopEnd else Alignment.TopStart)
+                    .padding(top = safeInset, bottom = safeInset),
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                spacingDp = spacing,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+
+        byAnchor[AzUnattachedAnchor.BOTTOM]?.let { hosts ->
+            UnattachedStack(
+                hosts = hosts,
+                modifier = Modifier
+                    .align(if (railOnLeft) Alignment.BottomEnd else Alignment.BottomStart)
+                    .padding(top = safeInset, bottom = safeInset),
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                spacingDp = spacing,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+
+        byAnchor[AzUnattachedAnchor.FLOATING]?.let { hosts ->
+            // The live position is kept in pixels for the drag and persisted as a window fraction,
+            // so it survives rotation and lands sensibly on a different screen size.
+            var stackSize by remember { mutableStateOf(IntSize.Zero) }
+            var position by remember { mutableStateOf<Offset?>(null) }
+
+            val minY = screenHeightPx * 0.1f
+            val maxY = maxOf(minY, screenHeightPx * 0.9f - stackSize.height)
+            val maxX = maxOf(0f, screenWidthPx - stackSize.width)
+
+            // Resolve the position once the stack has been measured: the persisted spot when there
+            // is one, otherwise parked against the edge opposite the rail. Re-clamped afterwards so
+            // a rotation, a resize, or an unfolding host can't strand it outside the safe zone.
+            LaunchedEffect(stackSize, screenWidthPx, screenHeightPx) {
+                if (stackSize == IntSize.Zero) return@LaunchedEffect
+                val settled = position
+                position = if (settled == null) {
+                    val saved = AzUnattachedStore.load()
+                    if (saved != null) {
+                        Offset(
+                            (saved.first * screenWidthPx).coerceIn(0f, maxX),
+                            (saved.second * screenHeightPx).coerceIn(minY, maxY),
+                        )
+                    } else {
+                        Offset(if (railOnLeft) maxX else 0f, minY)
+                    }
+                } else {
+                    Offset(settled.x.coerceIn(0f, maxX), settled.y.coerceIn(minY, maxY))
+                }
+            }
+
+            UnattachedStack(
+                hosts = hosts,
+                modifier = Modifier
+                    .wrapContentSize(Alignment.TopStart, unbounded = true)
+                    .offset {
+                        val p = position
+                        IntOffset(p?.x?.roundToInt() ?: 0, p?.y?.roundToInt() ?: 0)
+                    }
+                    .onGloballyPositioned { stackSize = it.size }
+                    .pointerInput(minY, maxY, maxX) {
+                        detectDragGestures(
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                val base = position ?: Offset(0f, minY)
+                                position = Offset(
+                                    (base.x + dragAmount.x).coerceIn(0f, maxX),
+                                    (base.y + dragAmount.y).coerceIn(minY, maxY),
+                                )
+                            },
+                            onDragEnd = {
+                                val settled = position
+                                if (settled != null && screenWidthPx > 0f && screenHeightPx > 0f) {
+                                    AzUnattachedStore.save(
+                                        settled.x / screenWidthPx,
+                                        settled.y / screenHeightPx,
+                                    )
+                                }
+                            },
+                        )
+                    },
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                spacingDp = spacing,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+    }
+}
+
+/** One anchor's column of unattached hosts, each unfolding its own sub-items beneath it. */
+@Composable
+private fun UnattachedStack(
+    hosts: List<AzNavItem>,
+    modifier: Modifier,
+    scope: AzNavRailScopeImpl,
+    navController: NavController?,
+    currentDestination: String?,
+    hostStates: MutableMap<String, Boolean>,
+    buttonSize: Dp,
+    spacingDp: Dp,
+    onCyclerClick: (AzNavItem) -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(spacingDp),
+    ) {
+        hosts.forEach { host ->
+            UnattachedNode(
+                item = host,
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+    }
+}
+
+/**
+ * One unattached item — plus, when it is an expanded host, its rail sub-items beneath it. Emitted
+ * flat into the enclosing stack's [Column] so a host and its children share the rail's spacing.
+ */
+@Composable
+private fun UnattachedNode(
+    item: AzNavItem,
+    scope: AzNavRailScopeImpl,
+    navController: NavController?,
+    currentDestination: String?,
+    hostStates: MutableMap<String, Boolean>,
+    buttonSize: Dp,
+    onCyclerClick: (AzNavItem) -> Unit,
+) {
+    // A cycler shows its transient option while the commit window is still running, exactly as it
+    // does on the rail.
+    val displayItem =
+        if (item.isCycler) item.copy(selectedOption = scope.transientCyclerOptions[item.id] ?: item.selectedOption)
+        else item
+
+    RailContent(
+        defaultShape = scope.defaultShape,
+        item = displayItem,
+        navController = navController,
+        isSelected = (item.route != null && item.route == currentDestination) ||
+            item.classifiers.any { scope.activeClassifiers.contains(it) },
+        buttonSize = buttonSize,
+        onClick = {
+            scope.lastTouchedItemId = item.id
+            scope.onClickMap[item.id]?.invoke()
+        },
+        onRailCyclerClick = onCyclerClick,
+        onItemClick = { scope.advancedConfig.onInteraction?.invoke(item.id, item) },
+        onHostClick = {
+            val expanded = !(hostStates[item.id] ?: false)
+            hostStates[item.id] = expanded
+            scope.onExpandedChangeMap[item.id]?.invoke(expanded)
+        },
+        onItemGloballyPositioned = scope.advancedConfig.onItemGloballyPositioned,
+        onBoundsCalculated = { id, bounds -> scope.itemBoundsCache[id] = bounds },
+        onBoundsCleared = { id -> scope.itemBoundsCache.remove(id) },
+        activeColor = scope.activeColor,
+    )
+
+    if (item.isHost && hostStates[item.id] == true) {
+        val children = scope.navItems.filter { it.isSubItem && it.hostId == item.id && it.isRailItem }
+        children.forEach { child ->
+            UnattachedNode(
+                item = child,
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzUnattachedStore.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/AzUnattachedStore.kt
@@ -1,0 +1,36 @@
+package com.hereliesaz.aznavrail.internal
+
+import com.hereliesaz.aznavrail.service.azCacheSettings
+
+/**
+ * Persistence for the [com.hereliesaz.aznavrail.model.AzUnattachedAnchor.FLOATING] stack's position.
+ *
+ * The position is stored as a **fraction of the window** rather than raw pixels, so a stack dropped
+ * near the right edge on a phone comes back near the right edge after a rotation, a resize, or on a
+ * different device. Backed by `azCacheSettings` (multiplatform-settings), the same store the About
+ * reader's HTTP cache and the guidance controller use: `SharedPreferences` on Android,
+ * `java.util.prefs` on desktop, `localStorage` on wasmJs, `NSUserDefaults` on iOS.
+ */
+internal object AzUnattachedStore {
+
+    private const val KEY = "az_unattached_floating_pos"
+
+    /** The saved position as `x` / `y` fractions of the window, or null when nothing is saved yet. */
+    fun load(): Pair<Float, Float>? {
+        val raw = azCacheSettings.getString(KEY, "")
+        if (raw.isBlank()) return null
+        val parts = raw.split(',')
+        if (parts.size != 2) return null
+        val x = parts[0].toFloatOrNull() ?: return null
+        val y = parts[1].toFloatOrNull() ?: return null
+        return x.coerceIn(0f, 1f) to y.coerceIn(0f, 1f)
+    }
+
+    /** Saves [xFraction] / [yFraction] (both 0..1) as the floating stack's home. */
+    fun save(xFraction: Float, yFraction: Float) {
+        azCacheSettings.putString(
+            KEY,
+            "${xFraction.coerceIn(0f, 1f)},${yFraction.coerceIn(0f, 1f)}",
+        )
+    }
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/MenuItem.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/MenuItem.kt
@@ -170,10 +170,13 @@ internal fun MenuItem(
     val effectiveActiveColor = activeColor ?: MaterialTheme.colorScheme.primary
     val effectiveDefaultColor = item.textColor ?: item.color ?: MaterialTheme.colorScheme.primary
 
+    // A menu row is type, not a button, so an alerted item can't become a triangle here — it takes
+    // the same warning yellow instead, so the drawer and the rail agree about which item is flagged.
+    val alertColor = item.alert?.color()
     val textColor = if (isDisabled) {
-        effectiveDefaultColor.copy(alpha = 0.5f)
+        (alertColor ?: effectiveDefaultColor).copy(alpha = 0.5f)
     } else {
-        effectiveDefaultColor
+        alertColor ?: effectiveDefaultColor
     }
 
     val backgroundColor = if (isSelected && !isPressed) {
@@ -273,6 +276,16 @@ internal fun MenuItem(
                         }
                     }
                 }
+            }
+
+            // Per-item loading: the row keeps its label and spins a small ring beside it, rather
+            // than the whole rail being replaced by one global spinner.
+            if (item.isLoading) {
+                com.hereliesaz.aznavrail.AzLoad(
+                    size = 20.dp,
+                    color = textColor,
+                    showLabel = false,
+                )
             }
 
             var showBadge by remember { mutableStateOf(false) }

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/NestedRail.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/NestedRail.kt
@@ -143,6 +143,7 @@ private fun NestedItemWrapper(
                 ),
             )
         }) {
+            val alert = item.alert
             AzNavRailButton(
                 onClick = {
                     if (item.isHost) {
@@ -154,17 +155,40 @@ private fun NestedItemWrapper(
                     }
                 },
                 text = item.text,
-                color = item.color ?: MaterialTheme.colorScheme.onSurface,
-                activeColor = activeColor,
-                textColor = item.textColor,
+                color = alert?.color() ?: item.color ?: MaterialTheme.colorScheme.onSurface,
+                activeColor = alert?.color() ?: activeColor,
+                textColor = if (alert != null) alert.color() else item.textColor,
                 fillColor = item.fillColor,
-                shape = item.shape ?: AzButtonShape.CIRCLE,
+                shape = if (alert != null) AzButtonShape.TRIANGLE else (item.shape ?: AzButtonShape.CIRCLE),
                 size = AzNavRailDefaults.ButtonWidth,
                 enabled = !item.disabled,
                 isSelected = (item.route != null && currentDestination == item.route) || item.classifiers.any { activeClassifiers.contains(it) },
-                itemContent = item.content,
+                isLoading = item.isLoading,
+                itemContent = if (alert != null) null else item.content,
                 rotationDegrees = rotationDegrees
             )
+
+            // Nested-rail children carry badges too — they are rail items like any other, and used
+            // to be the one place a declared badge was silently dropped.
+            val showBadge = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+            androidx.compose.runtime.LaunchedEffect(item.badge) {
+                if (!item.badge.isNullOrBlank()) {
+                    showBadge.value = true
+                    if (!item.persistentBadge) {
+                        kotlinx.coroutines.delay(1000)
+                        showBadge.value = false
+                    }
+                } else {
+                    showBadge.value = false
+                }
+            }
+            if (showBadge.value && !item.badge.isNullOrBlank()) {
+                com.hereliesaz.aznavrail.AzBadge(
+                    text = item.badge,
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    containerColor = item.color ?: activeColor,
+                )
+            }
         }
 
         if (item.isHost && hostStates[item.id] == true) {

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/RailContent.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/internal/RailContent.kt
@@ -132,19 +132,24 @@ internal fun RailContent(
             }
             .then(dragModifier)
     ) {
+        // While an item owns a notice/warning popup it stops being itself and becomes the alert
+        // glyph: a yellow, rounded-corner triangle outline. Everything else about it is untouched,
+        // and it reverts the instant the popup is dismissed.
+        val alert = item.alert
         AzNavRailButton(
             onClick = finalOnClick,
             text = textToShow,
             modifier = Modifier,
-            color = item.color ?: MaterialTheme.colorScheme.primary,
-            activeColor = activeColor ?: MaterialTheme.colorScheme.primary,
-            textColor = item.textColor,
+            color = alert?.color() ?: item.color ?: MaterialTheme.colorScheme.primary,
+            activeColor = alert?.color() ?: activeColor ?: MaterialTheme.colorScheme.primary,
+            textColor = if (alert != null) alert.color() else item.textColor,
             fillColor = item.fillColor,
             size = buttonSize,
-            shape = item.shape ?: defaultShape,
+            shape = if (alert != null) AzButtonShape.TRIANGLE else (item.shape ?: defaultShape),
             enabled = isEnabled,
             isSelected = isSelected,
-            itemContent = item.content,
+            isLoading = item.isLoading,
+            itemContent = if (alert != null) null else item.content,
             rotationDegrees = rotationDegrees
         )
 

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzButtonShape.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzButtonShape.kt
@@ -8,6 +8,12 @@ enum class AzButtonShape {
     SQUARE,
     /** Renders as a fixed-height wide rectangle (typically for text labels). */
     RECTANGLE,
+    /**
+     * Renders as an upward-pointing triangle outline with rounded corners — the warning glyph a rail
+     * item takes on while it owns a notice/warning [com.hereliesaz.aznavrail.AzPopup]. Available as
+     * an ordinary item shape too.
+     */
+    TRIANGLE,
     /** No border is drawn; the button is still interactive but visually borderless. */
     NONE
 }

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzDropdownTrigger.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzDropdownTrigger.kt
@@ -1,0 +1,50 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * What the user taps to open an [com.hereliesaz.aznavrail.AzDropdownMenu].
+ *
+ * In AzNavRail tradition the trigger is not a free composable slot — it is one of the sanctioned
+ * shapes below. The default is [MoreVert] (the three vertical dots), so a drop-down declared with no
+ * configuration reads as a menu affordance rather than as the app's launcher icon.
+ */
+sealed interface AzDropdownTrigger {
+    /** The Material "more" glyph — three vertical dots. The default. */
+    data object MoreVert : AzDropdownTrigger
+
+    /** The hamburger glyph (three stacked bars). */
+    data object Hamburger : AzDropdownTrigger
+
+    /**
+     * The host app's launcher icon, drawn exactly like the rail's header. This was the only trigger
+     * before triggers were configurable; pass it to keep that look.
+     */
+    data object AppIcon : AzDropdownTrigger
+
+    /** A word (or two) that hosts the menu, drawn in the screen title's accent. */
+    data class Text(val text: String) : AzDropdownTrigger
+
+    /**
+     * A developer-supplied icon. [model] accepts the same values a rail item's `content` does — a
+     * Compose `ImageVector` or `Painter`, an image URL, or any other Coil-compatible model.
+     */
+    data class Icon(val model: Any) : AzDropdownTrigger
+}
+
+/** Where an [com.hereliesaz.aznavrail.AzDropdownMenu]'s trigger is drawn. */
+enum class AzDropdownTriggerPlacement {
+    /**
+     * [TITLE] when the drop-down is declared inside an `AzHostActivityLayout` (the usual case — a
+     * drop-down declared in an `onscreen { … }` block), [INLINE] otherwise. The default.
+     */
+    AUTO,
+
+    /**
+     * The trigger is lifted out of the call site and drawn next to the big screen title, above the
+     * onscreen content area. Several drop-downs hosted this way line their triggers up beside each
+     * other in declaration order.
+     */
+    TITLE,
+
+    /** The trigger is drawn where the composable is called, like any other widget. */
+    INLINE,
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzItemAlert.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzItemAlert.kt
@@ -1,0 +1,16 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * The alert styling applied to the rail item that raised an [com.hereliesaz.aznavrail.AzPopup].
+ *
+ * Both levels redraw the item as a **yellow, rounded-corner triangle outline** — the universal
+ * "something wants your attention" glyph — and both revert the moment the popup is dismissed.
+ * They differ only in shade, so a warning reads louder than a notice.
+ */
+enum class AzItemAlert {
+    /** Informational. Drawn in a softer amber. */
+    NOTICE,
+
+    /** Something is wrong. Drawn in a full, saturated warning yellow. */
+    WARNING,
+}

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzItemConfig.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzItemConfig.kt
@@ -48,5 +48,11 @@ data class AzItemConfig(
     /** Optional short badge text drawn in a small circle on the item's button corner. */
     val badge: String? = null,
     /** Whether the badge should remain permanently visible (true) or dissolve after 1 second (false). */
-    val persistentBadge: Boolean = false
+    val persistentBadge: Boolean = false,
+    /** When true, this item's button spins its own loading animation in place of its content. */
+    val isLoading: Boolean = false,
+    /** Marks a host declared with `azUnattachedHostItem`, which lives outside the rail strip. */
+    val isUnattached: Boolean = false,
+    /** Where an [isUnattached] host parks. Ignored for every other item. */
+    val unattachedAnchor: AzUnattachedAnchor? = null
 )

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzItemState.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzItemState.kt
@@ -1,0 +1,17 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * Per-item state layered on top of an already-declared item — the badge it carries, whether it is
+ * spinning its own loading animation, and whether a popup has flagged it.
+ *
+ * Every field is nullable and means "leave whatever the item already had". That is what lets
+ * `azItemState(id = "sync", isLoading = true)` set the spinner without also clearing the badge, and
+ * what lets an [com.hereliesaz.aznavrail.AzPopupController]'s override sit on top of a declared
+ * state without erasing the parts it doesn't care about.
+ */
+data class AzItemState(
+    val badge: String? = null,
+    val persistentBadge: Boolean? = null,
+    val isLoading: Boolean? = null,
+    val alert: AzItemAlert? = null,
+)

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzNavItem.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzNavItem.kt
@@ -65,6 +65,25 @@ data class AzNavItem(
     val badge: String? = null,
     /** Whether the badge should remain permanently visible (true) or dissolve after 1 second (false). */
     val persistentBadge: Boolean = false,
+    /**
+     * Per-item loading state. When true this item's button hides its content and spins its own
+     * [com.hereliesaz.aznavrail.AzLoad] in place — every rail item is its own loading animation,
+     * rather than the whole app being blocked by one global spinner.
+     */
+    val isLoading: Boolean = false,
+    /**
+     * Transient alert styling. Set by an [com.hereliesaz.aznavrail.AzPopupController] on the item
+     * that raised a notice/warning popup, which redraws it as a yellow rounded-corner triangle
+     * outline for as long as the popup is up. Null is the item's normal appearance.
+     */
+    val alert: AzItemAlert? = null,
+    /**
+     * True for a host declared with `azUnattachedHostItem`: it is a rail host that does NOT live in
+     * the rail strip. It is drawn on its own at [unattachedAnchor] and unfolds its sub-items there.
+     */
+    val isUnattached: Boolean = false,
+    /** Where an [isUnattached] host parks. Null (and ignored) for every other item. */
+    val unattachedAnchor: AzUnattachedAnchor? = null,
 ) {
     companion object {
         /**
@@ -82,6 +101,7 @@ data class AzNavItem(
             shape: AzButtonShape? = null,
             badge: String? = null,
             persistentBadge: Boolean = false,
+            isLoading: Boolean = false,
         ): AzNavItem = AzNavItem(
             id = id,
             text = text,
@@ -95,6 +115,7 @@ data class AzNavItem(
             shape = shape,
             badge = badge,
             persistentBadge = persistentBadge,
+            isLoading = isLoading,
         )
     }
 }

--- a/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzUnattachedAnchor.kt
+++ b/aznavrail-cmp/src/commonMain/kotlin/com/hereliesaz/aznavrail/model/AzUnattachedAnchor.kt
@@ -1,0 +1,25 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * Where an **unattached host rail item** (`azUnattachedHostItem`) parks itself.
+ *
+ * An unattached host is a rail host item that does not live in the [com.hereliesaz.aznavrail.AzNavRail]
+ * strip. It is drawn as its own free-standing button somewhere else on the screen; tapping it unfolds
+ * its sub-items (declared the usual way, with `hostId` pointing at it) beneath it, exactly as they
+ * would have unfolded inside the rail. Several unattached hosts sharing an anchor stack into a
+ * column, again exactly as they would have stacked in the rail.
+ */
+enum class AzUnattachedAnchor {
+    /** The bottom of the screen, on the side opposite the rail. */
+    BOTTOM,
+
+    /** The side opposite the rail, at the same height the rail's own items start. */
+    OPPOSITE,
+
+    /**
+     * Free-floating and draggable. The stack's position is persisted, so it comes back where the
+     * user left it on the next launch. It is clamped to the same 10%–90% vertical safe zone the
+     * rail's FAB mode uses.
+     */
+    FLOATING,
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzDropdownMenu.kt
@@ -63,7 +63,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -80,7 +79,14 @@ import com.hereliesaz.aznavrail.internal.MoreFromAzOverlay
 import com.hereliesaz.aznavrail.service.GithubDocsRepository
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzDockingSide
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.unit.IntRect
+import com.hereliesaz.aznavrail.internal.AzDropdownTriggerButton
+import com.hereliesaz.aznavrail.internal.AzDropdownTriggerSpec
+import com.hereliesaz.aznavrail.internal.AzTitleTriggerSlot
 import com.hereliesaz.aznavrail.model.AzDropdownDesign
+import com.hereliesaz.aznavrail.model.AzDropdownTrigger
+import com.hereliesaz.aznavrail.model.AzDropdownTriggerPlacement
 import com.hereliesaz.aznavrail.model.AzEasing
 import com.hereliesaz.aznavrail.model.AzEntrance
 import com.hereliesaz.aznavrail.model.AzExit
@@ -136,6 +142,17 @@ interface AzDropdownMenuScope {
      * @param maxTiltDegrees Maximum tilt angle for [tiltOnPress].
      * @param itemExit Exit played as the panel dismisses (see [AzExit]); defaults to [AzExit.Turnstile].
      *   Items are held mounted through the close so they can animate out.
+     * @param trigger What the user taps to open the menu. Defaults to [AzDropdownTrigger.MoreVert] —
+     *   the three vertical dots. Pass [AzDropdownTrigger.Text] for a word, [AzDropdownTrigger.Icon]
+     *   for your own glyph/image, [AzDropdownTrigger.Hamburger] for the bars, or
+     *   [AzDropdownTrigger.AppIcon] for the launcher icon (the pre-trigger default). The trigger's
+     *   size and clip shape come from [headerIconSize] / [headerIconShape].
+     * @param triggerPlacement Where that trigger is drawn. [AzDropdownTriggerPlacement.AUTO] (the
+     *   default) lifts it up next to the big screen title, above the onscreen content area, whenever
+     *   the drop-down is declared inside an `AzHostActivityLayout`; standalone drop-downs stay
+     *   inline. Several title-hosted drop-downs line their triggers up beside each other in
+     *   declaration order. Force either behaviour with [AzDropdownTriggerPlacement.TITLE] /
+     *   [AzDropdownTriggerPlacement.INLINE].
      */
     fun azConfig(
         design: AzDropdownDesign = AzDropdownDesign.MENU,
@@ -162,6 +179,8 @@ interface AzDropdownMenuScope {
         menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment =
             com.hereliesaz.aznavrail.model.AzMenuItemAlignment.SIDE,
         justifyMenuItems: Boolean = true,
+        trigger: AzDropdownTrigger = AzDropdownTrigger.MoreVert,
+        triggerPlacement: AzDropdownTriggerPlacement = AzDropdownTriggerPlacement.AUTO,
     )
 
     /**
@@ -239,6 +258,8 @@ internal data class AzDropdownConfig(
     val menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment =
         com.hereliesaz.aznavrail.model.AzMenuItemAlignment.SIDE,
     val justifyMenuItems: Boolean = true,
+    val trigger: AzDropdownTrigger = AzDropdownTrigger.MoreVert,
+    val triggerPlacement: AzDropdownTriggerPlacement = AzDropdownTriggerPlacement.AUTO,
 )
 
 /** One declared entry, collected by the builder and rendered by the composable. */
@@ -323,12 +344,14 @@ private class AzDropdownMenuScopeImpl : AzDropdownMenuScope {
         dimBehindMenuAlpha: Float,
         menuItemAlignment: com.hereliesaz.aznavrail.model.AzMenuItemAlignment,
         justifyMenuItems: Boolean,
+        trigger: AzDropdownTrigger,
+        triggerPlacement: AzDropdownTriggerPlacement,
     ) {
         config = AzDropdownConfig(
             design, dockingSide, vibrate, expandedWidth, collapsedWidth, headerIconShape, headerIconSize,
             showFooter, inAppAbout, appRepositoryUrl, itemTextStyle, itemEntrance, entranceStaggerMs,
             entranceDurationMs, entranceEasing, entranceStartAngle, tiltOnPress, maxTiltDegrees, itemExit,
-            dimBehindMenu, dimBehindMenuAlpha, menuItemAlignment, justifyMenuItems,
+            dimBehindMenu, dimBehindMenuAlpha, menuItemAlignment, justifyMenuItems, trigger, triggerPlacement,
         )
     }
 
@@ -795,7 +818,8 @@ private fun entryLabel(entry: AzDropdownEntry): String = when (entry) {
  * the rail, the side is physical ([AzDockingSide.LEFT] → left edge, [AzDockingSide.RIGHT] → right).
  */
 private class AzDropdownEdgePositionProvider(
-    private val dockingSide: AzDockingSide
+    private val dockingSide: AzDockingSide,
+    private val anchorOverride: () -> IntRect? = { null },
 ) : PopupPositionProvider {
     override fun calculatePosition(
         anchorBounds: IntRect,
@@ -803,12 +827,13 @@ private class AzDropdownEdgePositionProvider(
         layoutDirection: LayoutDirection,
         popupContentSize: IntSize
     ): IntOffset {
+        val anchor = anchorOverride() ?: anchorBounds
         val x = if (dockingSide == AzDockingSide.LEFT) 0 else windowSize.width - popupContentSize.width
-        val fitsBelow = anchorBounds.bottom + popupContentSize.height <= windowSize.height
+        val fitsBelow = anchor.bottom + popupContentSize.height <= windowSize.height
         val y = if (fitsBelow) {
-            anchorBounds.bottom
+            anchor.bottom
         } else {
-            (anchorBounds.top - popupContentSize.height).coerceAtLeast(0)
+            (anchor.top - popupContentSize.height).coerceAtLeast(0)
         }
         return IntOffset(x, y)
     }
@@ -890,47 +915,59 @@ fun AzDropdownMenu(
     val maxPanelHeight = (LocalConfiguration.current.screenHeightDp * 0.8f).dp
     val panelWidth = if (config.design == AzDropdownDesign.RAIL) config.collapsedWidth else config.expandedWidth
 
-    val positionProvider = remember(config.dockingSide) {
-        AzDropdownEdgePositionProvider(config.dockingSide)
+    // Where the trigger ends up. AUTO lifts it into the screen-title row whenever there is a host to
+    // put it in; a standalone drop-down (no AzHostActivityLayout) has no title row, so it stays inline.
+    val titleHost = LocalAzNavHostScope.current as? AzNavHostScopeImpl
+    val hostsTrigger = titleHost != null && when (config.triggerPlacement) {
+        AzDropdownTriggerPlacement.INLINE -> false
+        AzDropdownTriggerPlacement.TITLE, AzDropdownTriggerPlacement.AUTO -> true
     }
 
-    // The trigger is the app's launcher icon, loaded exactly like the rail's header icon.
+    // The trigger's real window-space bounds, reported by whichever button ends up drawing it, so
+    // the panel drops from the button the user tapped even when that button lives in the title row.
+    var triggerBounds by remember { mutableStateOf<IntRect?>(null) }
+
+    val positionProvider = remember(config.dockingSide) {
+        AzDropdownEdgePositionProvider(config.dockingSide) { triggerBounds }
+    }
+
+    // The launcher icon, loaded exactly like the rail's header icon. Only AzDropdownTrigger.AppIcon
+    // uses it.
     val appIcon = remember(context.packageName) {
         try { context.packageManager.getApplicationIcon(context.packageName) } catch (e: Exception) { null }
     }
 
-    Box(modifier = modifier) {
-        // The inline app-icon trigger — the app icon, clipped to the configured shape/size. The icon
-        // itself is decorative; the box carries the "Menu" accessibility label.
-        val iconClipShape: Shape? = when (config.headerIconShape) {
-            AzHeaderIconShape.CIRCLE -> CircleShape
-            AzHeaderIconShape.ROUNDED -> RoundedCornerShape(12.dp)
-            else -> null
+    // One slot per drop-down. It carries the trigger's (comparable) look as snapshot state and its
+    // behaviour as plain fields, so the title row can render a trigger that always calls back into
+    // this composition without this composition having to re-publish a fresh lambda every frame.
+    val slot = remember { AzTitleTriggerSlot() }
+    slot.onTap = {
+        setOpen(!isOpen)
+        if (config.vibrate) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+    }
+    slot.onBounds = { bounds -> triggerBounds = bounds }
+    slot.publish(
+        AzDropdownTriggerSpec(
+            trigger = config.trigger,
+            size = config.headerIconSize,
+            iconShape = config.headerIconShape,
+            appIcon = appIcon,
+            textStyle = config.itemTextStyle,
+        )
+    )
+
+    if (hostsTrigger) {
+        DisposableEffect(titleHost, slot) {
+            titleHost?.registerTitleTrigger(slot)
+            onDispose { titleHost?.unregisterTitleTrigger(slot) }
         }
-        val clipModifier = if (iconClipShape != null) Modifier.clip(iconClipShape) else Modifier
-        Box(
-            modifier = Modifier
-                // Automatic breathing room around the app-icon trigger so it never sits flush against
-                // neighbouring widgets (mirrors the rail header's spacing).
-                .padding(AzNavRailDefaults.HeaderPadding)
-                .size(config.headerIconSize)
-                .then(clipModifier)
-                .clickable {
-                    setOpen(!isOpen)
-                    if (config.vibrate) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                }
-                .semantics(mergeDescendants = true) { contentDescription = "Menu" },
-            contentAlignment = Alignment.Center
-        ) {
-            if (appIcon != null) {
-                Image(
-                    painter = rememberAsyncImagePainter(appIcon),
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxSize().then(clipModifier)
-                )
-            } else {
-                Icon(imageVector = Icons.Default.Menu, contentDescription = null)
-            }
+    }
+
+    Box(modifier = modifier) {
+        // The trigger itself, unless the host has taken it up to the title row — in which case
+        // nothing is drawn here and only the dropped panel below still belongs to this call site.
+        if (!hostsTrigger) {
+            AzDropdownTriggerButton(slot)
         }
 
         // Keep the panel composed through the staggered exit so items can animate out before teardown.

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzLoad.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzLoad.kt
@@ -11,22 +11,33 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 /**
- * A standard loading spinner component for AzNavRail.
+ * The standard AzNavRail loading spinner: a circular border rotating about its Y axis, with
+ * "loading..." in the middle.
  *
- * It renders a rotating circular border with "loading..." text in the center.
- * This component is used by [AzNavRail] when `isLoading` is set to true in `azAdvanced`,
- * and by [AzButton] when its `isLoading` state is true.
+ * Used full-size by the About/More-from-Az readers, and shrunk down **inside individual buttons** —
+ * every rail item is its own loading animation, so a single item can spin while the rest of the rail
+ * stays live. The label is dropped automatically at button scale, where there is no room for it.
  *
- * It uses a simple Y-axis rotation animation.
+ * @param size The spinner's diameter. Defaults to the full-screen reader size.
+ * @param color Ring and label colour. [Color.Unspecified] (the default) uses the theme primary.
+ * @param showLabel Whether "loading..." is drawn. Defaults to true only when [size] is large enough
+ *   to fit it.
  */
 @Composable
-fun AzLoad() {
+fun AzLoad(
+    size: Dp = 120.dp,
+    color: Color = Color.Unspecified,
+    showLabel: Boolean = size >= 96.dp,
+) {
     val infiniteTransition = rememberInfiniteTransition()
     val rotationY by infiniteTransition.animateFloat(
         initialValue = 0f,
@@ -37,25 +48,29 @@ fun AzLoad() {
         )
     )
 
+    val ringColor = color.takeOrElse { MaterialTheme.colorScheme.primary }
+
     Box(
         modifier = Modifier
-            .size(120.dp)
+            .size(size)
             .graphicsLayer {
                 this.rotationY = rotationY
             }
             .border(
                 width = 2.dp,
-                color = MaterialTheme.colorScheme.primary,
+                color = ringColor,
                 shape = CircleShape
             ),
         contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = "loading...",
-            style = TextStyle(
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 16.sp
+        if (showLabel) {
+            Text(
+                text = "loading...",
+                style = TextStyle(
+                    color = ringColor,
+                    fontSize = 16.sp
+                )
             )
-        )
+        }
     }
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavHost.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavHost.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -19,6 +20,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.MaterialTheme
@@ -30,6 +32,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -59,6 +62,9 @@ import com.hereliesaz.aznavrail.bottomsheet.AzBottomSheet
 import com.hereliesaz.aznavrail.bottomsheet.AzSheetController
 import com.hereliesaz.aznavrail.internal.AboutOverlay
 import com.hereliesaz.aznavrail.internal.AzBottomSheetItem
+import com.hereliesaz.aznavrail.internal.AzDropdownTriggerButton
+import com.hereliesaz.aznavrail.internal.AzTitleTriggerSlot
+import com.hereliesaz.aznavrail.internal.AzUnattachedRail
 import com.hereliesaz.aznavrail.internal.AzLayoutConfig
 import com.hereliesaz.aznavrail.internal.AzNavMode
 import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
@@ -130,6 +136,31 @@ interface AzNavHostScope : AzNavRailScope {
      * @param content The composable content.
      */
     fun onscreen(alignment: Alignment = Alignment.TopStart, page: Float = 0f, content: @Composable () -> Unit)
+
+    /**
+     * Registers a popup window driven by [controller], drawn over everything else in the host.
+     *
+     * A popup is **bound to a rail item**: `controller.show(itemId = "sync")` names one explicitly,
+     * and `controller.show()` binds to whichever rail item the user touched last. The body receives
+     * that item as an [AzPopupItemHandle] through its [AzPopupScope], so the two share state in both
+     * directions — the popup can read the item and write back to it (badge, its own loading
+     * animation, an alert flag), and those writes outlive the DSL re-running until the popup clears
+     * them.
+     *
+     * A [AzPopupKind.NOTICE] or [AzPopupKind.WARNING] popup additionally redraws its bound item as a
+     * **yellow, rounded-corner triangle outline** for as long as it is up, and restores the item
+     * when it closes.
+     *
+     * @param controller Created with [rememberAzPopupController] outside the DSL so its state
+     *   survives recomposition.
+     * @param dismissOnOutsideTap Whether tapping the scrim closes the popup.
+     * @param content The popup's body. Defaults to the built-in title/message/OK panel.
+     */
+    fun azPopup(
+        controller: AzPopupController,
+        dismissOnOutsideTap: Boolean = true,
+        content: @Composable AzPopupScope.() -> Unit = { AzPopupBody() },
+    )
 
     /**
      * Registers a bottom sheet that draws above the rail, the menu, and the onscreen area, and
@@ -215,6 +246,24 @@ class AzNavHostScopeImpl(
     val backgrounds = mutableListOf<AzBackgroundItem>()
     val onscreenItems = mutableListOf<AzOnscreenItem>()
     internal val bottomSheets = mutableListOf<AzBottomSheetItem>()
+    internal val popups = mutableListOf<AzPopupItem>()
+
+    /**
+     * Drop-down triggers lifted out of their call sites and hosted next to the screen title, in
+     * registration order (which is declaration order, since `onscreen` blocks compose in order).
+     *
+     * Registered from `AzDropdownMenu`'s `DisposableEffect`, so — unlike [onscreenItems] — this is
+     * NOT cleared by [resetHost]: it is keyed to composition lifetime, not to the DSL pass.
+     */
+    internal val titleTriggers = mutableStateListOf<AzTitleTriggerSlot>()
+
+    internal fun registerTitleTrigger(slot: AzTitleTriggerSlot) {
+        if (!titleTriggers.contains(slot)) titleTriggers.add(slot)
+    }
+
+    internal fun unregisterTitleTrigger(slot: AzTitleTriggerSlot) {
+        titleTriggers.remove(slot)
+    }
 
     // --- Built-in overlay visibility ---
     // The rail (which always runs inside this host) flips these on user action; the host renders the
@@ -263,6 +312,14 @@ class AzNavHostScopeImpl(
         bottomSheets.add(AzBottomSheetItem(controller, config, onSwipeLeft, onSwipeRight, content))
     }
 
+    override fun azPopup(
+        controller: AzPopupController,
+        dismissOnOutsideTap: Boolean,
+        content: @Composable AzPopupScope.() -> Unit,
+    ) {
+        popups.add(AzPopupItem(controller, dismissOnOutsideTap, content))
+    }
+
     fun getRailScopeImpl() = railScope
 
     fun resetHost() {
@@ -270,6 +327,7 @@ class AzNavHostScopeImpl(
         backgrounds.clear()
         onscreenItems.clear()
         bottomSheets.clear()
+        popups.clear()
     }
 }
 
@@ -347,6 +405,7 @@ fun AzHostActivityLayout(
     scope.apply(content)
     // Re-apply persisted reloc-item reorders so drag-and-drop sticks across recomposition.
     scope.getRailScopeImpl().applyRelocReorders()
+    scope.getRailScopeImpl().applyItemStates()
 
     // The status-driven guidance controller. Created here, provided to the rail (which routes/renders
     // it), and returned to the developer so they can `activate`/`deactivate` goals (see AzStatus.kt).
@@ -461,7 +520,10 @@ fun AzHostActivityLayout(
         val titleAlignment = if (visualDockingSideProxy == AzDockingSide.LEFT) Alignment.CenterEnd else Alignment.CenterStart
         val titlePaddingSide = if (visualDockingSideProxy == AzDockingSide.LEFT) Modifier.padding(end = 32.dp) else Modifier.padding(start = 32.dp)
 
-        if (currentTitle != null && currentTitle != AzNavRailDefaults.NO_TITLE && currentTitle.isNotBlank()) {
+        val hasTitle = currentTitle != null && currentTitle != AzNavRailDefaults.NO_TITLE && currentTitle.isNotBlank()
+        // The title row is also where hosted drop-down triggers live, so it is drawn whenever there
+        // is a title OR at least one trigger to place.
+        if (hasTitle || scope.titleTriggers.isNotEmpty()) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -470,31 +532,47 @@ fun AzHostActivityLayout(
                     .then(titlePaddingSide),
                 contentAlignment = titleAlignment
             ) {
-                // Keying on the title text restarts the composition (and the kinetic entrance) every
-                // time the active screen changes, giving the big Metro title its WP7 sweep-in.
-                key(currentTitle) {
-                    val titleKinetic = rememberAzKineticModifier(
-                        index = 0,
-                        count = 1,
-                        visible = true,
-                        entrance = railScopeImpl.titleEntrance,
-                        exit = AzExit.None,
-                        staggerMs = 0,
-                        durationMs = 420,
-                        easing = com.hereliesaz.aznavrail.model.AzEasing.Wp7Decelerate,
-                        startAngle = 70f,
-                        tiltOnPress = false,
-                        maxTiltDegrees = 0f,
-                        dockingSide = visualDockingSideProxy
-                    )
-                    Text(
-                        text = currentTitle,
-                        modifier = titleKinetic,
-                        style = MaterialTheme.typography.displayMedium // Much bigger requirement
-                            .copy(fontWeight = FontWeight.Bold)
-                            .merge(railScopeImpl.titleTextStyle),
-                        color = MaterialTheme.colorScheme.onBackground
-                    )
+                // Title and triggers read like an app bar mirrored onto the rail's docking side: the
+                // triggers sit hard against the edge the title hugs, with the title just inboard of
+                // them. Several triggers line up beside each other in registration order.
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(0.dp)
+                ) {
+                    if (visualDockingSideProxy != AzDockingSide.LEFT) {
+                        scope.titleTriggers.forEach { slot -> AzDropdownTriggerButton(slot) }
+                    }
+                    if (hasTitle) {
+                        // Keying on the title text restarts the composition (and the kinetic
+                        // entrance) every time the active screen changes.
+                        key(currentTitle) {
+                            val titleKinetic = rememberAzKineticModifier(
+                                index = 0,
+                                count = 1,
+                                visible = true,
+                                entrance = railScopeImpl.titleEntrance,
+                                exit = AzExit.None,
+                                staggerMs = 0,
+                                durationMs = 420,
+                                easing = com.hereliesaz.aznavrail.model.AzEasing.Wp7Decelerate,
+                                startAngle = 70f,
+                                tiltOnPress = false,
+                                maxTiltDegrees = 0f,
+                                dockingSide = visualDockingSideProxy
+                            )
+                            Text(
+                                text = currentTitle!!,
+                                modifier = titleKinetic,
+                                style = MaterialTheme.typography.displayMedium // Much bigger requirement
+                                    .copy(fontWeight = FontWeight.Bold)
+                                    .merge(railScopeImpl.titleTextStyle),
+                                color = MaterialTheme.colorScheme.onBackground
+                            )
+                        }
+                    }
+                    if (visualDockingSideProxy == AzDockingSide.LEFT) {
+                        scope.titleTriggers.forEach { slot -> AzDropdownTriggerButton(slot) }
+                    }
                 }
             }
         }
@@ -534,6 +612,21 @@ fun AzHostActivityLayout(
                 railAlignment = railAlignment,
                 reverseLayout = reverseLayout,
                 content = {}
+            )
+        }
+
+        // Unattached host items — rail hosts that live outside the rail strip. Drawn after the rail
+        // so a floating stack can be dragged over it, and before the built-in overlays so About /
+        // Help / More-from-Az still cover everything.
+        CompositionLocalProvider(
+            LocalAzNavHostScope provides scope,
+            LocalAzSafeZones provides AzSafeZones(safeTop, safeBottom)
+        ) {
+            AzUnattachedRail(
+                scope = railScope,
+                navController = navController,
+                currentDestination = effectiveCurrentDestination,
+                visualDockingSide = visualDockingSideProxy
             )
         }
 
@@ -627,6 +720,16 @@ fun AzHostActivityLayout(
                 onSwipeLeft = item.onSwipeLeft,
                 onSwipeRight = item.onSwipeRight,
                 content = item.content,
+            )
+        }
+
+        // Popups sit above the sheets: they are the layer that interrupts, and a warning raised
+        // while a sheet is open still has to be the thing the user answers.
+        scope.popups.forEach { popup ->
+            AzPopupHost(
+                popup = popup,
+                railScope = railScope,
+                modifier = Modifier.zIndex(3f)
             )
         }
     }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRail.kt
@@ -78,6 +78,8 @@ import com.hereliesaz.aznavrail.internal.CyclerTransientState
 import com.hereliesaz.aznavrail.internal.Footer
 import com.hereliesaz.aznavrail.internal.MenuItem
 import com.hereliesaz.aznavrail.internal.RailItems
+import com.hereliesaz.aznavrail.internal.toComposeShape
+import com.hereliesaz.aznavrail.internal.azUnattachedSubtreeIds
 import com.hereliesaz.aznavrail.internal.SecretScreens
 import com.hereliesaz.aznavrail.internal.rememberAzClosingState
 import com.hereliesaz.aznavrail.internal.rememberAzKineticModifier
@@ -164,6 +166,7 @@ fun AzNavRail(
         scope.reset()
         scope.apply(content)
         scope.applyRelocReorders()
+        scope.applyItemStates()
     }
 
     val packageManager = context.packageManager
@@ -183,6 +186,11 @@ fun AzNavRail(
             GithubDocsRepository.repoUrlFromPackage(packageName) ?: scope.appRepositoryUrl
         }
     }
+
+    // Ids of the unattached hosts and their whole subtrees. They are declared on this scope like any
+    // other item, but they render at their own anchor (see `AzUnattachedRail`), so the rail strip
+    // and the drawer both have to skip them.
+    val unattachedIds = remember(scope.navItems.toList()) { azUnattachedSubtreeIds(scope.navItems) }
 
     var isExpanded by remember { mutableStateOf(if (scope.noMenu) false else initiallyExpanded) }
     var dissolving: com.hereliesaz.aznavrail.internal.DissolveState? by remember { mutableStateOf(null) }
@@ -528,13 +536,16 @@ fun AzNavRail(
                     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
                         val hasExplicitHelpItem =
                             scope.navItems.any { it.isHelpItem || it.id == AzNavRailDefaults.AUTO_HELP_ID }
+                        val attachedItems =
+                            if (unattachedIds.isEmpty()) scope.navItems
+                            else scope.navItems.filterNot { it.id in unattachedIds }
                         val displayItems =
                             if (scope.advancedConfig.helpEnabled && !hasExplicitHelpItem) {
-                                scope.navItems + AzNavItem.Help(
+                                attachedItems + AzNavItem.Help(
                                     id = AzNavRailDefaults.AUTO_HELP_ID,
                                     isRailItem = false
                                 )
-                            } else scope.navItems
+                            } else attachedItems
                         val orderedItems =
                             if (reverseLayout) displayItems.reversed() else displayItems
                         val topLevelItems = orderedItems.filter { !it.isSubItem }
@@ -630,6 +641,9 @@ fun AzNavRail(
                                             )
                                         },
                                         onItemSelected = { item ->
+                                            // Remember who was touched last: a notice/warning popup
+                                            // raised without an explicit source claims this item.
+                                            scope.lastTouchedItemId = item.id
                                             if (item.isHelpItem) toggleHelpOverlay(item.id); if (item.collapseOnClick && !scope.noMenu) isExpanded =
                                             false
                                         },
@@ -666,6 +680,9 @@ fun AzNavRail(
                                             )
                                         },
                                         onItemSelected = { item ->
+                                            // Remember who was touched last: a notice/warning popup
+                                            // raised without an explicit source claims this item.
+                                            scope.lastTouchedItemId = item.id
                                             if (item.isHelpItem) toggleHelpOverlay(item.id); if (item.collapseOnClick && !scope.noMenu) isExpanded =
                                             false
                                         },
@@ -703,7 +720,9 @@ fun AzNavRail(
                                 .padding(8.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            val buttonShape = scope.defaultShape
+                            // `defaultShape` is an AzButtonShape; border/background need the real
+                            // Compose Shape it maps to.
+                            val buttonShape = scope.defaultShape.toComposeShape()
                             val uriHandler = androidx.compose.ui.platform.LocalUriHandler.current
                             val transparentShapeModifier = Modifier
                                 .size(activeButtonSize)
@@ -804,7 +823,8 @@ fun AzNavRail(
                 }
 
                 val isRailOpen = !(isFloating && !showFloatingButtons) && !(scope.noMenu && scope.isFoldedUp)
-                val railItemsCount = scope.navItems.filter { it.isRailItem && !it.isSubItem }.size
+                val railItemsCount =
+                    scope.navItems.filter { it.isRailItem && !it.isSubItem && it.id !in unattachedIds }.size
                 val railItemsRendered = rememberAzClosingState(
                     open = isRailOpen,
                     exit = AzExit.Turnstile,
@@ -1037,6 +1057,7 @@ private fun MenuItemNode(
             scope.activeClassifiers.contains(it)
         },
         onClick = {
+            scope.lastTouchedItemId = item.id
             if (item.isHelpItem) onToggleHelp(item.id) else scope.onClickMap[item.id]?.invoke(); scope.advancedConfig.onInteraction?.invoke(
             item.id,
             item

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailButton.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import com.hereliesaz.aznavrail.internal.AzNavRailDefaults
+import com.hereliesaz.aznavrail.internal.toComposeShape
 import com.hereliesaz.aznavrail.model.AzButtonShape
 import com.hereliesaz.aznavrail.model.AzComposableContent
 import com.hereliesaz.aznavrail.util.text.AutoSizeText
@@ -108,16 +109,13 @@ internal fun AzNavRailButton(
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
 
-    val buttonShape: Shape = when (shape) {
-        AzButtonShape.CIRCLE -> CircleShape
-        AzButtonShape.SQUARE -> RectangleShape
-        AzButtonShape.RECTANGLE -> RectangleShape
-        AzButtonShape.NONE -> RectangleShape
-    }
+    val buttonShape: Shape = shape.toComposeShape()
 
     // STRICT WIDTH COMPLIANCE for all shapes.
     val buttonModifier = when (shape) {
-        AzButtonShape.CIRCLE, AzButtonShape.SQUARE -> modifier
+        // The triangle occupies the same square footprint as a circle, so an item that flips to the
+        // warning glyph doesn't reflow the rail around it.
+        AzButtonShape.CIRCLE, AzButtonShape.SQUARE, AzButtonShape.TRIANGLE -> modifier
             .size(size)
             .aspectRatio(1f)
         AzButtonShape.RECTANGLE, AzButtonShape.NONE -> {
@@ -177,7 +175,12 @@ internal fun AzNavRailButton(
     ) {
         Box(
             // If itemContent is present (Color/Img), we force 0 padding to Fill/Crop. Otherwise, apply text padding.
-            modifier = if (itemContent != null) Modifier else Modifier.padding(contentPadding),
+            // A triangle's usable area is its lower half, so its content is nudged down off the apex.
+            modifier = when {
+                itemContent != null -> Modifier
+                shape == AzButtonShape.TRIANGLE -> Modifier.padding(contentPadding).padding(top = size * 0.25f)
+                else -> Modifier.padding(contentPadding)
+            },
             contentAlignment = Alignment.Center
         ) {
             Box(
@@ -201,7 +204,15 @@ internal fun AzNavRailButton(
                     )
                 }
             }
-            if (isLoading) AzLoad()
+            // Each button spins its own spinner, scaled to the button rather than the full-screen
+            // default, and tinted to the item's own colour so a loading item still reads as itself.
+            if (isLoading) {
+                val spinnerSize = when (shape) {
+                    AzButtonShape.RECTANGLE, AzButtonShape.NONE -> 28.dp
+                    else -> size * 0.6f
+                }
+                AzLoad(size = spinnerSize, color = finalColor, showLabel = false)
+            }
         }
     }
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzNavRailScope.kt
@@ -20,7 +20,10 @@ import com.hereliesaz.aznavrail.model.AzEasing
 import com.hereliesaz.aznavrail.model.AzEntrance
 import com.hereliesaz.aznavrail.model.AzExit
 import com.hereliesaz.aznavrail.model.AzHeaderIconShape
+import com.hereliesaz.aznavrail.model.AzItemAlert
 import com.hereliesaz.aznavrail.model.AzItemConfig
+import com.hereliesaz.aznavrail.model.AzItemState
+import com.hereliesaz.aznavrail.model.AzUnattachedAnchor
 import com.hereliesaz.aznavrail.model.AzMenuItemAlignment
 import com.hereliesaz.aznavrail.model.AzNavItem
 import com.hereliesaz.aznavrail.model.AzNestedRailAlignment
@@ -293,7 +296,7 @@ interface AzNavRailScope {
      * @param info Description text for the Help/Info screen.
      * @param onClick Callback invoked when the item is clicked.
      */
-    fun azMenuItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azMenuItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds an explicit Help trigger item to the rail.
@@ -305,7 +308,7 @@ interface AzNavRailScope {
      * @param color Custom color.
      * @param shape Custom shape.
      */
-    fun azHelpRailItem(id: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null)
+    fun azHelpRailItem(id: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false)
 
     /**
      * Adds an explicit Help trigger item as a SubItem to a Host Item.
@@ -318,7 +321,7 @@ interface AzNavRailScope {
      * @param color Custom color.
      * @param shape Custom shape.
      */
-    fun azHelpSubItem(id: String, hostId: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null)
+    fun azHelpSubItem(id: String, hostId: String, text: String = "Help", content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false)
 
     /**
      * Adds an item to the always-visible rail.
@@ -336,7 +339,7 @@ interface AzNavRailScope {
      * @param onFocus Callback invoked when the item receives focus.
      * @param onClick Callback invoked when the item is clicked.
      */
-    fun azRailItem(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
+    fun azRailItem(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Nested Rail item. This item opens a secondary popup rail when clicked.
@@ -356,7 +359,7 @@ interface AzNavRailScope {
      * @param keepNestedRailOpen If true, the nested rail remains open until the parent item is tapped again.
      * @param nestedContent DSL block to define the items within the nested rail.
      */
-    fun azNestedRail(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, alignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onFocus: (() -> Unit)? = null, keepNestedRailOpen: Boolean = false, nestedContent: AzNavRailScope.() -> Unit)
+    fun azNestedRail(id: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, alignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onFocus: (() -> Unit)? = null, keepNestedRailOpen: Boolean = false, nestedContent: AzNavRailScope.() -> Unit)
 
     /**
      * Adds a toggle switch item to the menu.
@@ -365,7 +368,7 @@ interface AzNavRailScope {
      * @param toggleOnText Text to display when checked.
      * @param toggleOffText Text to display when unchecked.
      */
-    fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a toggle switch item to the rail.
@@ -382,7 +385,7 @@ interface AzNavRailScope {
      * @param info Help info string.
      * @param onClick Click callback.
      */
-    fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a cycler item (multi-state button) to the menu.
@@ -391,7 +394,7 @@ interface AzNavRailScope {
      * @param selectedOption The currently selected option.
      * @param disabledOptions List of options that cannot be selected.
      */
-    fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a cycler item to the always-visible rail.
@@ -415,7 +418,7 @@ interface AzNavRailScope {
      * @param fillColor Translucent fill color override.
      * @param onClick Callback fired on commit.
      */
-    fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a visual divider line to the menu list. Has no effect on the collapsed rail.
@@ -436,7 +439,7 @@ interface AzNavRailScope {
      * @param info Help info string.
      * @param onClick Click callback.
      */
-    fun azMenuHostItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
+    fun azMenuHostItem(id: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Host Item to the rail. Sub-items targeting [id] via their
@@ -461,6 +464,7 @@ interface AzNavRailScope {
         fillColor: Color? = null,
         badge: String? = null,
         persistentBadge: Boolean = false,
+        isLoading: Boolean = false,
         initiallyExpanded: Boolean = false,
         expandWhen: (() -> Boolean)? = null,
         onExpandedChange: ((Boolean) -> Unit)? = null,
@@ -468,11 +472,83 @@ interface AzNavRailScope {
     )
 
     /**
+     * Adds an **unattached** Host Item — a rail host that does not live in the rail strip.
+     *
+     * It is drawn on its own at [anchor], and tapping it unfolds its sub-items inline beneath it,
+     * exactly as they would have unfolded inside the rail. Sub-items attach the usual way, by
+     * pointing their `hostId` at this item's [id] (`azRailSubItem`, `azRailSubToggle`,
+     * `azRailSubCycler`, `azRailSubHostItem` — sub-hosts nest to any depth). Declare several
+     * unattached hosts sharing an [anchor] and they stack into a column, spaced exactly as they
+     * would have been in the rail.
+     *
+     * The host and its whole subtree are removed from the rail strip and the drawer menu; this item
+     * exists only at its anchor.
+     *
+     * @param anchor Where it parks: [AzUnattachedAnchor.BOTTOM] (bottom of the screen, opposite the
+     *   rail), [AzUnattachedAnchor.OPPOSITE] (opposite side, level with the rail's items), or
+     *   [AzUnattachedAnchor.FLOATING] (draggable, with its position persisted across launches).
+     *   Other parameters mirror [azRailHostItem]; see that method's docs.
+     */
+    fun azUnattachedHostItem(
+        id: String,
+        text: String,
+        anchor: AzUnattachedAnchor = AzUnattachedAnchor.OPPOSITE,
+        route: String? = null,
+        content: Any? = null,
+        color: Color? = null,
+        shape: AzButtonShape? = null,
+        disabled: Boolean = false,
+        screenTitle: String? = null,
+        info: String? = null,
+        classifiers: Set<String> = emptySet(),
+        menuText: String? = null,
+        textColor: Color? = null,
+        fillColor: Color? = null,
+        badge: String? = null,
+        persistentBadge: Boolean = false,
+        isLoading: Boolean = false,
+        initiallyExpanded: Boolean = false,
+        expandWhen: (() -> Boolean)? = null,
+        onExpandedChange: ((Boolean) -> Unit)? = null,
+        onClick: (() -> Unit)? = null
+    )
+
+    /**
+     * Decorates an **already-declared** item — of any kind, anywhere: a rail item, a menu item, a
+     * sub-item, a host, a nested-rail child, an unattached host — with the per-item state the rail
+     * can render on top of it.
+     *
+     * This is the uniform way to give *every* item a badge and its own loading animation without
+     * every builder growing the same three parameters. Call it anywhere in the DSL block; it is
+     * applied after all items are declared, so the order does not matter. Values left null are left
+     * alone, so decorating only the badge does not clear the item's loading state.
+     *
+     * ```
+     * azRailItem(id = "sync", text = "Sync") { sync() }
+     * azItemState(id = "sync", isLoading = syncing, badge = pendingCount.takeIf { it > 0 }?.toString())
+     * ```
+     *
+     * @param id The id of the item to decorate. Unknown ids are ignored.
+     * @param badge Short badge text drawn in a small circle on the button's corner; blank/null hides it.
+     * @param persistentBadge Whether the badge stays visible (true) or dissolves after a second (false).
+     * @param isLoading Whether this item's button spins its own loading animation in place of its content.
+     * @param alert Alert styling — a notice/warning redraws the item as a yellow, rounded-corner
+     *   triangle outline. Usually set for you by an [com.hereliesaz.aznavrail.AzPopupController].
+     */
+    fun azItemState(
+        id: String,
+        badge: String? = null,
+        persistentBadge: Boolean? = null,
+        isLoading: Boolean? = null,
+        alert: AzItemAlert? = null
+    )
+
+    /**
      * Adds a Sub Item to a Host Item in the menu.
      *
      * @param hostId The ID of the parent Host Item.
      */
-    fun azMenuSubItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onClick: (() -> Unit)? = null)
+    fun azMenuSubItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Item to a Host Item in the rail. Parameters mirror [azMenuSubItem]; on the rail
@@ -480,7 +556,7 @@ interface AzNavRailScope {
      *
      * @param onFocus Called when the sub-item gains focus.
      */
-    fun azRailSubItem(id: String, hostId: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
+    fun azRailSubItem(id: String, hostId: String, text: String = "", route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Item that is itself a Host Item in the menu. It is a child of [hostId] (so it only
@@ -489,7 +565,7 @@ interface AzNavRailScope {
      *
      * @param hostId The ID of the parent Host Item this sub-host belongs to.
      */
-    fun azMenuSubHostItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
+    fun azMenuSubHostItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, expandWhen: (() -> Boolean)? = null, onExpandedChange: ((Boolean) -> Unit)? = null, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Item that is itself a Host Item to the rail. It is a child of
@@ -516,6 +592,7 @@ interface AzNavRailScope {
         fillColor: Color? = null,
         badge: String? = null,
         persistentBadge: Boolean = false,
+        isLoading: Boolean = false,
         initiallyExpanded: Boolean = false,
         expandWhen: (() -> Boolean)? = null,
         onExpandedChange: ((Boolean) -> Unit)? = null,
@@ -533,13 +610,13 @@ interface AzNavRailScope {
      * @param toggleOffText Label shown when unchecked.
      * @param onClick Fired on toggle.
      */
-    fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+    fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Toggle to a Host Item in the rail. Parameters mirror [azMenuSubToggle]; only
      * visible while the parent host is expanded on the rail.
      */
-    fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+    fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuToggleOnText: String? = null, menuToggleOffText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Cycler to a Host Item in the menu.
@@ -551,13 +628,13 @@ interface AzNavRailScope {
      * @param disabledOptions Options that should be skipped during cycling.
      * @param onClick Fired on commit.
      */
-    fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+    fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Sub Cycler to a Host Item in the rail. Parameters mirror [azMenuSubCycler]; the
      * cycler only renders while the parent host is expanded on the rail.
      */
-    fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, onClick: (() -> Unit)? = null)
+    fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, disabledOptions: List<String>? = null, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuOptions: List<String>? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onClick: (() -> Unit)? = null)
 
     /**
      * Adds a Relocatable Item to a Host Item in the rail.
@@ -584,7 +661,7 @@ interface AzNavRailScope {
      * @param forceHiddenMenuOpen Programmatic control to explicitly show or hide the hidden menu.
      * @param onHiddenMenuDismiss Callback invoked when the hidden menu dismisses itself.
      */
-    fun azRailRelocItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null, onRelocate: ((Int, Int, List<String>) -> Unit)? = null, nestedRailAlignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, keepNestedRailOpen: Boolean = false, nestedContent: (AzNavRailScope.() -> Unit)? = null, forceHiddenMenuOpen: Boolean = false, onHiddenMenuDismiss: (() -> Unit)? = null, hiddenMenu: HiddenMenuScope.() -> Unit = {})
+    fun azRailRelocItem(id: String, hostId: String, text: String, route: String? = null, content: Any? = null, color: Color? = null, shape: AzButtonShape? = null, disabled: Boolean = false, screenTitle: String? = null, info: String? = null, classifiers: Set<String> = emptySet(), menuText: String? = null, textColor: Color? = null, fillColor: Color? = null, badge: String? = null, persistentBadge: Boolean = false, isLoading: Boolean = false, onFocus: (() -> Unit)? = null, onClick: (() -> Unit)? = null, onRelocate: ((Int, Int, List<String>) -> Unit)? = null, nestedRailAlignment: AzNestedRailAlignment = AzNestedRailAlignment.VERTICAL, keepNestedRailOpen: Boolean = false, nestedContent: (AzNavRailScope.() -> Unit)? = null, forceHiddenMenuOpen: Boolean = false, onHiddenMenuDismiss: (() -> Unit)? = null, hiddenMenu: HiddenMenuScope.() -> Unit = {})
 }
 
 /**
@@ -710,6 +787,27 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
      * drag end and re-applied via [applyRelocReorders] after the DSL block runs.
      */
     val savedRelocOrders: androidx.compose.runtime.snapshots.SnapshotStateMap<String, List<String>> = mutableStateMapOf()
+    /**
+     * Per-item state declared through [azItemState], keyed by item id. Cleared on each [reset] and
+     * re-declared by the DSL, like the items themselves.
+     */
+    val declaredItemStates = mutableMapOf<String, AzItemState>()
+
+    /**
+     * Per-item state pushed **imperatively** from an [com.hereliesaz.aznavrail.AzPopupController]'s
+     * item handle. Survives [reset] (the DSL re-runs constantly and would otherwise wipe it on the
+     * next frame) and wins over [declaredItemStates], because it represents something that happened
+     * after the developer's declaration — a popup taking ownership of the item that raised it.
+     */
+    val itemOverrides: androidx.compose.runtime.snapshots.SnapshotStateMap<String, AzItemState> = mutableStateMapOf()
+
+    /**
+     * The last rail/menu item the user touched. A notice/warning popup raised with no explicit
+     * source item claims this one, which is what "the last touched rail item turns into a warning
+     * triangle" resolves to.
+     */
+    var lastTouchedItemId: String? by mutableStateOf(null)
+
     /** Cache of window-space bounds for each item, populated as items are laid out. */
     val itemBoundsCache = mutableStateMapOf<String, Rect>()
     /** Transient selected options for cyclers during the debounce window. */
@@ -729,6 +827,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         onRelocateMap.clear()
         expandWhenMap.clear()
         onExpandedChangeMap.clear()
+        declaredItemStates.clear()
         statusPredicates.clear()
         guidanceEdges.clear()
         guidanceGoals.clear()
@@ -782,6 +881,43 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
             }
         }
         staleHosts.forEach { savedRelocOrders.remove(it) }
+    }
+
+    /**
+     * Stamps [declaredItemStates] and [itemOverrides] onto the freshly-declared [navItems] (and onto
+     * nested-rail children, which live in their parent's `nestedRailItems`).
+     *
+     * Called right after the DSL block runs, alongside [applyRelocReorders], for the same reason:
+     * the DSL rebuilds every item from scratch on each recomposition, so anything layered on top of
+     * an item has to be re-applied afterwards or it lasts exactly one frame.
+     */
+    fun applyItemStates() {
+        if (declaredItemStates.isEmpty() && itemOverrides.isEmpty()) return
+        fun decorate(item: AzNavItem): AzNavItem {
+            val declared = declaredItemStates[item.id]
+            val override = itemOverrides[item.id]
+            // Nested-rail children are decorated too, so `azItemState` reaches items declared inside
+            // a `nestedContent { … }` block — hence the recursion happens even when the parent
+            // itself carries no state of its own.
+            if (declared == null && override == null) {
+                val children = item.nestedRailItems ?: return item
+                return item.copy(nestedRailItems = children.map { decorate(it) })
+            }
+            val badge = override?.badge ?: declared?.badge ?: item.badge
+            val persistent = override?.persistentBadge ?: declared?.persistentBadge ?: item.persistentBadge
+            val loading = override?.isLoading ?: declared?.isLoading ?: item.isLoading
+            val alert = override?.alert ?: declared?.alert ?: item.alert
+            return item.copy(
+                badge = badge,
+                persistentBadge = persistent,
+                isLoading = loading,
+                alert = alert,
+                nestedRailItems = item.nestedRailItems?.map { decorate(it) },
+            )
+        }
+        for (i in navItems.indices) {
+            navItems[i] = decorate(navItems[i])
+        }
     }
 
     // Config
@@ -1069,14 +1205,14 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         }
     }
 
-    override fun azMenuItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azMenuItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azHelpRailItem(id: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?) {
+    override fun azHelpRailItem(id: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean) {
         checkId(id)
         navItems.add(
-            AzNavItem.Help(
+            AzNavItem.Help(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 id = id,
                 text = text,
                 menuText = menuText,
@@ -1090,13 +1226,13 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         )
     }
 
-    override fun azHelpSubItem(id: String, hostId: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?) {
+    override fun azHelpSubItem(id: String, hostId: String, text: String, content: Any?, color: Color?, shape: AzButtonShape?, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean) {
         checkId(id)
         if (navItems.none { it.id == hostId }) {
             throw IllegalArgumentException("`azHelpSubItem(id = \"$id\", hostId = \"$hostId\", ...)` references a host that has not been declared yet. Sub-items attach to a previously-registered host so the rail can resolve `hostId` -> host item when rendering. Fix: declare a parent `azMenuHostItem` / `azRailHostItem` / `azHelpRailItem` (or any item) with `id = \"$hostId\"` BEFORE this `azHelpSubItem` call in the `azRailContent { ... }` block; or change the `hostId` argument here to match an id that already exists.")
         }
         navItems.add(
-            AzNavItem(
+            AzNavItem(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 id = id,
                 text = text,
                 menuText = menuText,
@@ -1113,11 +1249,11 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         )
     }
 
-    override fun azRailItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azRailItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azNestedRail(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, alignment: AzNestedRailAlignment, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onFocus: (() -> Unit)?, keepNestedRailOpen: Boolean, nestedContent: AzNavRailScope.() -> Unit) {
+    override fun azNestedRail(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, alignment: AzNestedRailAlignment, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onFocus: (() -> Unit)?, keepNestedRailOpen: Boolean, nestedContent: AzNavRailScope.() -> Unit) {
         checkId(id)
         val nestedScope = AzNavRailScopeImpl(this.globalIdSet)
         nestedScope.azConfig(dockingSide = this.dockingSide, packButtons = this.packButtons, noMenu = this.noMenu, vibrate = this.vibrate, displayAppName = this.displayAppName, activeClassifiers = this.activeClassifiers, expandedWidth = this.expandedWidth, collapsedWidth = this.collapsedWidth, railItemWidth = this.railItemWidth, showFooter = this.showFooter, appRepositoryUrl = this.appRepositoryUrl)
@@ -1136,7 +1272,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         if (onFocus != null) onFocusMap[id] = onFocus
 
         navItems.add(
-            AzNavItem(
+            AzNavItem(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 id = id, text = text, menuText = menuText, route = route, isRailItem = true, isNestedRail = true,
                 nestedRailAlignment = alignment, nestedRailItems = nestedScope.navItems.toList(),
                 disabled = disabled, screenTitle = screenTitle ?: text,
@@ -1146,30 +1282,30 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         )
     }
 
-    override fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azMenuToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azRailToggle(id: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azMenuCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
-    override fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azRailCycler(id: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = false, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
     override fun azDivider() {
         navItems.add(AzNavItem(id = "divider_${navItems.size}", text = "", isRailItem = false, isDivider = true))
     }
 
-    override fun azMenuHostItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, expandWhen: (() -> Boolean)?, onExpandedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {
+    override fun azMenuHostItem(id: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, expandWhen: (() -> Boolean)?, onExpandedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {
         if (expandWhen != null) expandWhenMap[id] = expandWhen
         if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
     override fun azRailHostItem(
@@ -1188,6 +1324,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         fillColor: Color?,
         badge: String?,
         persistentBadge: Boolean,
+        isLoading: Boolean,
         initiallyExpanded: Boolean,
         expandWhen: (() -> Boolean)?,
         onExpandedChange: ((Boolean) -> Unit)?,
@@ -1199,7 +1336,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
             id = id,
             text = text,
             menuText = menuText,
-            config = AzItemConfig(
+            config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 classifiers = classifiers,
                 route = route,
                 screenTitle = screenTitle,
@@ -1217,12 +1354,82 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
             onClick = onClick ?: {})
     }
 
-    override fun azMenuSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onClick: (() -> Unit)?) {
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azUnattachedHostItem(
+        id: String,
+        text: String,
+        anchor: AzUnattachedAnchor,
+        route: String?,
+        content: Any?,
+        color: Color?,
+        shape: AzButtonShape?,
+        disabled: Boolean,
+        screenTitle: String?,
+        info: String?,
+        classifiers: Set<String>,
+        menuText: String?,
+        textColor: Color?,
+        fillColor: Color?,
+        badge: String?,
+        persistentBadge: Boolean,
+        isLoading: Boolean,
+        initiallyExpanded: Boolean,
+        expandWhen: (() -> Boolean)?,
+        onExpandedChange: ((Boolean) -> Unit)?,
+        onClick: (() -> Unit)?
+    ) {
+        if (expandWhen != null) expandWhenMap[id] = expandWhen
+        if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
+        addItem(
+            id = id,
+            text = text,
+            menuText = menuText,
+            config = AzItemConfig(
+                classifiers = classifiers,
+                route = route,
+                screenTitle = screenTitle,
+                info = info,
+                // Unattached hosts are rail-flavoured (they render rail buttons and unfold rail
+                // sub-items); `isUnattached` is what keeps them out of the rail strip itself.
+                isRailItem = true,
+                disabled = disabled,
+                isHost = true,
+                content = content,
+                color = color,
+                textColor = textColor,
+                fillColor = fillColor,
+                shape = shape,
+                badge = badge,
+                persistentBadge = persistentBadge,
+                isLoading = isLoading,
+                initiallyExpanded = initiallyExpanded,
+                isUnattached = true,
+                unattachedAnchor = anchor
+            ),
+            onClick = onClick ?: {})
     }
 
-    override fun azRailSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, isSubItem = true, hostId = hostId, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    override fun azItemState(
+        id: String,
+        badge: String?,
+        persistentBadge: Boolean?,
+        isLoading: Boolean?,
+        alert: AzItemAlert?
+    ) {
+        val existing = declaredItemStates[id]
+        declaredItemStates[id] = AzItemState(
+            badge = badge ?: existing?.badge,
+            persistentBadge = persistentBadge ?: existing?.persistentBadge,
+            isLoading = isLoading ?: existing?.isLoading,
+            alert = alert ?: existing?.alert,
+        )
+    }
+
+    override fun azMenuSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
+    }
+
+    override fun azRailSubItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?) {
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = true, disabled = disabled, isSubItem = true, hostId = hostId, onFocus = onFocus, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape, badge = badge, persistentBadge = persistentBadge), onClick = onClick ?: {})
     }
 
     override fun azMenuSubHostItem(
@@ -1242,6 +1449,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         fillColor: Color?,
         badge: String?,
         persistentBadge: Boolean,
+        isLoading: Boolean,
         expandWhen: (() -> Boolean)?,
         onExpandedChange: ((Boolean) -> Unit)?,
         onClick: (() -> Unit)?
@@ -1249,7 +1457,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         checkSubHost(id, hostId, "azMenuSubHostItem")
         if (expandWhen != null) expandWhenMap[id] = expandWhen
         if (onExpandedChange != null) onExpandedChangeMap[id] = onExpandedChange
-        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+        addItem(id = id, text = text, menuText = menuText, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, route = route, screenTitle = screenTitle, info = info, isRailItem = false, disabled = disabled, isHost = true, isSubItem = true, hostId = hostId, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
     override fun azRailSubHostItem(
@@ -1269,6 +1477,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         fillColor: Color?,
         badge: String?,
         persistentBadge: Boolean,
+        isLoading: Boolean,
         initiallyExpanded: Boolean,
         expandWhen: (() -> Boolean)?,
         onExpandedChange: ((Boolean) -> Unit)?,
@@ -1281,7 +1490,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
             id = id,
             text = text,
             menuText = menuText,
-            config = AzItemConfig(
+            config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 classifiers = classifiers,
                 route = route,
                 screenTitle = screenTitle,
@@ -1314,23 +1523,23 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         }
     }
 
-    override fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
-        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    override fun azMenuSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
-    override fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
-        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    override fun azRailSubToggle(id: String, hostId: String, isChecked: Boolean, toggleOnText: String, toggleOffText: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuToggleOnText: String?, menuToggleOffText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addToggle(id = id, isChecked = isChecked, toggleOnText = toggleOnText, toggleOffText = toggleOffText, menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
-    override fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
-        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    override fun azMenuSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = false, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
-    override fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, onClick: (() -> Unit)?) {
-        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
+    override fun azRailSubCycler(id: String, hostId: String, options: List<String>, selectedOption: String, route: String?, color: Color?, shape: AzButtonShape?, disabled: Boolean, disabledOptions: List<String>?, screenTitle: String?, info: String?, classifiers: Set<String>, menuOptions: List<String>?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onClick: (() -> Unit)?) {
+        addCycler(id = id, options = options, menuOptions = menuOptions, selectedOption = selectedOption, disabledOptions = disabledOptions, config = AzItemConfig(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, classifiers = classifiers, hostId = hostId, route = route, disabled = disabled, screenTitle = screenTitle, info = info, isRailItem = true, isSubItem = true, color = color, textColor = textColor, fillColor = fillColor, shape = shape), onClick = onClick ?: {})
     }
 
-    override fun azRailRelocItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, onFocus: (() -> Unit)?, onClick: (() -> Unit)?, onRelocate: ((Int, Int, List<String>) -> Unit)?, nestedRailAlignment: AzNestedRailAlignment, keepNestedRailOpen: Boolean, nestedContent: (AzNavRailScope.() -> Unit)?, forceHiddenMenuOpen: Boolean, onHiddenMenuDismiss: (() -> Unit)?, hiddenMenu: HiddenMenuScope.() -> Unit) {
+    override fun azRailRelocItem(id: String, hostId: String, text: String, route: String?, content: Any?, color: Color?, shape: AzButtonShape?, disabled: Boolean, screenTitle: String?, info: String?, classifiers: Set<String>, menuText: String?, textColor: Color?, fillColor: Color?, badge: String?, persistentBadge: Boolean, isLoading: Boolean, onFocus: (() -> Unit)?, onClick: (() -> Unit)?, onRelocate: ((Int, Int, List<String>) -> Unit)?, nestedRailAlignment: AzNestedRailAlignment, keepNestedRailOpen: Boolean, nestedContent: (AzNavRailScope.() -> Unit)?, forceHiddenMenuOpen: Boolean, onHiddenMenuDismiss: (() -> Unit)?, hiddenMenu: HiddenMenuScope.() -> Unit) {
         checkId(id)
         val hiddenMenuScope = HiddenMenuScopeImpl(id, hiddenMenuOnClickMap, hiddenMenuOnValueChangeMap)
         hiddenMenuScope.hiddenMenu()
@@ -1360,7 +1569,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
         } else null
 
         navItems.add(
-            AzNavItem(
+            AzNavItem(badge = badge, persistentBadge = persistentBadge, isLoading = isLoading, 
                 id = id, text = text, menuText = menuText, route = route, isRailItem = true, isSubItem = true, hostId = hostId,
                 isRelocItem = true, disabled = disabled, screenTitle = finalScreenTitle, info = info,
                 hiddenMenuItems = hiddenMenuScope.items, forceHiddenMenuOpen = forceHiddenMenuOpen, onHiddenMenuDismiss = onHiddenMenuDismiss, classifiers = classifiers, content = content, color = color, textColor = textColor, fillColor = fillColor, shape = shape,
@@ -1391,7 +1600,7 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
                 disabled = config.disabled, disabledOptions = disabledOptions, isSubItem = config.isSubItem,
                 hostId = config.hostId, info = config.info, color = config.color, textColor = config.textColor,
                 fillColor = config.fillColor, shape = config.shape, badge = config.badge,
-                persistentBadge = config.persistentBadge
+                persistentBadge = config.persistentBadge, isLoading = config.isLoading
             )
         )
     }
@@ -1415,7 +1624,8 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
                 menuToggleOnText = menuToggleOnText, menuToggleOffText = menuToggleOffText, disabled = config.disabled,
                 isSubItem = config.isSubItem, hostId = config.hostId, info = config.info, color = config.color,
                 textColor = config.textColor, fillColor = config.fillColor, shape = config.shape,
-                badge = config.badge, persistentBadge = config.persistentBadge
+                badge = config.badge, persistentBadge = config.persistentBadge,
+                isLoading = config.isLoading
             )
         )
     }
@@ -1439,7 +1649,10 @@ class AzNavRailScopeImpl(private val globalIdSet: MutableSet<String> = mutableSe
                 shape = config.shape,
                 initiallyExpanded = config.initiallyExpanded,
                 badge = config.badge,
-                persistentBadge = config.persistentBadge
+                persistentBadge = config.persistentBadge,
+                isLoading = config.isLoading,
+                isUnattached = config.isUnattached,
+                unattachedAnchor = config.unattachedAnchor
             )
         )
     }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzPopup.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/AzPopup.kt
@@ -1,0 +1,311 @@
+package com.hereliesaz.aznavrail
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.internal.color
+import com.hereliesaz.aznavrail.model.AzItemAlert
+import com.hereliesaz.aznavrail.model.AzItemState
+import com.hereliesaz.aznavrail.model.AzNavItem
+
+/** How loud an [AzPopup] is, and what it does to the rail item that raised it. */
+enum class AzPopupKind {
+    /** Ordinary information. The source item is left looking like itself. */
+    INFO,
+
+    /** A notice. The source item becomes a yellow rounded-corner triangle outline while it is up. */
+    NOTICE,
+
+    /** A warning. Same triangle, in a louder yellow. */
+    WARNING,
+}
+
+/** One live show request, describing what the popup is about and which item raised it. */
+data class AzPopupRequest(
+    /**
+     * The id of the rail item that raised it. Null asks the rail for the **last touched** item,
+     * which is what a warning raised from a background job — with no tap to name a source — binds to.
+     */
+    val itemId: String? = null,
+    val kind: AzPopupKind = AzPopupKind.INFO,
+    val title: String? = null,
+    val message: String? = null,
+    /** Anything else the popup body needs. Passed straight through, untouched. */
+    val payload: Any? = null,
+)
+
+/**
+ * The handle an [AzPopup] gets on the rail item that raised it — the shared channel between the two.
+ *
+ * The popup can read the item as the rail currently has it, and write back to it: a long-running
+ * action started from a rail item can spin that item's own loading animation, drop a badge on it
+ * when it finishes, or flag it. Writes are held on the rail scope and survive the DSL re-running, so
+ * they last until the popup clears them (which it does automatically on dismiss).
+ */
+@Stable
+interface AzPopupItemHandle {
+    /** The bound item's id. */
+    val id: String
+
+    /** The bound item as the rail currently renders it, or null if it is no longer declared. */
+    val item: AzNavItem?
+
+    /** Sets (or, with a null/blank [text], clears) the item's badge. */
+    fun setBadge(text: String?, persistent: Boolean = false)
+
+    /** Starts or stops the item's own loading animation. */
+    fun setLoading(loading: Boolean)
+
+    /** Flags the item, or clears the flag with null. A flagged item draws as the warning triangle. */
+    fun setAlert(alert: AzItemAlert?)
+
+    /** Drops everything this popup pushed onto the item, restoring what the DSL declared. */
+    fun clear()
+}
+
+/** What an [AzPopup]'s body is given: the request that opened it, its item, and a way out. */
+@Stable
+interface AzPopupScope {
+    val kind: AzPopupKind
+    val title: String?
+    val message: String?
+    val payload: Any?
+
+    /** The rail item that raised this popup, or null when it was raised without one. */
+    val item: AzPopupItemHandle?
+
+    /** Closes the popup (and reverts anything it did to [item] that it did not make permanent). */
+    fun dismiss()
+}
+
+/**
+ * Opens and closes an [AzPopup], and names the rail item it belongs to.
+ *
+ * Create one with [rememberAzPopupController], register a popup for it with `azPopup(controller)`
+ * in the host DSL, and raise it from anywhere — an item's `onClick`, a coroutine, a callback:
+ *
+ * ```
+ * val alerts = rememberAzPopupController()
+ * AzHostActivityLayout(navController = navController) {
+ *     azRailItem(id = "sync", text = "Sync") { alerts.show(itemId = "sync", title = "Syncing…") }
+ *     azPopup(alerts) {
+ *         Text(message ?: "")
+ *         AzButton(onClick = { item?.setLoading(false); dismiss() }, text = "Stop")
+ *     }
+ * }
+ * ```
+ */
+@Stable
+class AzPopupController {
+    /** The live request, or null when nothing is showing. */
+    var request: AzPopupRequest? by mutableStateOf(null)
+        private set
+
+    val isVisible: Boolean get() = request != null
+
+    /**
+     * Raises the popup.
+     *
+     * @param itemId The rail item this popup belongs to. Leave null to bind to the **last touched**
+     *   rail item, which is what makes an unattributed warning land on whatever the user just did.
+     */
+    fun show(
+        itemId: String? = null,
+        kind: AzPopupKind = AzPopupKind.INFO,
+        title: String? = null,
+        message: String? = null,
+        payload: Any? = null,
+    ) {
+        request = AzPopupRequest(itemId, kind, title, message, payload)
+    }
+
+    /** Closes the popup. */
+    fun dismiss() {
+        request = null
+    }
+}
+
+/** Creates the [AzPopupController] for one popup, surviving recomposition. */
+@Composable
+fun rememberAzPopupController(): AzPopupController = remember { AzPopupController() }
+
+/** Holds a popup registered via `AzNavHostScope.azPopup`. */
+internal data class AzPopupItem(
+    val controller: AzPopupController,
+    val dismissOnOutsideTap: Boolean,
+    val content: @Composable AzPopupScope.() -> Unit,
+)
+
+/** Writes an [AzPopup]'s changes into the rail scope's override map, keyed by item id. */
+internal class AzPopupItemHandleImpl(
+    override val id: String,
+    private val scope: AzNavRailScopeImpl,
+) : AzPopupItemHandle {
+
+    override val item: AzNavItem? get() = scope.navItems.firstOrNull { it.id == id }
+
+    private fun update(transform: (AzItemState) -> AzItemState) {
+        val current = scope.itemOverrides[id] ?: AzItemState()
+        scope.itemOverrides[id] = transform(current)
+    }
+
+    override fun setBadge(text: String?, persistent: Boolean) =
+        update { it.copy(badge = text, persistentBadge = persistent) }
+
+    override fun setLoading(loading: Boolean) = update { it.copy(isLoading = loading) }
+
+    override fun setAlert(alert: AzItemAlert?) = update { it.copy(alert = alert) }
+
+    override fun clear() {
+        scope.itemOverrides.remove(id)
+    }
+}
+
+/** The [AzPopupScope] handed to a popup's body. */
+internal class AzPopupScopeImpl(
+    private val request: AzPopupRequest,
+    override val item: AzPopupItemHandle?,
+    private val onDismiss: () -> Unit,
+) : AzPopupScope {
+    override val kind: AzPopupKind get() = request.kind
+    override val title: String? get() = request.title
+    override val message: String? get() = request.message
+    override val payload: Any? get() = request.payload
+    override fun dismiss() = onDismiss()
+}
+
+/**
+ * The built-in popup body: the request's title and message in the rail's own type, with a single
+ * "OK" that closes it. It is what `azPopup(controller)` renders when you don't supply a body.
+ */
+@Composable
+fun AzPopupScope.AzPopupBody() {
+    val accent = when (kind) {
+        AzPopupKind.INFO -> MaterialTheme.colorScheme.primary
+        AzPopupKind.NOTICE -> AzItemAlert.NOTICE.color()
+        AzPopupKind.WARNING -> AzItemAlert.WARNING.color()
+    }
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        title?.takeIf { it.isNotBlank() }?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                color = accent,
+                textAlign = TextAlign.Center,
+            )
+        }
+        message?.takeIf { it.isNotBlank() }?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+        }
+        AzButton(onClick = { dismiss() }, text = "OK", color = accent)
+    }
+}
+
+/**
+ * Renders one registered popup as a centred panel over a scrim.
+ *
+ * While a [AzPopupKind.NOTICE] / [AzPopupKind.WARNING] popup is up, the bound rail item is flagged
+ * — it redraws as a yellow rounded-corner triangle outline — and the flag is lifted again when the
+ * popup closes, so the item never keeps a warning it no longer owns.
+ */
+@Composable
+internal fun AzPopupHost(
+    popup: AzPopupItem,
+    railScope: AzNavRailScopeImpl,
+    modifier: Modifier = Modifier,
+) {
+    val request = popup.controller.request ?: return
+
+    // Resolve the bound item once per request: the explicit id if there is one, else whatever the
+    // user last touched.
+    val boundId = request.itemId ?: railScope.lastTouchedItemId
+    val handle = remember(boundId, railScope) {
+        boundId?.let { AzPopupItemHandleImpl(it, railScope) }
+    }
+
+    // The flag is owned by the popup's lifetime, not by the developer: raised with the request and
+    // dropped on dismissal (or when the popup leaves composition mid-flight).
+    DisposableEffect(request, handle) {
+        val alert = when (request.kind) {
+            AzPopupKind.INFO -> null
+            AzPopupKind.NOTICE -> AzItemAlert.NOTICE
+            AzPopupKind.WARNING -> AzItemAlert.WARNING
+        }
+        if (alert != null) handle?.setAlert(alert)
+        onDispose { if (alert != null) handle?.setAlert(null) }
+    }
+
+    val dismiss = { popup.controller.dismiss() }
+    val scope = remember(request, handle) { AzPopupScopeImpl(request, handle, dismiss) }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.45f))
+            .pointerInput(popup.dismissOnOutsideTap) {
+                detectTapGestures {
+                    if (popup.dismissOnOutsideTap) dismiss()
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            modifier = Modifier
+                .padding(24.dp)
+                .widthIn(max = 420.dp)
+                // Swallow taps on the panel itself so they don't reach the dismissing scrim.
+                .pointerInput(Unit) { detectTapGestures { } },
+            color = MaterialTheme.colorScheme.surface,
+            shape = RoundedCornerShape(12.dp),
+            tonalElevation = 2.dp,
+            shadowElevation = 8.dp,
+            border = BorderStroke(
+                width = 2.dp,
+                color = when (request.kind) {
+                    AzPopupKind.INFO -> railScope.activeColor.takeOrElse { MaterialTheme.colorScheme.primary }
+                    AzPopupKind.NOTICE -> AzItemAlert.NOTICE.color()
+                    AzPopupKind.WARNING -> AzItemAlert.WARNING.color()
+                },
+            ),
+        ) {
+            Box(modifier = Modifier.padding(24.dp)) {
+                popup.content(scope)
+            }
+        }
+    }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzShapes.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzShapes.kt
@@ -1,0 +1,104 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.hereliesaz.aznavrail.model.AzButtonShape
+import com.hereliesaz.aznavrail.model.AzItemAlert
+import kotlin.math.min
+import kotlin.math.sqrt
+
+/**
+ * An upward-pointing triangle with rounded corners, inscribed in the button's box — the glyph a rail
+ * item turns into while it owns a notice or warning popup.
+ *
+ * Each corner is cut back along both of its edges by [cornerRadius] and bridged with a quadratic
+ * curve through the original vertex, which is the cheap, well-behaved way to round an arbitrary
+ * polygon: no arc-centre trigonometry, and the curve stays inside the untouched triangle.
+ */
+internal data class AzRoundedTriangleShape(val cornerRadius: Dp = 6.dp) : Shape {
+
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ): Outline {
+        val radiusPx = with(density) { cornerRadius.toPx() }
+        return Outline.Generic(roundedTrianglePath(size, radiusPx))
+    }
+}
+
+/** The rounded-triangle [Path] for a box of [size], corners cut back by [radiusPx]. */
+internal fun roundedTrianglePath(size: Size, radiusPx: Float): Path {
+    val apex = Offset(size.width / 2f, 0f)
+    val bottomRight = Offset(size.width, size.height)
+    val bottomLeft = Offset(0f, size.height)
+    val vertices = listOf(apex, bottomRight, bottomLeft)
+
+    val path = Path()
+    if (size.width <= 0f || size.height <= 0f) return path
+
+    // Never cut back more than half an edge, or adjacent corners would overrun each other on a
+    // button small enough that the radius rivals the triangle's own edges.
+    fun distance(a: Offset, b: Offset): Float {
+        val dx = b.x - a.x
+        val dy = b.y - a.y
+        return sqrt(dx * dx + dy * dy)
+    }
+
+    fun towards(from: Offset, to: Offset, by: Float): Offset {
+        val length = distance(from, to)
+        if (length == 0f) return from
+        val t = (by / length).coerceIn(0f, 0.5f)
+        return Offset(from.x + (to.x - from.x) * t, from.y + (to.y - from.y) * t)
+    }
+
+    val shortestEdge = minOf(
+        distance(vertices[0], vertices[1]),
+        distance(vertices[1], vertices[2]),
+        distance(vertices[2], vertices[0]),
+    )
+    val cut = min(radiusPx, shortestEdge / 2f)
+
+    vertices.forEachIndexed { index, vertex ->
+        val previous = vertices[(index + vertices.size - 1) % vertices.size]
+        val next = vertices[(index + 1) % vertices.size]
+        val entry = towards(vertex, previous, cut)
+        val exit = towards(vertex, next, cut)
+        if (index == 0) path.moveTo(entry.x, entry.y) else path.lineTo(entry.x, entry.y)
+        path.quadraticTo(vertex.x, vertex.y, exit.x, exit.y)
+    }
+    path.close()
+    return path
+}
+
+/**
+ * The Compose [Shape] an [AzButtonShape] draws as — the single mapping every call site shares, so a
+ * new member (like [AzButtonShape.TRIANGLE]) can never be silently missed by one of them.
+ */
+internal fun AzButtonShape.toComposeShape(): Shape = when (this) {
+    AzButtonShape.CIRCLE -> CircleShape
+    AzButtonShape.SQUARE -> RectangleShape
+    AzButtonShape.RECTANGLE -> RectangleShape
+    AzButtonShape.TRIANGLE -> AzRoundedTriangleShape()
+    AzButtonShape.NONE -> RectangleShape
+}
+
+/**
+ * The stroke colour for an alerted item. Both levels are yellow — a notice sits back in amber, a
+ * warning comes forward in a saturated hazard yellow — so either reads instantly as "look at me"
+ * against the rail's normal accent.
+ */
+internal fun AzItemAlert.color(): Color = when (this) {
+    AzItemAlert.NOTICE -> Color(0xFFFFC107)
+    AzItemAlert.WARNING -> Color(0xFFFFD400)
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzTitleTriggers.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzTitleTriggers.kt
@@ -1,0 +1,198 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.hereliesaz.aznavrail.model.AzDropdownTrigger
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.MoreVert
+import com.hereliesaz.aznavrail.model.AzHeaderIconShape
+import kotlin.math.roundToInt
+
+/**
+ * The stable, comparable description of a drop-down's trigger.
+ *
+ * Every field is an immutable value, so a slot's spec can be re-published on each recomposition and
+ * compared away when nothing changed — which is what keeps the title-hosted trigger from looping the
+ * host's composition. Behaviour (the tap handler, the bounds reporter) deliberately lives on
+ * [AzTitleTriggerSlot] as plain fields instead, because those are only read from event callbacks.
+ */
+internal data class AzDropdownTriggerSpec(
+    val trigger: AzDropdownTrigger = AzDropdownTrigger.MoreVert,
+    val size: Dp = 40.dp,
+    val iconShape: AzHeaderIconShape = AzHeaderIconShape.CIRCLE,
+    /** Resolved launcher icon model, used only by [AzDropdownTrigger.AppIcon]. */
+    val appIcon: Any? = null,
+    /** Accent applied to the glyph / label. [Color.Unspecified] falls back to the theme primary. */
+    val color: Color = Color.Unspecified,
+    /** Optional style merged over an [AzDropdownTrigger.Text] trigger's default. */
+    val textStyle: TextStyle? = null,
+    val contentDescription: String = "Menu",
+)
+
+/**
+ * One drop-down's claim on a slot in the screen-title row.
+ *
+ * The drop-down composable owns its own open-state and renders its own panel where it is declared;
+ * only the trigger is relocated. It publishes [spec] (snapshot state, so the title row redraws when
+ * the trigger's look changes) and keeps [onTap] / [onBounds] refreshed as plain fields, so the title
+ * row's button always calls back into the drop-down's current composition.
+ */
+internal class AzTitleTriggerSlot {
+    var spec: AzDropdownTriggerSpec by mutableStateOf(AzDropdownTriggerSpec())
+
+    /** Opens/closes the owning drop-down. Read only from the click handler, never during composition. */
+    var onTap: () -> Unit = {}
+
+    /** Reports the trigger's window-space bounds so the owning drop-down can anchor its panel there. */
+    var onBounds: (IntRect) -> Unit = {}
+
+    /** Publishes [next] only when it actually differs, so equal re-publishes cost no recomposition. */
+    fun publish(next: AzDropdownTriggerSpec) {
+        if (spec != next) spec = next
+    }
+}
+
+/**
+ * Draws one trigger and wires its tap + bounds reporting.
+ *
+ * Used for both placements: the screen-title row renders one of these per registered slot, and an
+ * `INLINE` drop-down renders one at its own call site. Either way the drop-down learns where its
+ * trigger ended up, so the dropped panel is positioned against the real thing.
+ */
+@Composable
+internal fun AzDropdownTriggerButton(
+    slot: AzTitleTriggerSlot,
+    modifier: Modifier = Modifier,
+) {
+    val spec = slot.spec
+    val accent = spec.color.takeOrElse { MaterialTheme.colorScheme.primary }
+    val clipShape: Shape? = when (spec.iconShape) {
+        AzHeaderIconShape.CIRCLE -> CircleShape
+        AzHeaderIconShape.ROUNDED -> RoundedCornerShape(12.dp)
+        else -> null
+    }
+    val clipModifier = if (clipShape != null) Modifier.clip(clipShape) else Modifier
+
+    val boundsModifier = Modifier.onGloballyPositioned { coordinates ->
+        val pos = coordinates.positionInWindow()
+        val size = coordinates.size
+        slot.onBounds(
+            IntRect(
+                left = pos.x.roundToInt(),
+                top = pos.y.roundToInt(),
+                right = pos.x.roundToInt() + size.width,
+                bottom = pos.y.roundToInt() + size.height,
+            )
+        )
+    }
+
+    // A text trigger sizes to its own label; every icon trigger is a square of `spec.size`.
+    val sizeModifier =
+        if (spec.trigger is AzDropdownTrigger.Text) Modifier else Modifier.size(spec.size)
+
+    Box(
+        modifier = modifier
+            // Automatic breathing room so neighbouring triggers (and the title) never sit flush.
+            .padding(AzNavRailDefaults.HeaderPadding)
+            .then(sizeModifier)
+            .then(clipModifier)
+            .then(boundsModifier)
+            .clickable { slot.onTap() }
+            .semantics(mergeDescendants = true) { contentDescription = spec.contentDescription },
+        contentAlignment = Alignment.Center,
+    ) {
+        when (val trigger = spec.trigger) {
+            is AzDropdownTrigger.Text -> Text(
+                text = trigger.text,
+                style = MaterialTheme.typography.titleLarge.merge(spec.textStyle),
+                color = accent,
+                maxLines = 1,
+                softWrap = false,
+            )
+
+            is AzDropdownTrigger.Icon -> when (val model = trigger.model) {
+                is ImageVector -> Icon(
+                    imageVector = model,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.fillMaxSize(),
+                )
+
+                is Painter -> Image(
+                    painter = model,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize().then(clipModifier),
+                )
+
+                else -> Image(
+                    painter = rememberAsyncImagePainter(model),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize().then(clipModifier),
+                )
+            }
+
+            AzDropdownTrigger.AppIcon -> {
+                val appIcon = spec.appIcon
+                if (appIcon != null) {
+                    Image(
+                        painter = rememberAsyncImagePainter(appIcon),
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize().then(clipModifier),
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Filled.Menu,
+                        contentDescription = null,
+                        tint = accent,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+
+            AzDropdownTrigger.Hamburger -> Icon(
+                imageVector = Icons.Filled.Menu,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.fillMaxSize(),
+            )
+
+            AzDropdownTrigger.MoreVert -> Icon(
+                imageVector = Icons.Filled.MoreVert,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzUnattachedRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzUnattachedRail.kt
@@ -1,0 +1,362 @@
+package com.hereliesaz.aznavrail.internal
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import androidx.navigation.NavController
+import com.hereliesaz.aznavrail.AzNavRailScopeImpl
+import com.hereliesaz.aznavrail.model.AzDockingSide
+import com.hereliesaz.aznavrail.model.AzNavItem
+import com.hereliesaz.aznavrail.model.AzUnattachedAnchor
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/**
+ * Every id in the unattached hosts' subtrees — the hosts themselves plus their sub-items to any
+ * depth. The rail strip and the drawer filter these out, because an unattached host has left the
+ * rail: it draws itself (and unfolds its children) wherever its anchor puts it.
+ */
+internal fun azUnattachedSubtreeIds(items: List<AzNavItem>): Set<String> {
+    val roots = items.filter { it.isUnattached }.map { it.id }
+    if (roots.isEmpty()) return emptySet()
+    val ids = roots.toMutableSet()
+    // Sub-items reference their host by id, so one sweep per level resolves the whole tree. Bounded
+    // by the item count, which also stops a malformed cycle from spinning forever.
+    repeat(items.size) {
+        val grew = items.any { it.isSubItem && it.hostId in ids && ids.add(it.id) }
+        if (!grew) return ids
+    }
+    return ids
+}
+
+/**
+ * Draws the [AzUnattachedAnchor] stacks — the rail host items declared with `azUnattachedHostItem`,
+ * which live outside the rail strip.
+ *
+ * Hosts sharing an anchor stack into a column in declaration order, spaced exactly like rail items
+ * (and packed when the rail is packed). Tapping one unfolds its sub-items inline beneath it, and
+ * sub-hosts nest to any depth, matching the rail's accordion behaviour.
+ *
+ * @param scope The rail scope supplying items, callbacks and theme tokens.
+ * @param visualDockingSide The side the rail is currently drawn on; the [AzUnattachedAnchor.BOTTOM]
+ *   and [AzUnattachedAnchor.OPPOSITE] stacks park on the other one.
+ */
+@Composable
+internal fun AzUnattachedRail(
+    scope: AzNavRailScopeImpl,
+    navController: NavController?,
+    currentDestination: String?,
+    visualDockingSide: AzDockingSide,
+    modifier: Modifier = Modifier,
+) {
+    val unattached = scope.navItems.filter { it.isUnattached }
+    if (unattached.isEmpty()) return
+
+    val density = LocalDensity.current
+    val context = LocalContext.current
+    val configuration = LocalConfiguration.current
+    val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
+    val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
+    val coroutineScope = rememberCoroutineScope()
+
+    // Expansion state is owned here, not by the rail: an unattached host is not in the rail's
+    // hostStates map and must keep unfolding even while the rail's own menu is closed.
+    val hostStates = remember { mutableStateMapOf<String, Boolean>() }
+    val initiallyExpandedSeen = remember { mutableMapOf<String, Boolean>() }
+    val expandWhenSeen = remember { mutableMapOf<String, Boolean>() }
+    val cyclerJobs = remember { mutableStateMapOf<String, Job>() }
+
+    val subtreeIds = remember(scope.navItems.toList()) { azUnattachedSubtreeIds(scope.navItems) }
+
+    // Rising-edge auto-expand, mirroring the rail: expand when `initiallyExpanded` flips true, then
+    // leave the user alone.
+    LaunchedEffect(scope.navItems) {
+        scope.navItems.forEach { item ->
+            if (item.isHost && item.id in subtreeIds) {
+                if (item.initiallyExpanded && initiallyExpandedSeen[item.id] != true) {
+                    hostStates[item.id] = true
+                }
+                initiallyExpandedSeen[item.id] = item.initiallyExpanded
+            }
+        }
+    }
+
+    // Reactive expansion for unattached hosts — same edge-triggered contract as the rail's, and the
+    // same snapshot-plus-poll observation so plain (non-snapshot) sources still drive it.
+    val expandWhenKeys = scope.expandWhenMap.keys.filter { it in subtreeIds }.sorted().joinToString(",")
+    LaunchedEffect(expandWhenKeys) {
+        scope.expandWhenMap.toMap().forEach { (id, cond) ->
+            if (id !in subtreeIds) return@forEach
+            launch {
+                merge(
+                    snapshotFlow { cond() },
+                    flow { while (true) { emit(cond()); delay(300) } },
+                ).distinctUntilChanged().collect { conditionNow ->
+                    val before = expandWhenSeen[id]
+                    when {
+                        before == null -> if (conditionNow) hostStates[id] = true
+                        before != conditionNow -> hostStates[id] = conditionNow
+                    }
+                    expandWhenSeen[id] = conditionNow
+                }
+            }
+        }
+    }
+
+    val buttonSize = if (scope.railItemWidth.isSpecified) scope.railItemWidth else AzNavRailDefaults.ButtonWidth
+    val spacing = if (scope.packButtons) 0.dp else AzNavRailDefaults.RailContentVerticalArrangement
+    val railOnLeft = visualDockingSide == AzDockingSide.LEFT
+    val safeInset = with(density) { (screenHeightPx * 0.1f).toDp() }
+
+    val onCyclerClick: (AzNavItem) -> Unit = { item ->
+        if (!item.disabled) {
+            cyclerJobs[item.id]?.cancel()
+            val options = item.options ?: emptyList()
+            val enabled = options.filterNot { it in (item.disabledOptions ?: emptyList()) }
+            if (enabled.isNotEmpty()) {
+                val current = scope.transientCyclerOptions[item.id] ?: item.selectedOption
+                val next = enabled[(enabled.indexOf(current) + 1).mod(enabled.size)]
+                scope.transientCyclerOptions[item.id] = next
+                // Commit after the same 1s "stop" window the rail's cyclers use.
+                cyclerJobs[item.id] = coroutineScope.launch {
+                    delay(1000L)
+                    scope.onClickMap[item.id]?.invoke()
+                    cyclerJobs.remove(item.id)
+                }
+            }
+            scope.advancedConfig.onInteraction?.invoke(item.id, item)
+        }
+    }
+
+    val byAnchor = unattached.groupBy { it.unattachedAnchor ?: AzUnattachedAnchor.OPPOSITE }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        byAnchor[AzUnattachedAnchor.OPPOSITE]?.let { hosts ->
+            UnattachedStack(
+                hosts = hosts,
+                modifier = Modifier
+                    .align(if (railOnLeft) Alignment.TopEnd else Alignment.TopStart)
+                    .padding(top = safeInset, bottom = safeInset),
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                spacingDp = spacing,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+
+        byAnchor[AzUnattachedAnchor.BOTTOM]?.let { hosts ->
+            UnattachedStack(
+                hosts = hosts,
+                modifier = Modifier
+                    .align(if (railOnLeft) Alignment.BottomEnd else Alignment.BottomStart)
+                    .padding(top = safeInset, bottom = safeInset),
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                spacingDp = spacing,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+
+        byAnchor[AzUnattachedAnchor.FLOATING]?.let { hosts ->
+            // The live position is kept in pixels for the drag and persisted as a window fraction,
+            // so it survives rotation and lands sensibly on a different screen size.
+            var stackSize by remember { mutableStateOf(IntSize.Zero) }
+            var position by remember { mutableStateOf<Offset?>(null) }
+
+            val minY = screenHeightPx * 0.1f
+            val maxY = maxOf(minY, screenHeightPx * 0.9f - stackSize.height)
+            val maxX = maxOf(0f, screenWidthPx - stackSize.width)
+
+            // Resolve the position once the stack has been measured: the persisted spot when there
+            // is one, otherwise parked against the edge opposite the rail. Re-clamped afterwards so
+            // a rotation, a resize, or an unfolding host can't strand it outside the safe zone.
+            LaunchedEffect(stackSize, screenWidthPx, screenHeightPx) {
+                if (stackSize == IntSize.Zero) return@LaunchedEffect
+                val settled = position
+                position = if (settled == null) {
+                    val saved = AzUnattachedStore.load(context)
+                    if (saved != null) {
+                        Offset(
+                            (saved.first * screenWidthPx).coerceIn(0f, maxX),
+                            (saved.second * screenHeightPx).coerceIn(minY, maxY),
+                        )
+                    } else {
+                        Offset(if (railOnLeft) maxX else 0f, minY)
+                    }
+                } else {
+                    Offset(settled.x.coerceIn(0f, maxX), settled.y.coerceIn(minY, maxY))
+                }
+            }
+
+            UnattachedStack(
+                hosts = hosts,
+                modifier = Modifier
+                    .wrapContentSize(Alignment.TopStart, unbounded = true)
+                    .offset {
+                        val p = position
+                        IntOffset(p?.x?.roundToInt() ?: 0, p?.y?.roundToInt() ?: 0)
+                    }
+                    .onGloballyPositioned { stackSize = it.size }
+                    .pointerInput(minY, maxY, maxX) {
+                        detectDragGestures(
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                val base = position ?: Offset(0f, minY)
+                                position = Offset(
+                                    (base.x + dragAmount.x).coerceIn(0f, maxX),
+                                    (base.y + dragAmount.y).coerceIn(minY, maxY),
+                                )
+                            },
+                            onDragEnd = {
+                                val settled = position
+                                if (settled != null && screenWidthPx > 0f && screenHeightPx > 0f) {
+                                    AzUnattachedStore.save(
+                                        context,
+                                        settled.x / screenWidthPx,
+                                        settled.y / screenHeightPx,
+                                    )
+                                }
+                            },
+                        )
+                    },
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                spacingDp = spacing,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+    }
+}
+
+/** One anchor's column of unattached hosts, each unfolding its own sub-items beneath it. */
+@Composable
+private fun UnattachedStack(
+    hosts: List<AzNavItem>,
+    modifier: Modifier,
+    scope: AzNavRailScopeImpl,
+    navController: NavController?,
+    currentDestination: String?,
+    hostStates: MutableMap<String, Boolean>,
+    buttonSize: Dp,
+    spacingDp: Dp,
+    onCyclerClick: (AzNavItem) -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(spacingDp),
+    ) {
+        hosts.forEach { host ->
+            UnattachedNode(
+                item = host,
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+    }
+}
+
+/**
+ * One unattached item — plus, when it is an expanded host, its rail sub-items beneath it. Emitted
+ * flat into the enclosing stack's [Column] so a host and its children share the rail's spacing.
+ */
+@Composable
+private fun UnattachedNode(
+    item: AzNavItem,
+    scope: AzNavRailScopeImpl,
+    navController: NavController?,
+    currentDestination: String?,
+    hostStates: MutableMap<String, Boolean>,
+    buttonSize: Dp,
+    onCyclerClick: (AzNavItem) -> Unit,
+) {
+    // A cycler shows its transient option while the commit window is still running, exactly as it
+    // does on the rail.
+    val displayItem =
+        if (item.isCycler) item.copy(selectedOption = scope.transientCyclerOptions[item.id] ?: item.selectedOption)
+        else item
+
+    RailContent(
+        defaultShape = scope.defaultShape,
+        item = displayItem,
+        navController = navController,
+        isSelected = (item.route != null && item.route == currentDestination) ||
+            item.classifiers.any { scope.activeClassifiers.contains(it) },
+        buttonSize = buttonSize,
+        onClick = {
+            scope.lastTouchedItemId = item.id
+            scope.onClickMap[item.id]?.invoke()
+        },
+        onRailCyclerClick = onCyclerClick,
+        onItemClick = { scope.advancedConfig.onInteraction?.invoke(item.id, item) },
+        onHostClick = {
+            val expanded = !(hostStates[item.id] ?: false)
+            hostStates[item.id] = expanded
+            scope.onExpandedChangeMap[item.id]?.invoke(expanded)
+        },
+        onItemGloballyPositioned = scope.advancedConfig.onItemGloballyPositioned,
+        onBoundsCalculated = { id, bounds -> scope.itemBoundsCache[id] = bounds },
+        onBoundsCleared = { id -> scope.itemBoundsCache.remove(id) },
+        activeColor = scope.activeColor,
+    )
+
+    if (item.isHost && hostStates[item.id] == true) {
+        val children = scope.navItems.filter { it.isSubItem && it.hostId == item.id && it.isRailItem }
+        children.forEach { child ->
+            UnattachedNode(
+                item = child,
+                scope = scope,
+                navController = navController,
+                currentDestination = currentDestination,
+                hostStates = hostStates,
+                buttonSize = buttonSize,
+                onCyclerClick = onCyclerClick,
+            )
+        }
+    }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzUnattachedStore.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/AzUnattachedStore.kt
@@ -1,0 +1,36 @@
+package com.hereliesaz.aznavrail.internal
+
+import android.content.Context
+
+/**
+ * Persistence for the [com.hereliesaz.aznavrail.model.AzUnattachedAnchor.FLOATING] stack's position.
+ *
+ * The position is stored as a **fraction of the window** rather than raw pixels, so a stack dropped
+ * near the right edge comes back near the right edge after a rotation, a resize, or on a different
+ * device. Backed by a private `SharedPreferences`, the same way the guidance controller persists
+ * which tutorials have been completed.
+ */
+internal object AzUnattachedStore {
+
+    private const val PREFS_NAME = "aznavrail_unattached"
+    private const val KEY = "floating_pos"
+
+    /** The saved position as `x` / `y` fractions of the window, or null when nothing is saved yet. */
+    fun load(context: Context): Pair<Float, Float>? {
+        val raw = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY, null) ?: return null
+        val parts = raw.split(',')
+        if (parts.size != 2) return null
+        val x = parts[0].toFloatOrNull() ?: return null
+        val y = parts[1].toFloatOrNull() ?: return null
+        return x.coerceIn(0f, 1f) to y.coerceIn(0f, 1f)
+    }
+
+    /** Saves [xFraction] / [yFraction] (both 0..1) as the floating stack's home. */
+    fun save(context: Context, xFraction: Float, yFraction: Float) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY, "${xFraction.coerceIn(0f, 1f)},${yFraction.coerceIn(0f, 1f)}")
+            .apply()
+    }
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MenuItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/MenuItem.kt
@@ -172,10 +172,13 @@ internal fun MenuItem(
     val effectiveActiveColor = activeColor ?: MaterialTheme.colorScheme.primary
     val effectiveDefaultColor = item.textColor ?: item.color ?: MaterialTheme.colorScheme.primary
 
+    // A menu row is type, not a button, so an alerted item can't become a triangle here — it takes
+    // the same warning yellow instead, so the drawer and the rail agree about which item is flagged.
+    val alertColor = item.alert?.color()
     val textColor = if (isDisabled) {
-        effectiveDefaultColor.copy(alpha = 0.5f)
+        (alertColor ?: effectiveDefaultColor).copy(alpha = 0.5f)
     } else {
-        effectiveDefaultColor
+        alertColor ?: effectiveDefaultColor
     }
 
     val backgroundColor = if (isSelected && !isPressed) {
@@ -275,6 +278,16 @@ internal fun MenuItem(
                         }
                     }
                 }
+            }
+
+            // Per-item loading: the row keeps its label and spins a small ring beside it, rather
+            // than the whole rail being replaced by one global spinner.
+            if (item.isLoading) {
+                com.hereliesaz.aznavrail.AzLoad(
+                    size = 20.dp,
+                    color = textColor,
+                    showLabel = false,
+                )
             }
 
             var showBadge by remember { mutableStateOf(false) }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/NestedRail.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/NestedRail.kt
@@ -141,6 +141,7 @@ private fun NestedItemWrapper(
                 ),
             )
         }) {
+            val alert = item.alert
             AzNavRailButton(
                 onClick = {
                     if (item.isHost) {
@@ -152,17 +153,40 @@ private fun NestedItemWrapper(
                     }
                 },
                 text = item.text,
-                color = item.color ?: MaterialTheme.colorScheme.onSurface,
-                activeColor = activeColor,
-                textColor = item.textColor,
+                color = alert?.color() ?: item.color ?: MaterialTheme.colorScheme.onSurface,
+                activeColor = alert?.color() ?: activeColor,
+                textColor = if (alert != null) alert.color() else item.textColor,
                 fillColor = item.fillColor,
-                shape = item.shape ?: AzButtonShape.CIRCLE,
+                shape = if (alert != null) AzButtonShape.TRIANGLE else (item.shape ?: AzButtonShape.CIRCLE),
                 size = AzNavRailDefaults.ButtonWidth,
                 enabled = !item.disabled,
                 isSelected = (item.route != null && currentDestination == item.route) || item.classifiers.any { activeClassifiers.contains(it) },
-                itemContent = item.content,
+                isLoading = item.isLoading,
+                itemContent = if (alert != null) null else item.content,
                 rotationDegrees = rotationDegrees
             )
+
+            // Nested-rail children carry badges too — they are rail items like any other, and used
+            // to be the one place a declared badge was silently dropped.
+            val showBadge = androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+            androidx.compose.runtime.LaunchedEffect(item.badge) {
+                if (!item.badge.isNullOrBlank()) {
+                    showBadge.value = true
+                    if (!item.persistentBadge) {
+                        kotlinx.coroutines.delay(1000)
+                        showBadge.value = false
+                    }
+                } else {
+                    showBadge.value = false
+                }
+            }
+            if (showBadge.value && !item.badge.isNullOrBlank()) {
+                com.hereliesaz.aznavrail.AzBadge(
+                    text = item.badge,
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    containerColor = item.color ?: activeColor,
+                )
+            }
         }
 
         if (item.isHost && hostStates[item.id] == true) {

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/RailContent.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/internal/RailContent.kt
@@ -153,19 +153,24 @@ internal fun RailContent(
                 containerColor = item.color ?: activeColor ?: MaterialTheme.colorScheme.primary,
             )
         }
+        // While an item owns a notice/warning popup it stops being itself and becomes the alert
+        // glyph: a yellow, rounded-corner triangle outline. Everything else about it is untouched,
+        // and it reverts the instant the popup is dismissed.
+        val alert = item.alert
         AzNavRailButton(
             onClick = finalOnClick,
             text = textToShow,
             modifier = Modifier,
-            color = item.color ?: MaterialTheme.colorScheme.primary,
-            activeColor = activeColor ?: MaterialTheme.colorScheme.primary,
-            textColor = item.textColor,
+            color = alert?.color() ?: item.color ?: MaterialTheme.colorScheme.primary,
+            activeColor = alert?.color() ?: activeColor ?: MaterialTheme.colorScheme.primary,
+            textColor = if (alert != null) alert.color() else item.textColor,
             fillColor = item.fillColor,
             size = buttonSize,
-            shape = item.shape ?: defaultShape,
+            shape = if (alert != null) AzButtonShape.TRIANGLE else (item.shape ?: defaultShape),
             enabled = isEnabled,
             isSelected = isSelected,
-            itemContent = item.content,
+            isLoading = item.isLoading,
+            itemContent = if (alert != null) null else item.content,
             rotationDegrees = rotationDegrees
         )
     }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzButtonShape.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzButtonShape.kt
@@ -8,6 +8,12 @@ enum class AzButtonShape {
     SQUARE,
     /** Renders as a fixed-height wide rectangle (typically for text labels). */
     RECTANGLE,
+    /**
+     * Renders as an upward-pointing triangle outline with rounded corners — the warning glyph a rail
+     * item takes on while it owns a notice/warning [com.hereliesaz.aznavrail.AzPopup]. Available as
+     * an ordinary item shape too.
+     */
+    TRIANGLE,
     /** No border is drawn; the button is still interactive but visually borderless. */
     NONE
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzDropdownTrigger.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzDropdownTrigger.kt
@@ -1,0 +1,50 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * What the user taps to open an [com.hereliesaz.aznavrail.AzDropdownMenu].
+ *
+ * In AzNavRail tradition the trigger is not a free composable slot — it is one of the sanctioned
+ * shapes below. The default is [MoreVert] (the three vertical dots), so a drop-down declared with no
+ * configuration reads as a menu affordance rather than as the app's launcher icon.
+ */
+sealed interface AzDropdownTrigger {
+    /** The Material "more" glyph — three vertical dots. The default. */
+    data object MoreVert : AzDropdownTrigger
+
+    /** The hamburger glyph (three stacked bars). */
+    data object Hamburger : AzDropdownTrigger
+
+    /**
+     * The host app's launcher icon, drawn exactly like the rail's header. This was the only trigger
+     * before triggers were configurable; pass it to keep that look.
+     */
+    data object AppIcon : AzDropdownTrigger
+
+    /** A word (or two) that hosts the menu, drawn in the screen title's accent. */
+    data class Text(val text: String) : AzDropdownTrigger
+
+    /**
+     * A developer-supplied icon. [model] accepts the same values a rail item's `content` does — a
+     * Compose `ImageVector` or `Painter`, an image URL, or any other Coil-compatible model.
+     */
+    data class Icon(val model: Any) : AzDropdownTrigger
+}
+
+/** Where an [com.hereliesaz.aznavrail.AzDropdownMenu]'s trigger is drawn. */
+enum class AzDropdownTriggerPlacement {
+    /**
+     * [TITLE] when the drop-down is declared inside an `AzHostActivityLayout` (the usual case — a
+     * drop-down declared in an `onscreen { … }` block), [INLINE] otherwise. The default.
+     */
+    AUTO,
+
+    /**
+     * The trigger is lifted out of the call site and drawn next to the big screen title, above the
+     * onscreen content area. Several drop-downs hosted this way line their triggers up beside each
+     * other in declaration order.
+     */
+    TITLE,
+
+    /** The trigger is drawn where the composable is called, like any other widget. */
+    INLINE,
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzItemAlert.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzItemAlert.kt
@@ -1,0 +1,16 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * The alert styling applied to the rail item that raised an [com.hereliesaz.aznavrail.AzPopup].
+ *
+ * Both levels redraw the item as a **yellow, rounded-corner triangle outline** — the universal
+ * "something wants your attention" glyph — and both revert the moment the popup is dismissed.
+ * They differ only in shade, so a warning reads louder than a notice.
+ */
+enum class AzItemAlert {
+    /** Informational. Drawn in a softer amber. */
+    NOTICE,
+
+    /** Something is wrong. Drawn in a full, saturated warning yellow. */
+    WARNING,
+}

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzItemConfig.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzItemConfig.kt
@@ -48,5 +48,11 @@ data class AzItemConfig(
     /** Optional short badge text drawn in a small circle on the item's button corner. */
     val badge: String? = null,
     /** Whether the badge should remain permanently visible (true) or dissolve after 1 second (false). */
-    val persistentBadge: Boolean = false
+    val persistentBadge: Boolean = false,
+    /** When true, this item's button spins its own loading animation in place of its content. */
+    val isLoading: Boolean = false,
+    /** Marks a host declared with `azUnattachedHostItem`, which lives outside the rail strip. */
+    val isUnattached: Boolean = false,
+    /** Where an [isUnattached] host parks. Ignored for every other item. */
+    val unattachedAnchor: AzUnattachedAnchor? = null
 )

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzItemState.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzItemState.kt
@@ -1,0 +1,17 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * Per-item state layered on top of an already-declared item — the badge it carries, whether it is
+ * spinning its own loading animation, and whether a popup has flagged it.
+ *
+ * Every field is nullable and means "leave whatever the item already had". That is what lets
+ * `azItemState(id = "sync", isLoading = true)` set the spinner without also clearing the badge, and
+ * what lets an [com.hereliesaz.aznavrail.AzPopupController]'s override sit on top of a declared
+ * state without erasing the parts it doesn't care about.
+ */
+data class AzItemState(
+    val badge: String? = null,
+    val persistentBadge: Boolean? = null,
+    val isLoading: Boolean? = null,
+    val alert: AzItemAlert? = null,
+)

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzNavItem.kt
@@ -95,7 +95,26 @@ data class AzNavItem(
     val nestedRailAlignment: AzNestedRailAlignment? = null,
     val nestedRailItems: List<AzNavItem>? = null,
     val isHelpItem: Boolean = false,
-    val keepNestedRailOpen: Boolean = false
+    val keepNestedRailOpen: Boolean = false,
+    /**
+     * Per-item loading state. When true this item's button hides its content and spins its own
+     * [com.hereliesaz.aznavrail.AzLoad] in place — every rail item is its own loading animation,
+     * rather than the whole app being blocked by one global spinner.
+     */
+    val isLoading: Boolean = false,
+    /**
+     * Transient alert styling. Set by an [com.hereliesaz.aznavrail.AzPopupController] on the item
+     * that raised a notice/warning popup, which redraws it as a yellow rounded-corner triangle
+     * outline for as long as the popup is up. Null is the item's normal appearance.
+     */
+    val alert: AzItemAlert? = null,
+    /**
+     * True for a host declared with `azUnattachedHostItem`: it is a rail host that does NOT live in
+     * the rail strip. It is drawn on its own at [unattachedAnchor] and unfolds its sub-items there.
+     */
+    val isUnattached: Boolean = false,
+    /** Where an [isUnattached] host parks. Null (and ignored) for every other item. */
+    val unattachedAnchor: AzUnattachedAnchor? = null
 ) : Parcelable {
     companion object {
         /**
@@ -113,6 +132,7 @@ data class AzNavItem(
             shape: AzButtonShape? = null,
             badge: String? = null,
             persistentBadge: Boolean = false,
+            isLoading: Boolean = false,
         ): AzNavItem = AzNavItem(
             id = id,
             text = text,
@@ -126,6 +146,7 @@ data class AzNavItem(
             shape = shape,
             badge = badge,
             persistentBadge = persistentBadge,
+            isLoading = isLoading,
         )
     }
 }

--- a/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzUnattachedAnchor.kt
+++ b/aznavrail/src/main/java/com/hereliesaz/aznavrail/model/AzUnattachedAnchor.kt
@@ -1,0 +1,25 @@
+package com.hereliesaz.aznavrail.model
+
+/**
+ * Where an **unattached host rail item** (`azUnattachedHostItem`) parks itself.
+ *
+ * An unattached host is a rail host item that does not live in the [com.hereliesaz.aznavrail.AzNavRail]
+ * strip. It is drawn as its own free-standing button somewhere else on the screen; tapping it unfolds
+ * its sub-items (declared the usual way, with `hostId` pointing at it) beneath it, exactly as they
+ * would have unfolded inside the rail. Several unattached hosts sharing an anchor stack into a
+ * column, again exactly as they would have stacked in the rail.
+ */
+enum class AzUnattachedAnchor {
+    /** The bottom of the screen, on the side opposite the rail. */
+    BOTTOM,
+
+    /** The side opposite the rail, at the same height the rail's own items start. */
+    OPPOSITE,
+
+    /**
+     * Free-floating and draggable. The stack's position is persisted, so it comes back where the
+     * user left it on the next launch. It is clamped to the same 10%–90% vertical safe zone the
+     * rail's FAB mode uses.
+     */
+    FLOATING,
+}

--- a/docs/AZNAVRAIL_COMPLETE_GUIDE.md
+++ b/docs/AZNAVRAIL_COMPLETE_GUIDE.md
@@ -184,10 +184,34 @@ const settings: AzNavRailSettings = {
 
 A hamburger drop-down is **not** a rail mode — it is a standalone widget, `AzDropdownMenu`, declared
 with the **same opinionated DSL as the rail**. In AzNavRail tradition it accepts only the
-configuration the rest of the library sanctions (no arbitrary panel background, offsets, icon
-tint/source, or free composable escape hatch). Its trigger is the **app icon** (auto-drawn like the
-rail's header; its shape/size set via `azConfig`'s `headerIconShape`/`headerIconSize`), dropped
-inline like any widget. Tapping it unfolds an **overlay
+configuration the rest of the library sanctions (no arbitrary panel background, offsets, or free
+composable escape hatch).
+
+**The trigger.** `azConfig(trigger = …)` picks what the user taps, from the sanctioned set
+`AzDropdownTrigger`:
+
+| Trigger | What it draws |
+| --- | --- |
+| `AzDropdownTrigger.MoreVert` | Three vertical dots. **The default.** |
+| `AzDropdownTrigger.Hamburger` | The three stacked bars. |
+| `AzDropdownTrigger.Text("Filter")` | A word, in the rail's accent and menu type. |
+| `AzDropdownTrigger.Icon(myVector)` | Your own `ImageVector` / `Painter` / image URL / any Coil model. |
+| `AzDropdownTrigger.AppIcon` | The launcher icon, exactly like the rail's header (the pre-trigger default). |
+
+Its size and clip shape come from `azConfig`'s `headerIconSize` / `headerIconShape`, mirroring the
+rail's `azTheme`.
+
+**Where the trigger goes.** `azConfig(triggerPlacement = …)` takes an `AzDropdownTriggerPlacement`.
+The default, `AUTO`, means: when the drop-down is declared inside an `AzHostActivityLayout` — i.e.
+inside an `onscreen { … }` block, which is where drop-downs actually live — the trigger is **lifted
+out of the call site and placed next to the big screen title**, above the onscreen content area, on
+the side opposite the rail. Declare several drop-downs and their triggers **line up beside each
+other** there, in declaration order. The dropped panel still belongs to the call site and still
+drops from the real trigger button, because the button reports its window bounds back. A drop-down
+used outside a host has no title row, so `AUTO` leaves it inline. Force either with `TITLE` /
+`INLINE`.
+
+Tapping it unfolds an **overlay
 panel** (a `Popup`) of the items you declare. Configure it through `azConfig`: `design` picks
 `AzDropdownDesign.RAIL` (compact rail buttons at the collapsed width ≈100dp) or `AzDropdownDesign.MENU`
 (default; full-width labeled rows at the expanded width ≈160dp); `dockingSide` pins the panel to the
@@ -203,6 +227,7 @@ only the rail's sanctioned per-item knobs, plus a `route` that navigates the sup
 
 ```kotlin
 AzDropdownMenu(navController = navController) {
+    // Three dots next to the screen title, because both defaults already say so.
     azConfig(design = AzDropdownDesign.MENU, dockingSide = AzDockingSide.LEFT)
     azItem("Home", route = "home") { }
     azToggle(isChecked = dark, toggleOnText = "Dark", toggleOffText = "Light") { dark = it }
@@ -488,6 +513,71 @@ AzHostActivityLayout(
 The callback fires once per state transition (expand or collapse), including on initial composition with the starting value. To also observe host-item sub-menu expansion, use `onInteraction` and filter for `action === 'Host toggled'` (React) or the item's `isHost` flag (Android).
 
 ---
+
+### Unattached hosts (`azUnattachedHostItem`)
+
+A host does not have to live *in* the rail. `azUnattachedHostItem` declares a rail host that is
+drawn on its own somewhere else on the screen; tapping it unfolds its sub-items inline beneath it,
+exactly as they would have unfolded inside the rail. Sub-items attach the usual way — by pointing
+their `hostId` at it — so `azRailSubItem` / `azRailSubToggle` / `azRailSubCycler` /
+`azRailSubHostItem` all work unchanged, and sub-hosts still nest to any depth.
+
+The host and its whole subtree are removed from the rail strip *and* the drawer menu: an unattached
+host exists only at its anchor.
+
+`anchor: AzUnattachedAnchor` says where it parks:
+
+| Anchor | Where it sits |
+| --- | --- |
+| `OPPOSITE` (default) | The side of the screen opposite the rail, level with where the rail's own items start. |
+| `BOTTOM` | The bottom of the screen, on the side opposite the rail. |
+| `FLOATING` | Free-floating and **draggable**, with its position **persisted** across launches. |
+
+Declare several unattached hosts sharing an anchor and they **stack into a column**, spaced exactly
+as they would have been in the rail (and packed when `packButtons` is on). The `FLOATING` stack
+drags as one unit; its position is stored as a fraction of the window, so it survives rotation and
+lands sensibly on a different screen size, and it is clamped to the same 10%–90% vertical safe zone
+FAB mode uses.
+
+```kotlin
+azUnattachedHostItem(id = "tools", text = "Tools", anchor = AzUnattachedAnchor.FLOATING)
+azRailSubItem(id = "measure", hostId = "tools", text = "Measure") { measure() }
+azRailSubToggle(
+    id = "grid", hostId = "tools",
+    isChecked = grid, toggleOnText = "Grid On", toggleOffText = "Grid Off",
+) { grid = !grid }
+
+azUnattachedHostItem(id = "layers", text = "Layers", anchor = AzUnattachedAnchor.BOTTOM)
+azRailSubItem(id = "layer-1", hostId = "layers", text = "Base") { select(0) }
+```
+
+
+### Per-item badges, loading and alerts (`azItemState`)
+
+Every item builder takes `badge` / `persistentBadge` / `isLoading` directly, and **every** item —
+rail item, menu item, sub-item, host, unattached host, nested-rail child — can also be decorated
+after the fact with `azItemState`, so you never have to thread the same three arguments through a
+builder that happens not to be the one you are using:
+
+```kotlin
+azRailItem(id = "sync", text = "Sync") { startSync() }
+azItemState(
+    id = "sync",
+    isLoading = syncing,                                   // this item spins its own animation
+    badge = pending.takeIf { it > 0 }?.toString(),          // and carries its own badge
+)
+```
+
+`azItemState` is applied after every item is declared, so declaration order does not matter, and
+values left `null` leave whatever the item already had — decorating the badge does not clear the
+loading state. Unknown ids are ignored.
+
+**Loading is per item, not per app.** A loading item hides its content and spins an `AzLoad` ring
+scaled to its own button and tinted to its own colour; the rest of the rail stays live. In the
+drawer, the row keeps its label and spins a small ring beside it.
+
+**Badges render everywhere.** Rail buttons, menu rows and nested-rail children all draw them
+(nested-rail children previously dropped a declared badge on the floor).
 
 ## 5. Drag & Drop (Relocatable Items)
 
@@ -1075,4 +1165,60 @@ The overlay also **delivers real window insets to the content**: an `OnApplyWind
 
 **Pages (Z-ordering).** `onscreen(alignment, page = 0f)` and `background(weight, page = 0f)` take a `page: Float`. Items sharing a page render on one co-planar layer (positioned with standard Compose `alignment`, so distinct alignments — or your own `Row`/`Column` inside the content — tile without overlapping). Items on *different* pages are stacked in Z and may overlap: a **higher** page number draws **further back**, the lowest page on top. Decimal pages (`1.5f`) insert a layer between existing ones without renumbering. `background()` items form their own book of pages beneath the entire `onscreen` book (itself beneath the rail and nav bar); `weight` breaks ties within a background page, and onscreen pages still respect the safe zones. The system is gated by `AzHostActivityLayout(pagesEnabled = true)` (the default); when on it is forced — items with no explicit page share page `0f`. Set `pagesEnabled = false` to fall back to plain declaration-order rendering (backgrounds by `weight`) with `page` ignored. The React port mirrors this on `<AzOnscreen page={…}>` / `<AzBackground page={…}>` and `pagesEnabled`.
 
+---
 
+## 11. Popups (`AzPopup`)
+
+An `AzPopup` is a window that is **bound to a rail item**, and the two share state in both
+directions. Create a controller with `rememberAzPopupController()`, register it in the host DSL with
+`azPopup(controller)`, and raise it from anywhere — an item's `onClick`, a coroutine, a callback.
+
+```kotlin
+val alerts = rememberAzPopupController()
+
+AzHostActivityLayout(navController = navController) {
+    azRailItem(id = "sync", text = "Sync") {
+        alerts.show(itemId = "sync", title = "Syncing", message = "Talking to the server…")
+    }
+
+    azPopup(alerts) {
+        Text(message ?: "")
+        AzButton(
+            onClick = { item?.setLoading(false); item?.setBadge(null); dismiss() },
+            text = "Stop",
+        )
+    }
+}
+```
+
+**The shared handle.** The body runs in an `AzPopupScope`, which exposes the request (`kind`,
+`title`, `message`, `payload`), a `dismiss()`, and `item` — an `AzPopupItemHandle` on the rail item
+that raised the popup. Through it the popup can read the item as the rail currently has it
+(`item.item`) and write back to it:
+
+- `setLoading(true)` — spin that item's own loading animation while the popup's work runs
+- `setBadge("3")` — drop a badge on it when the work finishes
+- `setAlert(AzItemAlert.WARNING)` — flag it
+- `clear()` — drop everything the popup pushed, restoring what the DSL declared
+
+Those writes are held on the rail scope, so they survive the DSL re-running on every recomposition
+— they last until the popup clears them.
+
+**Which item.** `show(itemId = "sync")` names one explicitly. `show()` with no id binds to the
+**last touched** rail item, which is what makes a warning raised from a background job land on
+whatever the user just did.
+
+**Notices and warnings mark their item.** While a `AzPopupKind.NOTICE` or `AzPopupKind.WARNING`
+popup is up, its bound item is redrawn as a **yellow, rounded-corner triangle outline** — the
+warning glyph — and reverts the instant the popup closes. `NOTICE` uses a softer amber, `WARNING` a
+saturated hazard yellow. In the drawer, where a row is type rather than a button, the flagged item
+takes the same yellow instead. The triangle is also available as an ordinary item shape,
+`AzButtonShape.TRIANGLE`.
+
+```kotlin
+// No tap to attribute it to — lands on whatever the user last touched.
+alerts.show(kind = AzPopupKind.WARNING, title = "Offline", message = "Changes are queued.")
+```
+
+`azPopup(controller)` with no body renders the built-in title/message/OK panel;
+`azPopup(controller, dismissOnOutsideTap = false)` makes it modal.


### PR DESCRIPTION
Adds four features to both the Android (`aznavrail`) and Compose-Multiplatform (`aznavrail-cmp`) modules, kept in lockstep as usual.

## 1. Drop-down triggers

`AzDropdownMenu`'s trigger is now chosen, not fixed to the app icon.

`azConfig(trigger = …)` takes an `AzDropdownTrigger`:

| Trigger | Draws |
| --- | --- |
| `MoreVert` | Three vertical dots. **New default.** |
| `Hamburger` | The three bars. |
| `Text("Filter")` | A word, in the rail's accent. |
| `Icon(model)` | Your own `ImageVector` / `Painter` / URL / any Coil model. |
| `AppIcon` | The launcher icon — the previous default, kept. |

`azConfig(triggerPlacement = …)` takes `AzDropdownTriggerPlacement { AUTO, TITLE, INLINE }`. `AUTO` (default) **lifts the trigger out of its call site and places it next to the big screen title**, above the onscreen content area, on the side opposite the rail — whenever the drop-down is declared inside an `AzHostActivityLayout`. Declare several and their triggers **line up beside each other** in declaration order. A drop-down used outside a host has no title row, so `AUTO` leaves it inline.

The dropped panel stays composed at the call site and anchors to the *real* trigger via the window-space bounds the trigger reports back, so it still drops from the button the user tapped. The plumbing is `AzTitleTriggerSlot`: it publishes a comparable `AzDropdownTriggerSpec` as snapshot state and keeps its tap/bounds callbacks as plain fields — which is what stops the host's composition from looping on a freshly-allocated lambda every frame.

## 2. Unattached host rail items

`azUnattachedHostItem(id, text, anchor = …)` declares a rail host that does **not** live in the rail strip. Tapping it unfolds its sub-items inline beneath it, exactly as they would have unfolded in the rail; sub-items attach by `hostId` as usual and sub-hosts nest to any depth. The host and its whole subtree are filtered out of both the rail and the drawer.

`AzUnattachedAnchor`:
- `OPPOSITE` (default) — the side opposite the rail, level with where the rail's items start
- `BOTTOM` — the bottom of the screen, opposite side
- `FLOATING` — draggable, position persisted across launches

Several hosts sharing an anchor **stack into a column** with the rail's own spacing and packing. The `FLOATING` stack drags as one unit, is clamped to the same 10%–90% vertical safe zone FAB mode uses, and persists its position **as a fraction of the window** so it survives rotation and lands sensibly on a different screen size (multiplatform-settings on CMP, `SharedPreferences` on Android).

## 3. Per-item badges and loading

- Every item builder now accepts `badge` / `persistentBadge` / `isLoading`.
- Any already-declared item — rail, menu, sub-item, host, nested-rail child — can be decorated by id with `azItemState(id, badge, persistentBadge, isLoading, alert)`, applied after the whole DSL runs, so declaration order is irrelevant and null fields leave existing values alone.
- **Loading is per item**: the button hides its content and spins an `AzLoad` scaled to itself and tinted to its own colour; the rest of the rail stays live. A menu row keeps its label and spins a small ring beside it. `AzLoad` gained `size` / `color` / `showLabel`.
- **Badges now render in nested rails** — `NestedRail.kt` was silently dropping a declared badge.

## 4. Popups

`AzPopupController` + `azPopup(controller)` register a window **bound to a rail item**. The body runs in an `AzPopupScope` exposing `kind` / `title` / `message` / `payload`, `dismiss()`, and `item` — an `AzPopupItemHandle` that reads the live `AzNavItem` and writes back to it (`setBadge`, `setLoading`, `setAlert`, `clear`). Those writes survive the DSL re-running each recomposition, so they last until the popup clears them.

`show(itemId = …)` names the source item; `show()` with no id binds to the **last touched** rail item, so a warning raised from a background job lands on whatever the user just did.

A `NOTICE` / `WARNING` popup redraws its bound item as a **yellow, rounded-corner triangle outline** for exactly as long as it is up — raised and dropped by the popup's own `DisposableEffect`, never left behind. In the drawer, where a row is type rather than a button, the flagged item takes the same yellow. The glyph is available as an ordinary shape too, `AzButtonShape.TRIANGLE`.

## Incidental fix

`AzNavRail`'s `noMenu` footer was passing an `AzButtonShape` where a Compose `Shape` was required — a pre-existing compile error on `main`. Every conversion now goes through a single `AzButtonShape.toComposeShape()`, so a new shape member can't be silently missed by one call site.

## Compatibility

New parameters are all defaulted and new model fields are all defaulted, so existing call sites are unaffected — with one deliberate behavioural change: a drop-down that previously showed the app icon inline now shows three dots next to the screen title. `azConfig(trigger = AzDropdownTrigger.AppIcon, triggerPlacement = AzDropdownTriggerPlacement.INLINE)` restores the old look exactly.

## Testing

`:aznavrail:compileDebugKotlin`, `:aznavrail-cmp:compileKotlinDesktop`, `:aznavrail-cmp-demo:compileKotlinDesktop` and `:SampleApp:compileDebugKotlin` all build. The repo has no test suite for these paths and the changes are UI-layout behaviour, so **none of this has been exercised at runtime** — the placement, stacking, drag-persistence and triangle rendering are unverified on a device.

Docs updated: `AGENTS.md` and the canonical `docs/AZNAVRAIL_COMPLETE_GUIDE.md` (the bundled copies are left to the sync workflow). The React port is **not** covered by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019poyMKoWB5zb6QdfVr5bXy

---
_Generated by [Claude Code](https://claude.ai/code/session_019poyMKoWB5zb6QdfVr5bXy)_